### PR TITLE
Find bad file descriptor imports

### DIFF
--- a/acme_diags/acme_diags_driver.py
+++ b/acme_diags/acme_diags_driver.py
@@ -20,7 +20,7 @@ import traceback
 import subprocess
 import cdp.cdp_run
 import acme_diags
-import cdms2.tvariable 
+#import cdms2.tvariable
 from acme_diags.parameter.core_parameter import CoreParameter
 from acme_diags.parser import SET_TO_PARSER
 from acme_diags.parser.core_parser import CoreParser

--- a/acme_diags/derivations/default_regions.py
+++ b/acme_diags/derivations/default_regions.py
@@ -1,4 +1,4 @@
-import cdutil
+#import cdutil
 
 regions_specs = {
     'NHEX': {'domain': cdutil.region.domain(latitude=(30., 90, 'ccb'))},

--- a/acme_diags/driver/utils/climo.py
+++ b/acme_diags/driver/utils/climo.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numpy.ma as ma
-import cdms2
+#import cdms2
 
 
 def climo(var, season):

--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -8,7 +8,7 @@ import glob
 import re
 import collections
 import traceback
-import cdms2
+#import cdms2
 import acme_diags.derivations.acme
 from acme_diags.driver import utils
 from . import climo

--- a/acme_diags/driver/utils/general.py
+++ b/acme_diags/driver/utils/general.py
@@ -4,10 +4,10 @@ import os
 import copy
 import pwd
 import grp
-import cdutil
-import MV2
-import genutil
-import cdms2
+# import cdutil
+# import MV2
+# import genutil
+# import cdms2
 from acme_diags import container
 from acme_diags.derivations.default_regions import regions_specs
 

--- a/acme_diags/plot/__init__.py
+++ b/acme_diags/plot/__init__.py
@@ -8,7 +8,7 @@ import importlib
 import traceback
 import numpy
 from matplotlib.colors import LinearSegmentedColormap
-from vcs.colors import matplotlib2vcs
+#from vcs.colors import matplotlib2vcs
 import acme_diags
 
 

--- a/tests/system/test.py
+++ b/tests/system/test.py
@@ -1,0 +1,5 @@
+# Run with `pip install ../.. && python test.py`
+import acme_diags.run
+import acme_diags.parameter
+import acme_diags.parser
+import acme_diags.plot 


### PR DESCRIPTION
Find import lines that cause the following error:
```
Fatal error in MPI_Init_thread: Other MPI error, error stack:
MPIR_Init_thread(572)..............: 
MPID_Init(224).....................: channel initialization failed
MPIDI_CH3_Init(105)................: 
MPID_nem_init(324).................: 
MPID_nem_tcp_init(178).............: 
MPID_nem_tcp_get_business_card(425): 
MPID_nem_tcp_init(384).............: gethostbyname failed, ml-9624328 (errno 1)
[unset]: write_line error; fd=-1 buf=:cmd=abort exitcode=3191567
:
system msg for write_line failure : Bad file descriptor
```
We need to find out why these imports cause the above error on my Mac intermittently;  I don't always get this error.