### PR TITLE
More cmip support

### DIFF
--- a/acme_diags/derivations/acme.py
+++ b/acme_diags/derivations/acme.py
@@ -615,7 +615,7 @@ derived_variables = {
         (('CLDTOT',), lambda cldtot: convert_units(cldtot, target_units="%"))
     ]),
     'CLOUD': OrderedDict([
-        (('clt',), rename),
+        (('cl',), rename),
         (('CLOUD',), lambda cldtot: convert_units(cldtot, target_units="%"))
     ]),
     # below for COSP output

--- a/acme_diags/derivations/acme.py
+++ b/acme_diags/derivations/acme.py
@@ -105,6 +105,13 @@ def prect(precc, precl):
     var.long_name = "Total precipitation rate (convective + large-scale)"
     return var
 
+def precst(precc, precl):
+    """Total precipitation flux = convective + large-scale"""
+    var = precc + precl
+    var = convert_units(var, "mm/day")
+    var.long_name = "Total snowfall flux (convective + large-scale)"
+    return var
+
 def tauxy(taux, tauy):
     """tauxy = (taux^2 + tauy^2)sqrt"""
     var = (taux**2 + tauy**2)**0.5
@@ -367,6 +374,10 @@ derived_variables = {
         (('pr',), lambda pr: qflxconvert_units(rename(pr))),
         (('PRECC', 'PRECL'), lambda precc, precl: prect(precc, precl))
     ]),
+    'PRECST': OrderedDict([
+        (('prsn',), lambda prsn: qflxconvert_units(rename(prsn))),
+        (('PRECSC', 'PRECSL'), lambda precsc, precsl: precst(precsc, precsl))
+    ]),
     'SST': OrderedDict([
         # lambda sst: convert_units(rename(sst),target_units="degC")),
         (('sst',), rename),
@@ -374,8 +385,8 @@ derived_variables = {
             convert_units(ts, target_units="degC"), ocnfrac, low_limit=0.9)),
         (('SST',), lambda sst: convert_units(sst, target_units="degC"))
     ]),
