### PR TITLE
Area mean time series: time slicing

### DIFF
--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -59,25 +59,8 @@ def run_diag(parameter):
             print("Selected region: {}".format(region))
             test_data = utils.dataset.Dataset(parameter, test=True)
             test = test_data.get_timeseries_variable(var)
+            print('Start and end time for selected time slices for test data: ', test.getTime().asComponentTime()[0],test.getTime().asComponentTime()[-1])
             
-            # Redefine time to be in the middle of the time interval
-            # And rewrite the time axis
-            #These steps are important for data where the absolute time doesn't full in the middle, such as E3SM, the time was recorded at the end of each time Bounds.
-            var_time = test.getTime()
-            tbounds = var_time.getBounds()
-            var_time[:] = 0.5*(tbounds[:,0]+tbounds[:,1])
-            var_time_absolute = var_time.asComponentTime()
-            time2 = cdms2.createAxis(var_time)
-            time2.designateTime()
-            #.designateTime() needs to be set before attributes changes.
-            time2.units = var_time.units
-            time2.calendar = var_time.calendar
-            #time2.calendar = cdtime.NoLeapCalendar
-            time2.id = 'time'
-            test.setAxis(0,time2)
-            
-            # Make sure data have correct montly Bounds
-            cdutil.setTimeBoundsMonthly(test)
             print('test shape',test.shape, test.units)
 
             parameter.viewer_descr[var] = getattr(test, 'long_name', var)
@@ -93,15 +76,13 @@ def run_diag(parameter):
                 parameter.ref_name_yrs = utils.general.get_name_and_yrs(parameter, ref_data)
 
                 ref = ref_data.get_timeseries_variable(var)
+                print('Start and end time for selected time slices for ref data: ', ref.getTime().asComponentTime()[0],ref.getTime().asComponentTime()[-1])
 
-                cdutil.setTimeBoundsMonthly(ref)
- 
                 
                 # TODO: Will this work if ref and test are timeseries data,
                 # but land_frac and ocean_frac are climo'ed.
                 test_domain, ref_domain = utils.general.select_region(
                     region, test, ref, land_frac, ocean_frac, parameter)
-                print(test_domain.getTime().asComponentTime())
 
                 # Average over selected region, and average
                 # over months to get the yearly mean.

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -1,7 +1,6 @@
 import os
 import collections
 import cdms2
-import cdtime
 import cdutil
 import acme_diags
 from acme_diags.driver import utils

--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -10,6 +10,7 @@ import collections
 import traceback
 import cdms2
 import acme_diags.derivations.acme
+from acme_diags.driver import utils
 from . import climo
 
 
@@ -94,6 +95,8 @@ class Dataset():
         #   v1 = Dataset.get_variable('v1', season)
         # and also:
         #   v1, v2, v3 = Dataset.get_variable('v1', season, extra_vars=['v2', 'v3'])
+        for variable in variables:
+            variable = utils.general.adjust_time_from_time_bounds(variable)
         return variables[0] if len(variables) == 1 else variables
 
 

--- a/acme_diags/driver/utils/general.py
+++ b/acme_diags/driver/utils/general.py
@@ -11,6 +11,28 @@ import cdms2
 from acme_diags import container
 from acme_diags.derivations.default_regions import regions_specs
 
+def adjust_time_from_time_bounds(var):
+    """
+    Redefine time to be in the middle of the time interval, and rewrite 
+    the time axis. This is important for data where the absolute time doesn't fall in the middle of the time interval, such as E3SM, the time was recorded at the end of each time Bounds.
+    """
+    var_time = var.getTime()
+    tbounds = var_time.getBounds()
+    var_time[:] = 0.5*(tbounds[:,0]+tbounds[:,1])
+    var_time_absolute = var_time.asComponentTime()
+    time2 = cdms2.createAxis(var_time)
+    time2.designateTime()
+    #.designateTime() needs to be set before attributes changes.
+    time2.units = var_time.units
+    time2.calendar = var_time.calendar
+    time2.setBounds(tbounds)
+    #time2.calendar = cdtime.NoLeapCalendar
+    time2.id = 'time'
+    var.setAxis(0,time2)
+#    cdutil.setTimeBoundsMonthly(var)
+ 
+    return var
+
 
 def get_name_and_yrs(parameters, dataset, season=''):
     """

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -44,7 +44,7 @@ def plot(var, regions_to_data, parameter):
         refs = data_set_for_region.refs
         test = data_set_for_region.test
         ax1 = fig.add_axes(panel[i_region])
-        ax1.plot(test.asma()[:-1], 'k', linewidth=2,label = 'model' +' ({0:.1f})'.format(np.mean(test.asma()[:-1])))
+        ax1.plot(test.asma(), 'k', linewidth=2,label = 'model' +' ({0:.1f})'.format(np.mean(test.asma())))
         for i_ref, ref in enumerate(refs):
             ax1.plot(ref.asma(), line_color[i_ref], linewidth=2,label = ref.ref_name +' ({0:.1f})'.format(np.mean(ref.asma())))
 


### PR DESCRIPTION
This PR is to correct the time slicing issue https://github.com/E3SM-Project/e3sm_diags/issues/231, due to E3SM data has time recorded at the end of the time interval, which causes cdutil to get the unexpected time slices for climatology calculation. Now in the dataset class, we have a function to adjust time to the middle of the time interval, this applies to both test and reference data. 