### PR TITLE
Area mean time series refine

### DIFF
--- a/acme_diags/acme_diags_driver.py
+++ b/acme_diags/acme_diags_driver.py
@@ -20,12 +20,17 @@ import traceback
 import subprocess
 import cdp.cdp_run
 import acme_diags
+import cdms2.tvariable 
 from acme_diags.parameter.core_parameter import CoreParameter
 from acme_diags.parser import SET_TO_PARSER
 from acme_diags.parser.core_parser import CoreParser
 from acme_diags.viewer.main import create_viewer
 from acme_diags.driver import utils
 from acme_diags import container
+
+
+# turn off MPI in cdms2 -- not currently supported by e3sm_diags
+cdms2.tvariable.HAVE_MPI = False
 
 
 def get_default_diags_path(set_name, run_type, print_path=True):

--- a/acme_diags/acme_diags_driver.py
+++ b/acme_diags/acme_diags_driver.py
@@ -289,6 +289,12 @@ def main(parameters=[]):
     if not parameters:
         parameters = get_parameters(parser)
 
+    # each case id (aka, variable) has a set of parameters specified.
+    # print out the parameters for each variable for trouble shootting
+    #for p in parameters:
+    #    attrs = vars(p)
+    #    print (', '.join("%s: %s" % item for item in attrs.items()))
+
     if not os.path.exists(parameters[0].results_dir):
         os.makedirs(parameters[0].results_dir, 0o755)
     if not parameters[0].no_viewer:  # Only save provenance for full runs.

--- a/acme_diags/acme_diags_vars.py
+++ b/acme_diags/acme_diags_vars.py
@@ -11,11 +11,15 @@ import glob
 import traceback
 import cdms2
 import acme_diags
+import cdms2.tvariable
 from acme_diags.acme_diags_driver import get_parameters
 from acme_diags.parser.core_parser import CoreParser
 from acme_diags.derivations.acme import derived_variables
 
 DUMMY_FILE_PATH = '/Users/shaheen2/test_model_data_for_acme_diags/20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc'
+
+# turn off MPI in cdms2 -- not currently supported by e3sm_diags
+cdms2.tvariable.HAVE_MPI = False
 
 def main():
     vars_in_e3sm_diags = list_of_vars_in_e3sm_diags()