-    'PREH2O': OrderedDict([
-        (('TMQ',), rename),
+    'TMQ': OrderedDict([
+        (('PREH2O',), rename),
         (('prw',), rename)
     ]),
     'SOLIN': OrderedDict([
@@ -456,6 +467,9 @@ derived_variables = {
     'FLDS': OrderedDict([
         (('rlds',), rename)
     ]),
+    'FLUS': OrderedDict([
+        (('rlus',), rename)
+    ]),
     'FLDSC': OrderedDict([
         (('rldscs',), rename),
         (('TS', 'FLNSC'), lambda ts, flnsc: fldsc(ts, flnsc))
@@ -470,6 +484,12 @@ derived_variables = {
     'FSDS': OrderedDict([
         (('rsds',), rename)
     ]),
+    'FSUS': OrderedDict([
+        (('rsus',), rename)
+    ]),
+    'FSUSC': OrderedDict([
+        (('rsuscs',), rename)
+    ]),
     'FSDSC': OrderedDict([
         (('rsdscs',), rename),
         (('rsdsc',), rename)
@@ -480,6 +500,12 @@ derived_variables = {
     ]),
     'FLUT': OrderedDict([
         (('rlut',), rename)
+    ]),
+    'FSUTOA': OrderedDict([
+        (('rsut',), rename)
+    ]),
+    'FSUTOAC': OrderedDict([
+        (('rsutcs',), rename)
     ]),
     'FLNT': OrderedDict([
         (('FLNT',), rename)
@@ -551,6 +577,7 @@ derived_variables = {
         (('tas',), lambda t: convert_units(t, target_units="DegC"))
     ]),
     'QFLX': OrderedDict([
+        (('evspsbl',), rename),
         (('QFLX',), lambda qflx: qflxconvert_units(qflx))
     ]),
     'LHFLX': OrderedDict([
@@ -584,7 +611,12 @@ derived_variables = {
         (('CLDMED',), lambda cldmed: convert_units(cldmed, target_units="%"))
     ]),
     'CLDTOT': OrderedDict([
+        (('clt',), rename),
         (('CLDTOT',), lambda cldtot: convert_units(cldtot, target_units="%"))
+    ]),
+    'CLOUD': OrderedDict([
+        (('clt',), rename),
+        (('CLOUD',), lambda cldtot: convert_units(cldtot, target_units="%"))
     ]),
     # below for COSP output
     # CLIPSO
@@ -706,6 +738,7 @@ derived_variables = {
         (('OMEGA',), lambda omega: convert_units(omega, target_units="mbar/day"))
     ]),
     'SHUM': OrderedDict([
+        (('hus',), lambda q: convert_units(rename(q), target_units="g/kg")),
         (('Q',), lambda q: convert_units(rename(q), target_units="g/kg")),
         (('SHUM',), lambda shum: convert_units(shum, target_units="g/kg"))
     ]),
@@ -714,7 +747,191 @@ derived_variables = {
         (('tauu','tauv'), lambda taux, tauy: tauxy(taux, tauy))
     ]),
     'AODVIS': OrderedDict([
+        (('od550aer',), rename),
         (('AODVIS',), lambda aod: convert_units(rename(aod), target_units = "dimensionless")),
         (('AOD_550_ann',), lambda aod: convert_units(rename(aod), target_units = "dimensionless"))
+    ]),
+    'AODABS': OrderedDict([
+        (('abs550aer',), rename)
+    ]),
+    'TS': OrderedDict([
+        (('ts',), rename)
+    ]),
+    'PS': OrderedDict([
+        (('ps',), rename)
+    ]),
+    'U10': OrderedDict([
+        (('sfcWind',), rename)
+    ]),
+    'QREFHT': OrderedDict([
+        (('huss',), rename)
+    ]),
+    'PRECC': OrderedDict([
+        (('prc',), rename)
+    ]),
+    'TAUX': OrderedDict([
+        (('tauu',), lambda tauu: -tauu)
+    ]),
+    'TAUY': OrderedDict([
+        (('tauv',), lambda tauv: -tauv)
+    ]),
+    'CLDICE': OrderedDict([
+        (('cli',), rename)
+    ]),
+    'TGCLDIWP': OrderedDict([
+        (('clivi',), rename)
+    ]),
+    'CLDLIQ': OrderedDict([
+        (('clw',), rename)
+    ]),
+    'TGCLDCWP': OrderedDict([
+        (('clwvi',), rename)
+    ]),
+    'O3': OrderedDict([
+        (('o3',), rename)
+    ]),
+    #Land variables
+    'SOILWATER_10CM': OrderedDict([
+        (('mrsos',), rename)
+    ]),
+    'SOILWATER_SUM': OrderedDict([
+        (('mrso',), rename)
+    ]),
+    'SOILICE_SUM': OrderedDict([
+        (('mrfso',), rename)
+    ]),
+    'QOVER': OrderedDict([
+        (('mrros',), rename)
+    ]),
+    'QRUNOFF': OrderedDict([
+        (('mrro',), rename)
+    ]),
+    'QINTR': OrderedDict([
+        (('prveg',), rename)
+    ]),
+    'QVEGE': OrderedDict([
+        (('evspsblveg',), rename)
+    ]),
+    'QSOIL': OrderedDict([
+        (('evspsblsoi',), rename)
+    ]),
+    'TRAN': OrderedDict([
+        (('tran',), rename)
+    ]),
+    'TSOI': OrderedDict([
+        (('tsl',), rename)
+    ]),
+    'LAI': OrderedDict([
+        (('lai',), rename)
+    ]),
+    #Ocean variables
+    'tauuo': OrderedDict([
+        (('tauuo',), rename)
+    ]),
+    'tos': OrderedDict([
+        (('tos',), rename)
+    ]),
+    'thetaoga': OrderedDict([
+        (('thetaoga',), rename)
+    ]),
+    'hfsifrazil': OrderedDict([
+        (('hfsifrazil',), rename)
+    ]),
+    'sos': OrderedDict([
+        (('sos',), rename)
+    ]),
+    'soga': OrderedDict([
+        (('soga',), rename)
+    ]),
+    'tosga': OrderedDict([
+        (('tosga',), rename)
+    ]),
+    'wo': OrderedDict([
+        (('wo',), rename)
+    ]),
+    'thetao': OrderedDict([
+        (('thetao',), rename)
+    ]),
+    'masscello': OrderedDict([
+        (('masscello',), rename)
+    ]),
+    'wfo': OrderedDict([
+        (('wfo',), rename)
+    ]),
+    'tauvo': OrderedDict([
+        (('tauvo',), rename)
+    ]),
+    'vo': OrderedDict([
+        (('vo',), rename)
+    ]),
+    'hfds': OrderedDict([
+        (('hfds',), rename)
+    ]),
+    'volo': OrderedDict([
+        (('volo',), rename)
+    ]),
+    'uo': OrderedDict([
+        (('uo',), rename)
+    ]),
+    'zos': OrderedDict([
+        (('zos',), rename)
+    ]),
+    'tob': OrderedDict([
+        (('tob',), rename)
+    ]),
+    'sosga': OrderedDict([
+        (('sosga',), rename)
+    ]),
+    'sfdsi': OrderedDict([
+        (('sfdsi',), rename)
+    ]),
+    'zhalfo': OrderedDict([
+        (('zhalfo',), rename)
+    ]),
+    'masso': OrderedDict([
+        (('masso',), rename)
+    ]),
+    'so': OrderedDict([
+        (('so',), rename)
+    ]),
+    'sob': OrderedDict([
+        (('sob',), rename)
+    ]),
+    'mlotst': OrderedDict([
+        (('mlotst',), rename)
+    ]),
+    'fsitherm': OrderedDict([
+        (('fsitherm',), rename)
+    ]),
+    'msftmz': OrderedDict([
+        (('msftmz',), rename)
+    ]),
+    #sea ice variables
+    'sitimefrac': OrderedDict([
+        (('sitimefrac',), rename)
+    ]),
+    'siconc': OrderedDict([
+        (('siconc',), rename)
+    ]),
+    'sisnmass': OrderedDict([
+        (('sisnmass',), rename)
+    ]),
+    'sisnthick': OrderedDict([
+        (('sisnthick',), rename)
+    ]),
+    'simass': OrderedDict([
+        (('simass',), rename)
+    ]),
+    'sithick': OrderedDict([
+        (('sithick',), rename)
+    ]),
+    'siu': OrderedDict([
+        (('siu',), rename)
+    ]),
+    'sitemptop': OrderedDict([
+        (('sitemptop',), rename)
+    ]),
+    'siv': OrderedDict([
+        (('siv',), rename)
     ])
 }

--- a/acme_diags/driver/default_diags/lat_lon_model_vs_model.cfg
+++ b/acme_diags/driver/default_diags/lat_lon_model_vs_model.cfg
@@ -341,7 +341,7 @@ diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
 [#]
 sets = ["lat_lon"]
 case_id = "model_vs_model"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
 diff_levels = [-12, -9, -6, -4, -3, -2, -1, 1, 2, 3, 4, 6, 9, 12]

--- a/acme_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
+++ b/acme_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
@@ -853,7 +853,7 @@ diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
 [#]
 sets = ["lat_lon"]
 case_id = "ERA-Interim"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
@@ -1100,7 +1100,7 @@ diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
 [#]
 sets = ["lat_lon"]
 case_id = "MERRA2"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]

--- a/acme_diags/driver/default_diags/polar_model_vs_model.cfg
+++ b/acme_diags/driver/default_diags/polar_model_vs_model.cfg
@@ -260,7 +260,7 @@ diff_levels = [-65, -55, -45, -35, -25, -15, -5, 5, 15, 25, 35, 45, 55, 65]
 [#]
 sets = ["polar"]
 case_id = "model_vs_model"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["polar_S", "polar_N"]
 contour_levels = [0, 1, 2, 4, 6, 8, 12, 14, 16, 18, 20, 22]

--- a/acme_diags/driver/default_diags/polar_model_vs_obs.cfg
+++ b/acme_diags/driver/default_diags/polar_model_vs_obs.cfg
@@ -453,7 +453,7 @@ diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
 [#]
 sets = ["polar"]
 case_id = "ERA-Interim"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
@@ -628,7 +628,7 @@ diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
 [#]
 sets = ["polar"]
 case_id = "MERRA2"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]

--- a/acme_diags/driver/default_diags/zonal_mean_xy_model_vs_model.cfg
+++ b/acme_diags/driver/default_diags/zonal_mean_xy_model_vs_model.cfg
@@ -152,7 +152,7 @@ seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 [#]
 sets = ["zonal_mean_xy"]
 case_id = "model_vs_model"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 
 [#]

--- a/acme_diags/driver/default_diags/zonal_mean_xy_model_vs_obs.cfg
+++ b/acme_diags/driver/default_diags/zonal_mean_xy_model_vs_obs.cfg
@@ -243,7 +243,7 @@ seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 [#]
 sets = ["zonal_mean_xy"]
 case_id = "ERA-Interim"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
@@ -286,7 +286,7 @@ seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 [#]
 sets = ["zonal_mean_xy"]
 case_id = "MERRA2"
-variables = ["PREH2O"]
+variables = ["TMQ"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]

--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -515,12 +515,17 @@ class Dataset():
         This is equivalent to returning False.
         """
         # Get all of the nc file paths in data_path.
-        path = os.path.join(data_path, '*.nc')
+        #path = os.path.join(data_path, '*.nc')
+        path = os.path.join(data_path, '*.*')
         files = sorted(glob.glob(path))
+
+        #Both .nc and .xml files are supported
+        if len(files) > 0:
+            file_fmt = files[0].split('.')[-1]
 
         # Everything between '{var}_' and '.nc' in a
         # time-series file is always 13 characters.
-        re_str = var + r'_.{13}.nc'
+        re_str = var + r'_.{13}.' + file_fmt
         re_str = os.path.join(data_path, re_str)
         matches = [f for f in files if re.search(re_str, f)]
 
@@ -534,10 +539,16 @@ class Dataset():
         # If nothing was found, try looking for the file with
         # the ref_name prepended to it.
         ref_name = getattr(self.parameters, 'ref_name', '')
-        path = os.path.join(data_path, ref_name, '*.nc')
+        #path = os.path.join(data_path, ref_name, '*.nc')
+        path = os.path.join(data_path, '*.*')
         files = sorted(glob.glob(path))
+        #Both .nc and .xml files are supported
+        if len(files) > 0:
+            file_fmt = files[0].split('.')[-1]
 
-        re_str = var + r'_.{13}.nc'
+        # Everything between '{var}_' and '.nc' in a
+        # time-series file is always 13 characters.
+        re_str = var + r'_.{13}.' + file_fmt
         re_str = os.path.join(data_path, ref_name, re_str)
         matches = [f for f in files if re.search(re_str, f)]
         # Again, there should only be one file per var in this new location.
@@ -587,6 +598,7 @@ class Dataset():
         end_time = '{}-12-15'.format(end_year)
 
         fnm = self._get_timeseries_file_path(var, data_path)
+        print(fnm)
         
         var = var_to_get if var_to_get else var
         # get available start and end years from file name: {var}_{start_yr}01_{end_yr}12.nc
@@ -597,7 +609,11 @@ class Dataset():
             msg = "Invalid year range specified for test/reference time series data" 
             raise RuntimeError(msg)
         else: 
-            with cdms2.open(fnm) as f:
-                var_time = f(var, time=(start_time, end_time, 'ccb'))(squeeze=1)
-
-                return var_time
+            #with cdms2.open(fnm) as f:
+            #    var_time = f(var, time=(start_time, end_time, 'ccb'))(squeeze=1)
+            #    return var_time
+            #For xml files using above with statement won't work because the Dataset object returned doesn't have attribute __enter__ for content management.
+            fin = cdms2.open(fnm)
+            var_time = fin(var, time=(start_time, end_time, 'ccb'))(squeeze=1)
+            fin.close() 
+            return var_time

--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -520,6 +520,7 @@ class Dataset():
         files = sorted(glob.glob(path))
 
         #Both .nc and .xml files are supported
+        file_fmt=''
         if len(files) > 0:
             file_fmt = files[0].split('.')[-1]
 
@@ -540,9 +541,10 @@ class Dataset():
         # the ref_name prepended to it.
         ref_name = getattr(self.parameters, 'ref_name', '')
         #path = os.path.join(data_path, ref_name, '*.nc')
-        path = os.path.join(data_path, '*.*')
+        path = os.path.join(data_path, ref_name, '*.*')
         files = sorted(glob.glob(path))
         #Both .nc and .xml files are supported
+        file_fmt=''
         if len(files) > 0:
             file_fmt = files[0].split('.')[-1]
 
@@ -598,7 +600,7 @@ class Dataset():
         end_time = '{}-12-15'.format(end_year)
 
         fnm = self._get_timeseries_file_path(var, data_path)
-        print(fnm)
+        #print(fnm)
         
         var = var_to_get if var_to_get else var
         # get available start and end years from file name: {var}_{start_yr}01_{end_yr}12.nc


### PR DESCRIPTION
The purpose of this PR is to use e3sm_diags as a tool to generate another layer of verification for completeness of v1 cmorized data:
-e3sm_diags now can take xmls files as input.
-variables from land and ocean components were added into derived variable list.

Example output files for cmorized files:https://acme-viewer.llnl.gov/zhang40/cmip_20191014/
In the example folder: all  experiments are grouped into: hist_r1-r5, amip_r1-r3, piControl, CO2(1pct and abrupt4xco2)

Caveat:
-only 2d variables are supported for now.
