### PR TITLE
add plevs parameters to core

### DIFF
--- a/acme_diags/parameter/core_parameter.py
+++ b/acme_diags/parameter/core_parameter.py
@@ -24,7 +24,8 @@ class CoreParameter(cdp.cdp_parameter.CDPParameter):
         self.regrid_tool = 'esmf'
         self.regrid_method = 'conservative'
         self.plevs = []
-        self.zonal_mean_2d_plevs = []
+        self.plot_log_plevs = False
+        self.plot_plevs = False
 
         # Plotting related.
         self.main_title = ''

--- a/acme_diags/parser/core_parser.py
+++ b/acme_diags/parser/core_parser.py
@@ -173,6 +173,23 @@ class CoreParser(cdp.cdp_parser.CDPParser):
             required=False)
 
         self.add_argument(
+            '--plot_plevs',
+            dest='plot_plevs',
+            help='plot specified plevs',
+            action='store_const',
+            const=True,
+            required=False)
+
+        self.add_argument(
+            '--plot_log_plevs',
+            dest='plot_log_plevs',
+            help='plot plevs on log-scale',
+            action='store_const',
+            const=True,
+            required=False)
+
+
+        self.add_argument(
             '-s', '--seasons',
             nargs='+',
             dest='seasons',


### PR DESCRIPTION
Add plev related parameters/parsers back to core sets, so that the old configuration files from users are still compatible. 