--- a/acme_diags/derivations/acme.py
+++ b/acme_diags/derivations/acme.py
@@ -403,7 +403,8 @@ derived_variables = {
         (('toa_net_sw_all_mon', 'toa_net_sw_clr_mon'),
          lambda net_all, net_clr: swcf(net_all, net_clr)),
         (('toa_cre_sw_mon',), rename),
-        (('FSNTOA', 'FSNTOAC'), lambda fsntoa, fsntoac: swcf(fsntoa, fsntoac))
+        (('FSNTOA', 'FSNTOAC'), lambda fsntoa, fsntoac: swcf(fsntoa, fsntoac)),
+        (('rsut', 'rsutcs'), lambda rsutcs, rsut: swcf(rsut, rsutcs)) 
     ]),
     'SWCFSRF': OrderedDict([
         (('SWCFSRF',), rename),
@@ -417,7 +418,8 @@ derived_variables = {
         (('toa_net_lw_all_mon', 'toa_net_lw_clr_mon'),
          lambda net_all, net_clr: lwcf(net_clr, net_all)),
         (('toa_cre_lw_mon',), rename),
-        (('FLNTOA', 'FLNTOAC'), lambda flntoa, flntoac: lwcf(flntoa, flntoac))
+        (('FLNTOA', 'FLNTOAC'), lambda flntoa, flntoac: lwcf(flntoa, flntoac)),
+        (('rlut', 'rlutcs'), lambda rlutcs, rlut: lwcf(rlut, rlutcs)) 
     ]),
     'LWCFSRF': OrderedDict([
         (('LWCFSRF',), rename),
@@ -497,12 +499,14 @@ derived_variables = {
     'RESTOM': OrderedDict([
         (('RESTOA',), rename),
         (('toa_net_all_mon',), rename),
-        (('FSNT', 'FLNT'), lambda fsnt, flnt: restom(fsnt, flnt))
+        (('FSNT', 'FLNT'), lambda fsnt, flnt: restom(fsnt, flnt)),
+        (('rtmt',), rename)
     ]),
     'RESTOA': OrderedDict([
         (('RESTOM',), rename),
         (('toa_net_all_mon',), rename),
-        (('FSNT', 'FLNT'), lambda fsnt, flnt: restoa(fsnt, flnt))
+        (('FSNT', 'FLNT'), lambda fsnt, flnt: restoa(fsnt, flnt)),
+        (('rtmt',), rename)
     ]),
 #    'TREFHT_LAND': OrderedDict([
 #        (('TREFHT_LAND',), rename),

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -72,6 +72,7 @@ def run_diag(parameter):
             # Average over selected region, and average
             # over months to get the yearly mean.
             test_domain = cdutil.averager(test_domain,axis = 'xy')
+            cdutil.setTimeBoundsMonthly(test_domain)
             test_domain_year = cdutil.YEAR(test_domain)
             #add back attributes since they got lost after applying cdutil.YEAR
             test_domain_year.long_name = test.long_name
@@ -97,6 +98,8 @@ def run_diag(parameter):
                 ref_domain = utils.general.select_region(region, ref, land_frac, ocean_frac, parameter)
 
                 ref_domain = cdutil.averager(ref_domain,axis = 'xy')
+                cdutil.setTimeBoundsMonthly(ref_domain)
+                print('Start and end time for selected time slices for ref data: ', ref_domain.getTime().asComponentTime()[0],ref_domain.getTime().asComponentTime()[-1])
                 ref_domain_year = cdutil.YEAR(ref_domain)
                 ref_domain_year.ref_name = ref_name
                 save_data[ref_name] = ref_domain_year.asma().tolist()

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -88,23 +88,26 @@ def run_diag(parameter):
             
                 parameter.ref_name_yrs = utils.general.get_name_and_yrs(parameter, ref_data)
 
-                ref = ref_data.get_timeseries_variable(var)
-                print('Start and end time for selected time slices for ref data: ', ref.getTime().asComponentTime()[0],ref.getTime().asComponentTime()[-1])
-                print('ref shape',ref.shape, ref.long_name, ref.units)
+                try: 
+                    ref = ref_data.get_timeseries_variable(var)
+                    print('Start and end time for selected time slices for ref data: ', ref.getTime().asComponentTime()[0],ref.getTime().asComponentTime()[-1])
+                    print('ref shape',ref.shape, ref.long_name, ref.units)
 
-                
-                # TODO: Will this work if ref and test are timeseries data,
-                # but land_frac and ocean_frac are climo'ed.
-                ref_domain = utils.general.select_region(region, ref, land_frac, ocean_frac, parameter)
+                    
+                    # TODO: Will this work if ref and test are timeseries data,
+                    # but land_frac and ocean_frac are climo'ed.
+                    ref_domain = utils.general.select_region(region, ref, land_frac, ocean_frac, parameter)
 
-                ref_domain = cdutil.averager(ref_domain,axis = 'xy')
-                cdutil.setTimeBoundsMonthly(ref_domain)
-                print('Start and end time for selected time slices for ref data: ', ref_domain.getTime().asComponentTime()[0],ref_domain.getTime().asComponentTime()[-1])
-                ref_domain_year = cdutil.YEAR(ref_domain)
-                ref_domain_year.ref_name = ref_name
-                save_data[ref_name] = ref_domain_year.asma().tolist()
+                    ref_domain = cdutil.averager(ref_domain,axis = 'xy')
+                    cdutil.setTimeBoundsMonthly(ref_domain)
+                    print('Start and end time for selected time slices for ref data: ', ref_domain.getTime().asComponentTime()[0],ref_domain.getTime().asComponentTime()[-1])
+                    ref_domain_year = cdutil.YEAR(ref_domain)
+                    ref_domain_year.ref_name = ref_name
+                    save_data[ref_name] = ref_domain_year.asma().tolist()
 
-                refs.append(ref_domain_year)
+                    refs.append(ref_domain_year)
+                except:
+                    print('No valid value for reference datasets available for the specified time range')
 
             # metrics_dict = create_metrics(ref_domain)
             #save_data = []

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -90,12 +90,9 @@ def run_diag(parameter):
 
                 try: 
                     ref = ref_data.get_timeseries_variable(var)
-                    print('Start and end time for selected time slices for ref data: ', ref.getTime().asComponentTime()[0],ref.getTime().asComponentTime()[-1])
-                    print('ref shape',ref.shape, ref.long_name, ref.units)
+                    #print('Start and end time for selected time slices for ref data: ', ref.getTime().asComponentTime()[0],ref.getTime().asComponentTime()[-1])
+                    #print('ref shape',ref.shape, ref.long_name, ref.units)
 
-                    
-                    # TODO: Will this work if ref and test are timeseries data,
-                    # but land_frac and ocean_frac are climo'ed.
                     ref_domain = utils.general.select_region(region, ref, land_frac, ocean_frac, parameter)
 
                     ref_domain = cdutil.averager(ref_domain,axis = 'xy')

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -65,6 +65,15 @@ def run_diag(parameter):
             parameter.viewer_descr[var] = getattr(test, 'long_name', var)
             # Get the name of the data, appended with the years averaged.
             parameter.test_name_yrs = utils.general.get_name_and_yrs(parameter, test_data)
+            test_domain = utils.general.select_region(
+                    region, test, land_frac, ocean_frac)
+            # Average over selected region, and average
+            # over months to get the yearly mean.
+            test_domain = cdutil.averager(test_domain,axis = 'xy')
+            test_domain_year = cdutil.YEAR(test_domain)
+            #add back attributes since they got lost after applying cdutil.YEAR
+            test_domain_year.long_name = test.long_name
+            test_domain_year.units = test.units
 
             refs = []
 
@@ -80,16 +89,11 @@ def run_diag(parameter):
                 
                 # TODO: Will this work if ref and test are timeseries data,
                 # but land_frac and ocean_frac are climo'ed.
-                test_domain, ref_domain = utils.general.select_region(
-                    region, test, ref, land_frac, ocean_frac, parameter)
+                #test_domain, ref_domain = utils.general.select_region(
+                #     region, test, ref, land_frac, ocean_frac, parameter)
+                ref_domain = utils.general.select_region(
+                    region, ref, land_frac, ocean_frac)
 
-                # Average over selected region, and average
-                # over months to get the yearly mean.
-                test_domain = cdutil.averager(test_domain,axis = 'xy')
-                test_domain_year = cdutil.YEAR(test_domain)
-                #add back attributes since they got lost after applying cdutil.YEAR
-                test_domain_year.long_name = test.long_name
-                test_domain_year.units = test.units
                 ref_domain = cdutil.averager(ref_domain,axis = 'xy')
                 ref_domain_year = cdutil.YEAR(ref_domain)
                 ref_domain_year.ref_name = ref_name
@@ -97,7 +101,8 @@ def run_diag(parameter):
                 refs.append(ref_domain_year)
 
             # metrics_dict = create_metrics(ref_domain)
-            metrics_dict = ref_domain_year.mean()
+            #metrics_dict = ref_domain_year.mean()
+            metrics_dict = []
             # print(test_domain_year.getTime().asComponentTime())
             # print(test.getTime().asComponentTime())
 

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -31,7 +31,6 @@ def run_diag(parameter):
     #    msg += 'because both the test and ref data need to be time-series files.'
     #    raise RuntimeError(msg)
 
-    print('_____',variables)
     for var in variables:
         # The data that'll be sent to the plotting function.
         # There are eight tuples, each will be plotted like so:

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -67,8 +67,8 @@ def run_diag(parameter):
             parameter.viewer_descr[var] = getattr(test, 'long_name', var)
             # Get the name of the data, appended with the years averaged.
             parameter.test_name_yrs = utils.general.get_name_and_yrs(parameter, test_data)
-            test_domain = utils.general.select_region(
-                    region, test, land_frac, ocean_frac)
+            test_domain = utils.general.select_region(region, test, land_frac, ocean_frac, parameter)
+
             # Average over selected region, and average
             # over months to get the yearly mean.
             test_domain = cdutil.averager(test_domain,axis = 'xy')
@@ -93,10 +93,7 @@ def run_diag(parameter):
                 
                 # TODO: Will this work if ref and test are timeseries data,
                 # but land_frac and ocean_frac are climo'ed.
-                #test_domain, ref_domain = utils.general.select_region(
-                #     region, test, ref, land_frac, ocean_frac, parameter)
-                ref_domain = utils.general.select_region(
-                    region, ref, land_frac, ocean_frac)
+                ref_domain = utils.general.select_region(region, ref, land_frac, ocean_frac, parameter)
 
                 ref_domain = cdutil.averager(ref_domain,axis = 'xy')
                 ref_domain_year = cdutil.YEAR(ref_domain)

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -31,6 +31,7 @@ def run_diag(parameter):
     #    msg += 'because both the test and ref data need to be time-series files.'
     #    raise RuntimeError(msg)
 
+    print('_____',variables)
     for var in variables:
         # The data that'll be sent to the plotting function.
         # There are eight tuples, each will be plotted like so:

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -60,7 +60,7 @@ def run_diag(parameter):
             test = test_data.get_timeseries_variable(var)
             print('Start and end time for selected time slices for test data: ', test.getTime().asComponentTime()[0],test.getTime().asComponentTime()[-1])
             
-            print('test shape',test.shape, test.units)
+            print('test shape',test.shape, test.long_name, test.units)
 
             parameter.viewer_descr[var] = getattr(test, 'long_name', var)
             # Get the name of the data, appended with the years averaged.
@@ -87,6 +87,9 @@ def run_diag(parameter):
                 # over months to get the yearly mean.
                 test_domain = cdutil.averager(test_domain,axis = 'xy')
                 test_domain_year = cdutil.YEAR(test_domain)
+                #add back attributes since they got lost after applying cdutil.YEAR
+                test_domain_year.long_name = test.long_name
+                test_domain_year.units = test.units
                 ref_domain = cdutil.averager(ref_domain,axis = 'xy')
                 ref_domain_year = cdutil.YEAR(ref_domain)
                 ref_domain_year.ref_name = ref_name

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -106,17 +106,9 @@ def run_diag(parameter):
                 except:
                     print('No valid value for reference datasets available for the specified time range')
 
-            # metrics_dict = create_metrics(ref_domain)
-            #save_data = []
-            #save_data.append(parameter.test_name_yrs)
-            #save_data.append(test_domain_year.asma())
-            # print(test_domain_year.getTime().asComponentTime())
-            # print(test.getTime().asComponentTime())
 
             metrics_dict = []
             
-            #save_data = RefsTestMetrics(test=[test_domain_year.asma().tolist()], refs=[x.asma().tolist() for x in refs], metrics=metrics_dict)
-
             #save data for potential later use
             parameter.output_file = '-'.join(
                 [var, region])
@@ -125,15 +117,11 @@ def run_diag(parameter):
             print('Data saved in: ' + fnm)
 
             with open(fnm, 'w') as outfile:
-                #json.dump(result, outfile, cls=utils.general.NumpyEncoder)
                 json.dump(save_data, outfile)
 
             regions_to_data[region] = RefsTestMetrics(test=test_domain_year, refs=refs, metrics=metrics_dict)
  
         area_mean_time_series_plot.plot(var, regions_to_data, parameter)
-        # TODO: How will this work when there are a bunch of plots for each image?
-        # Yes, these files should be saved.
-        # utils.general.save_ncfiles(parameter.current_set,
-        #                     mv1_domain, mv2_domain, diff, parameter)
+
     return parameter
 

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -89,6 +89,7 @@ def run_diag(parameter):
 
                 ref = ref_data.get_timeseries_variable(var)
                 print('Start and end time for selected time slices for ref data: ', ref.getTime().asComponentTime()[0],ref.getTime().asComponentTime()[-1])
+                print('ref shape',ref.shape, ref.long_name, ref.units)
 
                 
                 # TODO: Will this work if ref and test are timeseries data,

--- a/acme_diags/driver/area_mean_time_series_driver.py
+++ b/acme_diags/driver/area_mean_time_series_driver.py
@@ -113,7 +113,6 @@ def run_diag(parameter):
             # print(test.getTime().asComponentTime())
 
             metrics_dict = []
-            print(save_data)
             
             #save_data = RefsTestMetrics(test=[test_domain_year.asma().tolist()], refs=[x.asma().tolist() for x in refs], metrics=metrics_dict)
 

--- a/acme_diags/driver/cosp_histogram_driver.py
+++ b/acme_diags/driver/cosp_histogram_driver.py
@@ -73,8 +73,9 @@ def run_diag(parameter):
             for region in regions:
                 print("Selected region: {}".format(region))
 
-                mv1_domain, mv2_domain = utils.general.select_region(
-                    region, mv1, mv2, land_frac, ocean_frac, parameter)
+                mv1_domain = utils.general.select_region(region, mv1, land_frac, ocean_frac, parameter)
+                mv2_domain = utils.general.select_region(region, mv2, land_frac, ocean_frac, parameter)
+
 
                 parameter.output_file = '-'.join(
                     [ref_name, var, season, region])

--- a/acme_diags/driver/default_diags/area_mean_time_series_model_vs_model.cfg
+++ b/acme_diags/driver/default_diags/area_mean_time_series_model_vs_model.cfg
@@ -10,3 +10,41 @@ sets = ["area_mean_time_series"]
 case_id = "TREFHT"
 variables = ["TREFHT"]
 regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "RESTOM"
+variables = ["RESTOM"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "FLUT"
+variables = ["FLUT"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "FSNTOA"
+variables = ["FSNTOA"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "SWCF"
+variables = ["SWCF"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "LWCF"
+variables = ["LWCF"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "PRECT"
+variables = ["PRECT"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']

--- a/acme_diags/driver/default_diags/area_mean_time_series_model_vs_obs.cfg
+++ b/acme_diags/driver/default_diags/area_mean_time_series_model_vs_obs.cfg
@@ -1,5 +1,42 @@
 [#]
 sets = ["area_mean_time_series"]
+case_id = "RESTOM"
+variables = ["RESTOM"]
+ref_names = ["ceres_ebaf_toa_v2.8", "ceres_ebaf_toa_v4.0"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "FLUT"
+variables = ["FLUT"]
+ref_names = ["ceres_ebaf_toa_v2.8", "ceres_ebaf_toa_v4.0"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "FSNTOA"
+variables = ["FSNTOA"]
+ref_names = ["ceres_ebaf_toa_v2.8", "ceres_ebaf_toa_v4.0"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "SWCF"
+variables = ["SWCF"]
+ref_names = ["ceres_ebaf_toa_v2.8", "ceres_ebaf_toa_v4.0"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+[#]
+sets = ["area_mean_time_series"]
+case_id = "LWCF"
+variables = ["LWCF"]
+ref_names = ["ceres_ebaf_toa_v2.8", "ceres_ebaf_toa_v4.0"]
+regions = ['global', 'land', 'ocean', '90S50S','50S20S','20S20N','20N50N','50N90N']
+
+[#]
+sets = ["area_mean_time_series"]
 case_id = "PRECT"
 variables = ["PRECT"]
 ref_names = ["ERA-Interim", "MERRA2", "GPCP_v2.3"]

--- a/acme_diags/driver/lat_lon_driver.py
+++ b/acme_diags/driver/lat_lon_driver.py
@@ -123,8 +123,8 @@ def run_diag(parameter):
                     for region in regions:
                         print("Selected region: {}".format(region))
 
-                        mv1_domain, mv2_domain = utils.general.select_region(
-                            region, mv1, mv2, land_frac, ocean_frac, parameter)
+                        mv1_domain = utils.general.select_region(region, mv1, land_frac, ocean_frac, parameter)
+                        mv2_domain = utils.general.select_region(region, mv2, land_frac, ocean_frac, parameter)
 
                         parameter.output_file = '-'.join(
                             [ref_name, var, str(int(plev[ilev])), season, region])
@@ -164,8 +164,8 @@ def run_diag(parameter):
                 for region in regions:
                     print("Selected region: {}".format(region))
 
-                    mv1_domain, mv2_domain = utils.general.select_region(
-                        region, mv1, mv2, land_frac, ocean_frac, parameter)
+                    mv1_domain = utils.general.select_region(region, mv1, land_frac, ocean_frac, parameter)
+                    mv2_domain = utils.general.select_region(region, mv2, land_frac, ocean_frac, parameter)
 
                     parameter.output_file = '-'.join(
                         [ref_name, var, season, region])

--- a/acme_diags/driver/polar_driver.py
+++ b/acme_diags/driver/polar_driver.py
@@ -112,8 +112,9 @@ def run_diag(parameter):
                     for region in regions:
                         print("Selected region: {}".format(region))
 
-                        mv1_domain, mv2_domain = utils.general.select_region(
-                            region, mv1, mv2, land_frac, ocean_frac, parameter)
+                        mv1_domain = utils.general.select_region(region, mv1, land_frac, ocean_frac, parameter)
+                        mv2_domain = utils.general.select_region(region, mv2, land_frac, ocean_frac, parameter)
+
 
                         parameter.output_file = '-'.join(
                             [ref_name, var, str(int(plev[ilev])), season, region])
@@ -142,8 +143,9 @@ def run_diag(parameter):
                 for region in regions:
                     print("Selected region: {}".format(region))
 
-                    mv1_domain, mv2_domain = utils.general.select_region(
-                        region, mv1, mv2, land_frac, ocean_frac, parameter)
+                    mv1_domain = utils.general.select_region(region, mv1, land_frac, ocean_frac, parameter)
+                    mv2_domain = utils.general.select_region(region, mv2, land_frac, ocean_frac, parameter)
+
 
                     parameter.output_file = '-'.join(
                         [ref_name, var, season, region])

--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -581,8 +581,19 @@ class Dataset():
         start_year, end_year = self.get_start_and_end_years()
         start_time = '{}-01-15'.format(start_year)
         end_time = '{}-12-15'.format(end_year)
-        path = self._get_timeseries_file_path(var, data_path)
-        var = var_to_get if var_to_get else var
 
-        with cdms2.open(path) as f:
-            return f(var, time=(start_time, end_time, 'ccb'))(squeeze=1)
+        fnm = self._get_timeseries_file_path(var, data_path)
+        
+        var = var_to_get if var_to_get else var
+        # get available start and end years from file name: {var}_{start_yr}01_{end_yr}12.nc
+        var_start_year = fnm.split('/')[-1].split('_')[1][:4]
+        var_end_year = fnm.split('/')[-1].split('_')[2][:4]
+
+        if start_year < var_start_year or end_year > var_end_year:
+            msg = "Invalid year range specified for test/reference time series data" 
+            raise RuntimeError(msg)
+        else: 
+            with cdms2.open(fnm) as f:
+                var_time = f(var, time=(start_time, end_time, 'ccb'))(squeeze=1)
+
+                return var_time

--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -586,8 +586,8 @@ class Dataset():
         
         var = var_to_get if var_to_get else var
         # get available start and end years from file name: {var}_{start_yr}01_{end_yr}12.nc
-        var_start_year = fnm.split('/')[-1].split('_')[1][:4]
-        var_end_year = fnm.split('/')[-1].split('_')[2][:4]
+        var_start_year = fnm.split('/')[-1].split('_')[-2][:4]
+        var_end_year = fnm.split('/')[-1].split('_')[-1][:4]
 
         if start_year < var_start_year or end_year > var_end_year:
             msg = "Invalid year range specified for test/reference time series data" 

--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -205,13 +205,17 @@ class Dataset():
         """
         Get the user-defined start and end years.
         """
-        if self.ref:
-            start_yr = getattr(self.parameters, 'ref_start_yr')
-            end_yr = getattr(self.parameters, 'ref_end_yr')
-
+        if self.parameters.sets[0] == 'area_mean_time_series':
+            start_yr = getattr(self.parameters, 'start_yr')
+            end_yr = getattr(self.parameters, 'end_yr')
         else:
-            start_yr = getattr(self.parameters, 'test_start_yr')
-            end_yr = getattr(self.parameters, 'test_end_yr')
+            if self.ref:
+                start_yr = getattr(self.parameters, 'ref_start_yr')
+                end_yr = getattr(self.parameters, 'ref_end_yr')
+
+            else:
+                start_yr = getattr(self.parameters, 'test_start_yr')
+                end_yr = getattr(self.parameters, 'test_end_yr')
 
         return start_yr, end_yr
 

--- a/acme_diags/driver/utils/general.py
+++ b/acme_diags/driver/utils/general.py
@@ -129,7 +129,7 @@ def pressure_to_plevs(var, plev):
     return var_p
 
 
-def select_region(region, var1, var2, land_frac, ocean_frac, parameter):
+def select_region(region, var, land_frac, ocean_frac):
     """Select desired regions from transient variables."""
     domain = None
     # if region != 'global':
@@ -140,15 +140,10 @@ def select_region(region, var1, var2, land_frac, ocean_frac, parameter):
             land_ocean_frac = ocean_frac
         region_value = regions_specs[region]['value']
 
-        var1_domain = mask_by(
-            var1, land_ocean_frac, low_limit=region_value)
-        var2_domain = var2.regrid(
-            var1.getGrid(), regridTool=parameter.regrid_tool, regridMethod=parameter.regrid_method)
-        var2_domain = mask_by(
-            var2_domain, land_ocean_frac, low_limit=region_value)
+        var_domain = mask_by(
+            var, land_ocean_frac, low_limit=region_value)
     else:
-        var1_domain = var1
-        var2_domain = var2
+        var_domain = var
 
     try:
         # if region.find('global') == -1:
@@ -157,12 +152,45 @@ def select_region(region, var1, var2, land_frac, ocean_frac, parameter):
     except:
         print("No domain selector.")
 
-    var1_domain_selected = var1_domain(domain)
-    var2_domain_selected = var2_domain(domain)
-    var1_domain_selected.units = var1.units
-    var2_domain_selected.units = var1.units
+    var_domain_selected = var_domain(domain)
+    var_domain_selected.units = var.units
 
-    return var1_domain_selected, var2_domain_selected
+    return var_domain_selected
+
+#def select_region(region, var1, var2, land_frac, ocean_frac, parameter):
+#    """Select desired regions from transient variables."""
+#    domain = None
+#    # if region != 'global':
+#    if region.find('land') != -1 or region.find('ocean') != -1:
+#        if region.find('land') != -1:
+#            land_ocean_frac = land_frac
+#        elif region.find('ocean') != -1:
+#            land_ocean_frac = ocean_frac
+#        region_value = regions_specs[region]['value']
+#
+#        var1_domain = mask_by(
+#            var1, land_ocean_frac, low_limit=region_value)
+#        var2_domain = var2.regrid(
+#            var1.getGrid(), regridTool=parameter.regrid_tool, regridMethod=parameter.regrid_method)
+#        var2_domain = mask_by(
+#            var2_domain, land_ocean_frac, low_limit=region_value)
+#    else:
+#        var1_domain = var1
+#        var2_domain = var2
+#
+#    try:
+#        # if region.find('global') == -1:
+#        domain = regions_specs[region]['domain']
+#        print('Domain: ', domain)
+#    except:
+#        print("No domain selector.")
+#
+#    var1_domain_selected = var1_domain(domain)
+#    var2_domain_selected = var2_domain(domain)
+#    var1_domain_selected.units = var1.units
+#    var2_domain_selected.units = var1.units
+#
+#    return var1_domain_selected, var2_domain_selected
 
 
 def regrid_to_lower_res(mv1, mv2, regrid_tool, regrid_method):

--- a/acme_diags/driver/utils/general.py
+++ b/acme_diags/driver/utils/general.py
@@ -11,6 +11,8 @@ import cdms2
 from acme_diags import container
 from acme_diags.derivations.default_regions import regions_specs
 
+
+
 def adjust_time_from_time_bounds(var):
     """
     Redefine time to be in the middle of the time interval, and rewrite 

--- a/acme_diags/driver/utils/general.py
+++ b/acme_diags/driver/utils/general.py
@@ -131,7 +131,7 @@ def pressure_to_plevs(var, plev):
     return var_p
 
 
-def select_region(region, var, land_frac, ocean_frac):
+def select_region(region, var, land_frac, ocean_frac, parameter):
     """Select desired regions from transient variables."""
     domain = None
     # if region != 'global':
@@ -141,6 +141,9 @@ def select_region(region, var, land_frac, ocean_frac):
         elif region.find('ocean') != -1:
             land_ocean_frac = ocean_frac
         region_value = regions_specs[region]['value']
+
+        land_ocean_frac = land_ocean_frac.regrid(
+            var.getGrid(), regridTool=parameter.regrid_tool, regridMethod=parameter.regrid_method)
 
         var_domain = mask_by(
             var, land_ocean_frac, low_limit=region_value)
@@ -158,41 +161,6 @@ def select_region(region, var, land_frac, ocean_frac):
     var_domain_selected.units = var.units
 
     return var_domain_selected
-
-#def select_region(region, var1, var2, land_frac, ocean_frac, parameter):
-#    """Select desired regions from transient variables."""
-#    domain = None
-#    # if region != 'global':
-#    if region.find('land') != -1 or region.find('ocean') != -1:
-#        if region.find('land') != -1:
-#            land_ocean_frac = land_frac
-#        elif region.find('ocean') != -1:
-#            land_ocean_frac = ocean_frac
-#        region_value = regions_specs[region]['value']
-#
-#        var1_domain = mask_by(
-#            var1, land_ocean_frac, low_limit=region_value)
-#        var2_domain = var2.regrid(
-#            var1.getGrid(), regridTool=parameter.regrid_tool, regridMethod=parameter.regrid_method)
-#        var2_domain = mask_by(
-#            var2_domain, land_ocean_frac, low_limit=region_value)
-#    else:
-#        var1_domain = var1
-#        var2_domain = var2
-#
-#    try:
-#        # if region.find('global') == -1:
-#        domain = regions_specs[region]['domain']
-#        print('Domain: ', domain)
-#    except:
-#        print("No domain selector.")
-#
-#    var1_domain_selected = var1_domain(domain)
-#    var2_domain_selected = var2_domain(domain)
-#    var1_domain_selected.units = var1.units
-#    var2_domain_selected.units = var1.units
-#
-#    return var1_domain_selected, var2_domain_selected
 
 
 def regrid_to_lower_res(mv1, mv2, regrid_tool, regrid_method):

--- a/acme_diags/driver/zonal_mean_2d_driver.py
+++ b/acme_diags/driver/zonal_mean_2d_driver.py
@@ -181,8 +181,8 @@ def run_diag(parameter):
                 for region in regions:
                     print("Selected region: {}".format(region))
 
-                    mv1_domain, mv2_domain = utils.general.select_region(
-                        region, mv1, mv2, land_frac, ocean_frac, parameter)
+                    mv1_domain = utils.general.select_region(region, mv1, land_frac, ocean_frac, parameter)
+                    mv2_domain = utils.general.select_region(region, mv2, land_frac, ocean_frac, parameter)
 
                     parameter.output_file = '-'.join(
                         [ref_name, var, season, region])

--- a/acme_diags/parameter/area_mean_time_series_parameter.py
+++ b/acme_diags/parameter/area_mean_time_series_parameter.py
@@ -9,7 +9,11 @@ class AreaMeanTimeSeriesParameter(CoreParameter):
         # Granulating with regions doesn't make sense,
         # because we have multiple regions for each plot.
         # So keep all of the default values except regions. 
+        #self.seasons = ['ANN']
+        #print(dir(self))
         self.granulate.remove('regions')
+        self.granulate.remove('seasons')
+        
 
     def check_values(self):
         if not self.ref_names:

--- a/acme_diags/parameter/area_mean_time_series_parameter.py
+++ b/acme_diags/parameter/area_mean_time_series_parameter.py
@@ -23,12 +23,9 @@ class AreaMeanTimeSeriesParameter(CoreParameter):
             print(msg)
 
 
-        if self.test_timeseries_input and not (hasattr(self, 'test_start_yr') and hasattr(self, 'test_end_yr')):
-            msg = "You need to define both the 'test_start_yr' and 'test_end_yr' parameter."
+        if not (hasattr(self, 'start_yr') and hasattr(self, 'end_yr')):
+            msg = "You need to define both the 'start_yr' and 'end_yr' parameter."
             raise RuntimeError(msg)
 
-        if self.ref_timeseries_input and not (hasattr(self, 'ref_start_yr') and hasattr(self, 'ref_end_yr')):
-            msg = "You need to define both the 'ref_start_yr' and 'ref_end_yr' parameter."
-            raise RuntimeError(msg)
 
             #raise RuntimeError(msg)

--- a/acme_diags/parameter/area_mean_time_series_parameter.py
+++ b/acme_diags/parameter/area_mean_time_series_parameter.py
@@ -13,5 +13,7 @@ class AreaMeanTimeSeriesParameter(CoreParameter):
 
     def check_values(self):
         if not self.ref_names:
-            msg = 'You must have a value for ref_names.'
-            raise RuntimeError(msg)
+            msg = 'You have no value for ref_names. Caculate test data only'
+            print(msg)
+
+            #raise RuntimeError(msg)

--- a/acme_diags/parameter/area_mean_time_series_parameter.py
+++ b/acme_diags/parameter/area_mean_time_series_parameter.py
@@ -6,6 +6,8 @@ class AreaMeanTimeSeriesParameter(CoreParameter):
         super(AreaMeanTimeSeriesParameter, self).__init__()
         # A list of the reference names to run the diags on.
         self.ref_names = []
+        self.ref_timeseries_input = True
+        self.test_timeseries_input = True
         # Granulating with regions doesn't make sense,
         # because we have multiple regions for each plot.
         # So keep all of the default values except regions. 
@@ -19,5 +21,14 @@ class AreaMeanTimeSeriesParameter(CoreParameter):
         if not self.ref_names:
             msg = 'You have no value for ref_names. Caculate test data only'
             print(msg)
+
+
+        if self.test_timeseries_input and not (hasattr(self, 'test_start_yr') and hasattr(self, 'test_end_yr')):
+            msg = "You need to define both the 'test_start_yr' and 'test_end_yr' parameter."
+            raise RuntimeError(msg)
+
+        if self.ref_timeseries_input and not (hasattr(self, 'ref_start_yr') and hasattr(self, 'ref_end_yr')):
+            msg = "You need to define both the 'ref_start_yr' and 'ref_end_yr' parameter."
+            raise RuntimeError(msg)
 
             #raise RuntimeError(msg)

--- a/acme_diags/parameter/core_parameter.py
+++ b/acme_diags/parameter/core_parameter.py
@@ -71,7 +71,8 @@ class CoreParameter(cdp.cdp_parameter.CDPParameter):
         self.viewer_descr = {}
 
     def check_values(self):
-        must_have_params = ['reference_data_path', 'test_data_path', 'results_dir']
+        #must_have_params = ['reference_data_path', 'test_data_path', 'results_dir']
+        must_have_params = ['test_data_path', 'results_dir']
 
         for param in must_have_params:
             if not hasattr(self, param):

--- a/acme_diags/parser/area_mean_time_series_parser.py
+++ b/acme_diags/parser/area_mean_time_series_parser.py
@@ -22,3 +22,44 @@ class AreaMeanTimeSeriesParser(CoreParser):
             help='List of reference names.',
             required=False)
 
+        self.add_argument(
+            '--ref_timeseries_input',
+            dest='ref_timeseries_input',
+            help='The input reference data are timeseries files.',
+            action='store_const',
+            const=True,
+            required=False)
+
+        self.add_argument(
+            '--ref_start_yr',
+            dest='ref_start_yr',
+            help="Start year for the reference timeseries files.",
+            required=False)
+
+        self.add_argument(
+            '--ref_end_yr',
+            dest='ref_end_yr',
+            help="End year for the reference timeseries files.",
+            required=False)
+
+
+        self.add_argument(
+            '--test_timeseries_input',
+            dest='test_timeseries_input',
+            help='The input test data are timeseries files.',
+            action='store_const',
+            const=True,
+            required=False)
+
+        self.add_argument(
+            '--test_start_yr',
+            dest='test_start_yr',
+            help="Start year for the test timeseries files.",
+            required=False)
+
+        self.add_argument(
+            '--test_end_yr',
+            dest='test_end_yr',
+            help="End year for the test timeseries files.",
+            required=False)
+

--- a/acme_diags/parser/area_mean_time_series_parser.py
+++ b/acme_diags/parser/area_mean_time_series_parser.py
@@ -31,19 +31,6 @@ class AreaMeanTimeSeriesParser(CoreParser):
             required=False)
 
         self.add_argument(
-            '--ref_start_yr',
-            dest='ref_start_yr',
-            help="Start year for the reference timeseries files.",
-            required=False)
-
-        self.add_argument(
-            '--ref_end_yr',
-            dest='ref_end_yr',
-            help="End year for the reference timeseries files.",
-            required=False)
-
-
-        self.add_argument(
             '--test_timeseries_input',
             dest='test_timeseries_input',
             help='The input test data are timeseries files.',
@@ -52,14 +39,17 @@ class AreaMeanTimeSeriesParser(CoreParser):
             required=False)
 
         self.add_argument(
-            '--test_start_yr',
-            dest='test_start_yr',
-            help="Start year for the test timeseries files.",
+            '--start_yr',
+            dest='start_yr',
+            help="Start year for the timeseries files.",
             required=False)
 
         self.add_argument(
-            '--test_end_yr',
-            dest='test_end_yr',
-            help="End year for the test timeseries files.",
+            '--end_yr',
+            dest='end_yr',
+            help="End year for the timeseries files.",
             required=False)
+
+
+
 

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -36,8 +36,7 @@ def plot(var, regions_to_data, parameter):
 
     # Create the figure.
     figsize = [17.0, 10]
-    dpi = 150
-    fig = plt.figure(figsize=figsize, dpi=dpi)
+    fig = plt.figure(figsize=figsize, dpi=parameter.dpi)
     start_time = int(parameter.start_yr)
     end_time = int(parameter.end_yr)
     num_year = end_time - start_time+1

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -44,17 +44,17 @@ def plot(var, regions_to_data, parameter):
 
     s = parameter.test_name_yrs
     years = s[s.find("(")+1:s.find(")")]
-    test_name = s.split('(')[0]
-    if not test_name:
-        test_name = 'test model'
+    test_name = s.split('(')[0].replace(' ', '')
+    if test_name is '':
+        test_name = 'test data'
 
     for i_region, data_set_for_region in enumerate(regions_to_data.values()):
         refs = data_set_for_region.refs
         test = data_set_for_region.test
         ax1 = fig.add_axes(panel[i_region])
-        ax1.plot(test.asma(), 'k', linewidth=2,label = test_name +' ({0:.1f})'.format(np.mean(test.asma())))
+        ax1.plot(test.asma(), 'k', linewidth=2,label = test_name +'(mean: {0:.2f}, std: {1:.3f})'.format(np.mean(test.asma()), np.std(test.asma())))
         for i_ref, ref in enumerate(refs):
-            ax1.plot(ref.asma(), line_color[i_ref], linewidth=2,label = ref.ref_name +' ({0:.1f})'.format(np.mean(ref.asma())))
+            ax1.plot(ref.asma(), line_color[i_ref], linewidth=2,label = ref.ref_name +'(mean: {0:.1f}, std: {1:.2f})'.format(np.mean(ref.asma()), np.std(ref.asma())))
 
         x = np.arange(num_year)
         #do Truncation Division to accommodating long time records

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -15,14 +15,10 @@ def plot(var, regions_to_data, parameter):
     plotTitle = {'fontsize': 8.5}
     plotSideTitle = {'fontsize': 6.5}
 
-    # Position and sizes of subplot axes in page coordinates (0 to 1)
-    # The dimensions [left, bottom, width, height] of the new axes. All quantities are in fractions of figure width and height.
     line_color = ['r', 'b', 'g', 'm', 'c', 'y']
 
-    panel = [(0.1500, 0.5500, 0.7500, 0.3000),
-             (0.1500, 0.1300, 0.7500, 0.3000),
-             ]
-
+    # Position and sizes of subplot axes in page coordinates (0 to 1)
+    # The dimensions [left, bottom, width, height] of the new axes. All quantities are in fractions of figure width and height.
     panel = [(0.1, 0.70, 0.25, 0.225),
              (0.4, 0.70, 0.25, 0.225),
              (0.7, 0.70, 0.25, 0.225),
@@ -68,15 +64,12 @@ def plot(var, regions_to_data, parameter):
         ax1.set_xticks(x[::stepsize])
         x_ticks_labels = np.arange(start_time, end_time + 1, stepsize)
         ax1.set_xticklabels(x_ticks_labels, rotation='45', fontsize=8)
-
-        #if i_region % 3 == 0 :
-        #    ax1.set_ylabel(var + ' (' + test.units + ')')
         ax1.set_ylabel(var + ' (' + test.units + ')')
         ax1.set_xlabel('Year')
         ax1.legend(loc='best', prop={'size': 7})
-        #fig.text(panel[i_region][0]+0.12, panel[i_region][1]+panel[i_region][3]-0.015, parameter.regions[i_region],ha='center', color='black')
-    # Figure title.
         ax1.set_title(parameter.regions[i_region],fontsize = 10)
+
+    # Figure title.
     fig.suptitle('Annual mean ' + var + ' time series over regions ' + parameter.test_name_yrs, x=0.3, y=0.98, fontsize=15)
 
     # Save the figure.
@@ -113,7 +106,7 @@ def plot(var, regions_to_data, parameter):
                 ignore_container=True), parameter.output_file)
             fname = orig_fnm + '.%i.' %(i) + f
             print('Sub-plot saved in: ' + fname)
-            
+
             i += 1
 
     plt.close()

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -35,7 +35,7 @@ def plot(var, regions_to_data, parameter):
              ]
 
     # Create the figure.
-    figsize = [11.0, 8.5]
+    figsize = [17.0, 10]
     dpi = 150
     fig = plt.figure(figsize=figsize, dpi=dpi)
     num_year = int(parameter.test_end_yr) - int(parameter.test_start_yr) +1
@@ -53,10 +53,10 @@ def plot(var, regions_to_data, parameter):
         x_ticks_labels = [str(x) for x in range(int(parameter.test_start_yr),int(parameter.test_end_yr)+1)]
         ax1.set_xticklabels(x_ticks_labels, rotation='45', fontsize=6)
 
-        if i_region % 3 == 0 :
-            ax1.set_ylabel('variable name (units)')
-            #ax1.set_ylabel(test.long_name + ' (' + test.units + ')')
-        ax1.legend(loc=1, prop={'size': 6})
+        #if i_region % 3 == 0 :
+        #    ax1.set_ylabel(var + ' (' + test.units + ')')
+        ax1.set_ylabel(var + ' (' + test.units + ')')
+        ax1.legend(loc='best', prop={'size': 7})
         fig.text(panel[i_region][0]+0.12, panel[i_region][1]+panel[i_region][3]-0.015, parameter.regions[i_region],ha='center', color='black')
     # Figure title.
     fig.suptitle('Annual mean ' + var + ' over regions ' + parameter.test_name_yrs, x=0.5, y=0.97, fontsize=15)

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -17,21 +17,21 @@ def plot(var, regions_to_data, parameter):
 
     # Position and sizes of subplot axes in page coordinates (0 to 1)
     # The dimensions [left, bottom, width, height] of the new axes. All quantities are in fractions of figure width and height.
-    line_color = ['r', 'b', 'g', 'm']
+    line_color = ['r', 'b', 'g', 'm', 'c', 'y']
 
     panel = [(0.1500, 0.5500, 0.7500, 0.3000),
              (0.1500, 0.1300, 0.7500, 0.3000),
              ]
 
-    panel = [(0.1, 0.68, 0.25, 0.25),
-             (0.4, 0.68, 0.25, 0.25),
-             (0.7, 0.68, 0.25, 0.25),
-             (0.1, 0.38, 0.25, 0.25),
-             (0.4, 0.38, 0.25, 0.25),
-             (0.7, 0.38, 0.25, 0.25),
-             (0.1, 0.08, 0.25, 0.25),
-             (0.4, 0.08, 0.25, 0.25),
-             (0.7, 0.08, 0.25, 0.25),
+    panel = [(0.1, 0.70, 0.25, 0.225),
+             (0.4, 0.70, 0.25, 0.225),
+             (0.7, 0.70, 0.25, 0.225),
+             (0.1, 0.38, 0.25, 0.225),
+             (0.4, 0.38, 0.25, 0.225),
+             (0.7, 0.38, 0.25, 0.225),
+             (0.1, 0.06, 0.25, 0.225),
+             (0.4, 0.06, 0.25, 0.225),
+             (0.7, 0.06, 0.25, 0.225),
              ]
 
     # Create the figure.
@@ -54,12 +54,12 @@ def plot(var, regions_to_data, parameter):
         ax1 = fig.add_axes(panel[i_region])
         ax1.plot(test.asma(), 'k', linewidth=2,label = test_name +'(mean: {0:.2f}, std: {1:.3f})'.format(np.mean(test.asma()), np.std(test.asma())))
         for i_ref, ref in enumerate(refs):
-            ax1.plot(ref.asma(), line_color[i_ref], linewidth=2,label = ref.ref_name +'(mean: {0:.1f}, std: {1:.2f})'.format(np.mean(ref.asma()), np.std(ref.asma())))
+            ax1.plot(ref.asma(), line_color[i_ref], linewidth=2,label = ref.ref_name +'(mean: {0:.2f}, std: {1:.3f})'.format(np.mean(ref.asma()), np.std(ref.asma())))
 
         x = np.arange(num_year)
         #do Truncation Division to accommodating long time records
-        if num_year > 10:
-            stepsize = (num_year - 1)//10
+        if num_year > 19:
+            stepsize = num_year //10
         else:
             stepsize = 1
         ax1.set_xticks(x[::stepsize])

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -38,8 +38,8 @@ def plot(var, regions_to_data, parameter):
     figsize = [17.0, 10]
     dpi = 150
     fig = plt.figure(figsize=figsize, dpi=dpi)
-    start_time = int(parameter.test_start_yr)
-    end_time = int(parameter.test_end_yr)
+    start_time = int(parameter.start_yr)
+    end_time = int(parameter.end_yr)
     num_year = end_time - start_time+1
 
     s = parameter.test_name_yrs

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -42,11 +42,17 @@ def plot(var, regions_to_data, parameter):
     end_time = int(parameter.test_end_yr)
     num_year = end_time - start_time+1
 
+    s = parameter.test_name_yrs
+    years = s[s.find("(")+1:s.find(")")]
+    test_name = s.split('(')[0]
+    if not test_name:
+        test_name = 'test model'
+
     for i_region, data_set_for_region in enumerate(regions_to_data.values()):
         refs = data_set_for_region.refs
         test = data_set_for_region.test
         ax1 = fig.add_axes(panel[i_region])
-        ax1.plot(test.asma(), 'k', linewidth=2,label = 'model' +' ({0:.1f})'.format(np.mean(test.asma())))
+        ax1.plot(test.asma(), 'k', linewidth=2,label = test_name +' ({0:.1f})'.format(np.mean(test.asma())))
         for i_ref, ref in enumerate(refs):
             ax1.plot(ref.asma(), line_color[i_ref], linewidth=2,label = ref.ref_name +' ({0:.1f})'.format(np.mean(ref.asma())))
 
@@ -66,7 +72,7 @@ def plot(var, regions_to_data, parameter):
         ax1.legend(loc='best', prop={'size': 7})
         fig.text(panel[i_region][0]+0.12, panel[i_region][1]+panel[i_region][3]-0.015, parameter.regions[i_region],ha='center', color='black')
     # Figure title.
-    fig.suptitle('Annual mean ' + var + ' over regions ' + parameter.test_name_yrs, x=0.5, y=0.97, fontsize=15)
+    fig.suptitle('Annual mean ' + var + ' over regions: ' + parameter.test_name_yrs, x=0.5, y=0.97, fontsize=15)
 
     # Save the figure.
     output_file_name = var

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -38,7 +38,9 @@ def plot(var, regions_to_data, parameter):
     figsize = [17.0, 10]
     dpi = 150
     fig = plt.figure(figsize=figsize, dpi=dpi)
-    num_year = int(parameter.test_end_yr) - int(parameter.test_start_yr) +1
+    start_time = int(parameter.test_start_yr)
+    end_time = int(parameter.test_end_yr)
+    num_year = end_time - start_time+1
 
     for i_region, data_set_for_region in enumerate(regions_to_data.values()):
         refs = data_set_for_region.refs
@@ -49,9 +51,14 @@ def plot(var, regions_to_data, parameter):
             ax1.plot(ref.asma(), line_color[i_ref], linewidth=2,label = ref.ref_name +' ({0:.1f})'.format(np.mean(ref.asma())))
 
         x = np.arange(num_year)
-        ax1.set_xticks(x)
-        x_ticks_labels = [str(x) for x in range(int(parameter.test_start_yr),int(parameter.test_end_yr)+1)]
-        ax1.set_xticklabels(x_ticks_labels, rotation='45', fontsize=6)
+        #do Truncation Division to accommodating long time records
+        if num_year > 10:
+            stepsize = (num_year - 1)//10
+        else:
+            stepsize = 1
+        ax1.set_xticks(x[::stepsize])
+        x_ticks_labels = np.arange(start_time, end_time + 1, stepsize)
+        ax1.set_xticklabels(x_ticks_labels, rotation='45', fontsize=10)
 
         #if i_region % 3 == 0 :
         #    ax1.set_ylabel(var + ' (' + test.units + ')')

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -34,6 +34,10 @@ def plot(var, regions_to_data, parameter):
              (0.7, 0.06, 0.25, 0.225),
              ]
 
+    # Border padding relative to subplot axes for saving individual panels
+    # (left, bottom, right, top) in page coordinates
+    border = (-0.047, -0.06, 0.006, 0.03)
+
     # Create the figure.
     figsize = [17.0, 10]
     fig = plt.figure(figsize=figsize, dpi=parameter.dpi)
@@ -87,6 +91,30 @@ def plot(var, regions_to_data, parameter):
         fnm = os.path.join(get_output_dir(parameter.current_set, parameter,
             ignore_container=True), output_file_name + '.' + f)
         print('Plot saved in: ' + fnm)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(get_output_dir(
+            parameter.current_set, parameter), parameter.output_file)
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2,2)
+            subpage[1,:] = subpage[0,:] + subpage[1,:]
+            subpage = subpage + np.array(border).reshape(2,2)
+            subpage = list(((subpage)*page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save subplot
+            fname = fnm + '.%i.' %(i) + f
+            plt.savefig(fname, bbox_inches=extent)
+
+            orig_fnm = os.path.join(get_output_dir(parameter.current_set, parameter,
+                ignore_container=True), parameter.output_file)
+            fname = orig_fnm + '.%i.' %(i) + f
+            print('Sub-plot saved in: ' + fname)
+            
+            i += 1
 
     plt.close()
 

--- a/acme_diags/plot/cartopy/area_mean_time_series_plot.py
+++ b/acme_diags/plot/cartopy/area_mean_time_series_plot.py
@@ -64,15 +64,17 @@ def plot(var, regions_to_data, parameter):
             stepsize = 1
         ax1.set_xticks(x[::stepsize])
         x_ticks_labels = np.arange(start_time, end_time + 1, stepsize)
-        ax1.set_xticklabels(x_ticks_labels, rotation='45', fontsize=10)
+        ax1.set_xticklabels(x_ticks_labels, rotation='45', fontsize=8)
 
         #if i_region % 3 == 0 :
         #    ax1.set_ylabel(var + ' (' + test.units + ')')
         ax1.set_ylabel(var + ' (' + test.units + ')')
+        ax1.set_xlabel('Year')
         ax1.legend(loc='best', prop={'size': 7})
-        fig.text(panel[i_region][0]+0.12, panel[i_region][1]+panel[i_region][3]-0.015, parameter.regions[i_region],ha='center', color='black')
+        #fig.text(panel[i_region][0]+0.12, panel[i_region][1]+panel[i_region][3]-0.015, parameter.regions[i_region],ha='center', color='black')
     # Figure title.
-    fig.suptitle('Annual mean ' + var + ' over regions: ' + parameter.test_name_yrs, x=0.5, y=0.97, fontsize=15)
+        ax1.set_title(parameter.regions[i_region],fontsize = 10)
+    fig.suptitle('Annual mean ' + var + ' time series over regions ' + parameter.test_name_yrs, x=0.3, y=0.98, fontsize=15)
 
     # Save the figure.
     output_file_name = var

--- a/acme_diags/run.py
+++ b/acme_diags/run.py
@@ -141,10 +141,14 @@ class Run():
                     attr_value = getattr(parent, attr)
                     setattr(parameters[i], attr, attr_value)
 
+            print(list(set(none_default_param_parent) - \
+                set(none_default_param_child)))
             for attr in list(set(none_default_param_parent) - \
                 set(none_default_param_child)):
-                attr_value = getattr(parent, attr)
-                setattr(parameters[i], attr, attr_value)
+                #'seasons' is a corner case that don't need to get in to none-core sets, Ex. area mean time series
+                if attr != 'seasons':
+                    attr_value = getattr(parent, attr)
+                    setattr(parameters[i], attr, attr_value)
 
         #for i in range(len(parameters)):
         #    attrs = vars(parameters[i])

--- a/acme_diags/run.py
+++ b/acme_diags/run.py
@@ -74,6 +74,7 @@ class Run():
             # We just call it manually with the parameter object param.
             params = self.parser.select(param, params)
 
+
             final_params.extend(params)
 
         self.parser.check_values_of_params(final_params)
@@ -117,7 +118,13 @@ class Run():
             # make a deepcopy first.
             parent = copy.deepcopy(parent)
             self._remove_attrs_with_default_values(parent)
-            parameters[i] += parent
+            #parameters[i] += parent
+            for attr in dir(parent):
+                if not attr.startswith('_') and not hasattr(parameters[i], attr):
+                    # This attr of parent is a user-defined one and does not
+                    # already exist in the parameters[i] parameter object.
+                    attr_value = getattr(parent, attr)
+                    setattr(parameters[i], attr, attr_value)
 
 
     def _add_attrs_with_default_values(self, param):

--- a/acme_diags/run.py
+++ b/acme_diags/run.py
@@ -122,17 +122,29 @@ class Run():
             # removing the default values before addition)
             # make a deepcopy first.
             parent = copy.deepcopy(parent)
+            #find attributes that are not defaults
+
+            none_default_param_parent = self._find_attrs_with_default_values(parent)
+            none_default_param_child = self._find_attrs_with_default_values(parameters[i])
+
+
             self._remove_attrs_with_default_values(parent)
+ 
 
             #Simply copy over all attribute from parent to children
             #parameters[i] += parent
-
+             
             for attr in dir(parent):
                 if not attr.startswith('_') and not hasattr(parameters[i], attr):
                     # This attr of parent is a user-defined one and does not
                     # already exist in the parameters[i] parameter object.
                     attr_value = getattr(parent, attr)
                     setattr(parameters[i], attr, attr_value)
+
+            for attr in list(set(none_default_param_parent) - \
+                set(none_default_param_child)):
+                attr_value = getattr(parent, attr)
+                setattr(parameters[i], attr, attr_value)
 
         #for i in range(len(parameters)):
         #    attrs = vars(parameters[i])
@@ -170,6 +182,22 @@ class Run():
                 getattr(new_instance, attr) == getattr(param, attr):
                 delattr(param, attr)
 
+    def _find_attrs_with_default_values(self, param):
+        """
+        In the param, remove any parameters that
+        have their default value.
+        """
+        none_default_attr = []
+        new_instance = param.__class__()
+        for attr in dir(param):
+            # Ignore any of the hidden attributes.
+            if attr.startswith('_'):
+                continue
+            
+            if hasattr(new_instance, attr) and \
+                getattr(new_instance, attr) != getattr(param, attr):
+                none_default_attr.append(attr)
+        return none_default_attr
 
     def _get_instance_of_param_class(self, cls, parameters):
         """

--- a/acme_diags/run.py
+++ b/acme_diags/run.py
@@ -124,8 +124,8 @@ class Run():
             parent = copy.deepcopy(parent)
             #find attributes that are not defaults
 
-            none_default_param_parent = self._find_attrs_with_default_values(parent)
-            none_default_param_child = self._find_attrs_with_default_values(parameters[i])
+            none_default_param_parent = self._find_attrs_with_none_default_values(parent)
+            none_default_param_child = self._find_attrs_with_none_default_values(parameters[i])
 
 
             self._remove_attrs_with_default_values(parent)
@@ -186,7 +186,7 @@ class Run():
                 getattr(new_instance, attr) == getattr(param, attr):
                 delattr(param, attr)
 
-    def _find_attrs_with_default_values(self, param):
+    def _find_attrs_with_none_default_values(self, param):
         """
         In the param, remove any parameters that
         have their default value.

--- a/acme_diags/run.py
+++ b/acme_diags/run.py
@@ -57,6 +57,8 @@ class Run():
 
             # For each of the set_names, get the corresponding parameter.
             param = self._get_instance_of_param_class(SET_TO_PARAMETERS[set_name], parameters)
+            
+
             # Since each parameter will have lots of default values, we want to remove them.
             # Otherwise when calling get_parameters(), these default values
             # will take precedence over values defined in other_params.
@@ -93,10 +95,13 @@ class Run():
         But most of the important parameters are in CoreParameter,
         so copy them over to the ZonalMean2dParameter.
         """
+
         def get_parent(param):
             """
             From parameters, get any object that's a parent
             type to param.
+
+            Ex: CoreParameter object is a parent of AreaMeanTimeSeriesParameter object
             """
             try:
                 parent_class = param.__class__.__mro__[1]
@@ -118,13 +123,20 @@ class Run():
             # make a deepcopy first.
             parent = copy.deepcopy(parent)
             self._remove_attrs_with_default_values(parent)
+
+            #Simply copy over all attribute from parent to children
             #parameters[i] += parent
+
             for attr in dir(parent):
                 if not attr.startswith('_') and not hasattr(parameters[i], attr):
                     # This attr of parent is a user-defined one and does not
                     # already exist in the parameters[i] parameter object.
                     attr_value = getattr(parent, attr)
                     setattr(parameters[i], attr, attr_value)
+
+        #for i in range(len(parameters)):
+        #    attrs = vars(parameters[i])
+        #    print('all parameters', ','.join("%s: %s" % item for item in attrs.items()))
 
 
     def _add_attrs_with_default_values(self, param):


### PR DESCRIPTION
Finalizing are_mean_time_series set:

- Finalizing the logic to compose parameter list for new set with set-specific parameters, enabling model only, model vs obs, model vs models options.
- Refine the driver for the new sets: save metrics, refine plots

A few examples using this branch:
[time_series (model vs obs)](https://compy-dtn.pnl.gov/zhan429/examples/area_mean_with_obs/viewer/) 
[time_series (model vs models)](https://compy-dtn.pnl.gov/zhan429/examples/area_mean_with_models/viewer/area_mean_time_series/index.html)
[all_sets (model vs obs)](https://compy-dtn.pnl.gov/zhan429/examples/all_sets/viewer/)
[latlon and time_series (select same year range)](https://compy-dtn.pnl.gov/zhan429/examples/multiple_sets_2ts/viewer/)