### PR TITLE
Disable MPI in cdms2.tvariable

### DIFF
--- a/acme_diags/acme_diags_driver.py
+++ b/acme_diags/acme_diags_driver.py
@@ -19,6 +19,7 @@ import importlib
 import traceback
 import subprocess
 import cdp.cdp_run
+import cdms2.tvariable
 import acme_diags
 from acme_diags.parameter.core_parameter import CoreParameter
 from acme_diags.parser import SET_TO_PARSER
@@ -26,6 +27,10 @@ from acme_diags.parser.core_parser import CoreParser
 from acme_diags.viewer.main import create_viewer
 from acme_diags.driver import utils
 from acme_diags import container
+
+
+# turn off MPI in cdms2 -- not currently supported by e3sm_diags
+cdms2.tvariable.HAVE_MPI = False
 
 
 def get_default_diags_path(set_name, run_type, print_path=True):

--- a/acme_diags/acme_diags_vars.py
+++ b/acme_diags/acme_diags_vars.py
@@ -10,12 +10,18 @@ import argparse
 import glob
 import traceback
 import cdms2
+import cdms2.tvariable
 import acme_diags
 from acme_diags.acme_diags_driver import get_parameters
 from acme_diags.parser.core_parser import CoreParser
 from acme_diags.derivations.acme import derived_variables
 
+
+# turn off MPI in cdms2 -- not currently supported by e3sm_diags
+cdms2.tvariable.HAVE_MPI = False
+
 DUMMY_FILE_PATH = '/Users/shaheen2/test_model_data_for_acme_diags/20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc'
+
 
 def main():
     vars_in_e3sm_diags = list_of_vars_in_e3sm_diags()


### PR DESCRIPTION
This should fix an issue where e3sm_diags is not able to deepcopy variables because of (unneeded) MPI comm objects stored in the variable.

closes #242 