### PR TITLE
ENSO updates

### DIFF
--- a/acme_diags/driver/utils/dataset.py
+++ b/acme_diags/driver/utils/dataset.py
@@ -205,7 +205,7 @@ class Dataset():
         """
         Get the user-defined start and end years.
         """
-        if self.parameters.sets[0] in ['area_mean_time_series', 'enso_diags']:
+        if self.parameters.sets[0] in ['area_mean_time_series']:
             start_yr = getattr(self.parameters, 'start_yr')
             end_yr = getattr(self.parameters, 'end_yr')
         else:

--- a/acme_diags/parameter/enso_diags_parameter.py
+++ b/acme_diags/parameter/enso_diags_parameter.py
@@ -24,6 +24,38 @@ class EnsoDiagsParameter(CoreParameter):
                 self.plot_type, valid_plot_types)
             raise RuntimeError(msg)
 
-        if not (hasattr(self, 'start_yr') and hasattr(self, 'end_yr')):
-            msg = "You need to define both the 'start_yr' and 'end_yr' parameter."
-            raise RuntimeError(msg)
+        test_ref_start_yr_both_set = hasattr(self, 'test_start_yr') and hasattr(self, 'ref_start_yr')
+        if hasattr(self, 'start_yr'):
+            # Use `start_yr` as a default value for other parameters.
+            if not hasattr(self, 'test_start_yr'):
+                self.test_start_yr = self.start_yr
+            if not hasattr(self, 'ref_start_yr'):
+                self.ref_start_yr = self.start_yr
+        elif test_ref_start_yr_both_set and self.test_start_yr == self.ref_start_yr:
+            # Derive the value of self.start_yr
+            self.start_yr = self.test_start_yr
+
+        test_ref_end_yr_both_set = hasattr(self, 'test_end_yr') and hasattr(self, 'ref_end_yr')
+        if hasattr(self, 'end_yr'):
+            # Use `end_yr` as a default value for other parameters.
+            if not hasattr(self, 'test_end_yr'):
+                self.test_end_yr = self.end_yr
+            if not hasattr(self, 'ref_end_yr'):
+                self.ref_end_yr = self.end_yr
+        elif test_ref_end_yr_both_set and self.test_end_yr == self.ref_end_yr:
+            # Derive the value of self.end_yr
+            self.end_yr = self.test_end_yr
+
+        if hasattr(self, 'start_yr'):
+            # We need to re-evaluate this variable, since these attributes could have been set.
+            test_ref_end_yr_both_set = hasattr(self, 'test_end_yr') and hasattr(self, 'ref_end_yr')
+            if not (hasattr(self, 'end_yr') or test_ref_end_yr_both_set):
+                msg = "To use 'start_yr' you need to also define 'end_yr' or both 'test_end_yr' and 'ref_end_yr'."
+                raise RuntimeError(msg)
+
+        if hasattr(self, 'end_yr'):
+            # We need to re-evaluate this variable, since these attributes could have been set.
+            test_ref_start_yr_both_set = hasattr(self, 'test_start_yr') and hasattr(self, 'ref_start_yr')
+            if not (hasattr(self, 'start_yr') or test_ref_start_yr_both_set):
+                msg = "To use 'end_yr' you need to also define 'start_yr' or both 'test_start_yr' and 'ref_start_yr'."
+                raise RuntimeError(msg)

--- a/tests/system/all_sets.cfg
+++ b/tests/system/all_sets.cfg
@@ -149,7 +149,7 @@ debug = True
 
 [enso_diags]
 sets = ["enso_diags"]
-case_id = 'TREFHT-response'
+case_id = 'TREFHT-response-map'
 debug = True
 diff_colormap = "BrBG"
 output_format_subplot = ["png"]
@@ -168,11 +168,51 @@ print_statements  = True
 
 [#]
 sets = ["enso_diags"]
+case_id = 'TREFHT-response-map-start-yrs'
+debug = True
+diff_colormap = "BrBG"
+output_format_subplot = ["png"]
+regions = ["20S20N"]
+results_dir = "all_sets_results_test"
+seasons = ["ANN"]
+test_start_yr = '2012'
+ref_start_yr = '2012'
+end_yr = '2013'
+test_data_path = '.'
+test_file = 'TREFHT_201201_201312.nc'
+reference_data_path = '.'
+ref_file = 'TREFHT_201201_201312.nc'
+test_name = "system tests"
+variables = ["TREFHT"]
+print_statements = True
+
+[#]
+sets = ["enso_diags"]
+case_id = 'TREFHT-response-map-test-ref-yrs'
+debug = True
+diff_colormap = "BrBG"
+output_format_subplot = ["png"]
+regions = ["20S20N"]
+results_dir = "all_sets_results_test"
+seasons = ["ANN"]
+test_start_yr = '2012'
+ref_start_yr = '2012'
+test_end_yr = '2013'
+ref_end_yr = '2013'
+test_data_path = '.'
+test_file = 'TREFHT_201201_201312.nc'
+reference_data_path = '.'
+ref_file = 'TREFHT_201201_201312.nc'
+test_name = "system tests"
+variables = ["TREFHT"]
+print_statements = True
+
+[#]
+sets = ["enso_diags"]
 plot_type = "scatter"
-case_id = "TREFHT"
+case_id = "TREFHT-response-scatter"
 debug = True
 results_dir = "all_sets_results_test"
-variables = ["TREFHT"]
 seasons = ["ANN"]
 start_yr = '2012'
 end_yr = '2013'
@@ -182,4 +222,41 @@ reference_data_path = '.'
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
-print_statements  = True
+print_statements = True
+
+[#]
+sets = ["enso_diags"]
+plot_type = "scatter"
+case_id = "TREFHT-response-scatter-start-yrs"
+debug = True
+results_dir = "all_sets_results_test"
+seasons = ["ANN"]
+test_start_yr = '2012'
+ref_start_yr = '2012'
+end_yr = '2013'
+test_data_path = '.'
+test_file = 'TREFHT_201201_201312.nc'
+reference_data_path = '.'
+ref_file = 'TREFHT_201201_201312.nc'
+test_name = "system tests"
+variables = ["TREFHT"]
+print_statements = True
+
+[#]
+sets = ["enso_diags"]
+plot_type = "scatter"
+case_id = "TREFHT-response-scatter-test-ref-yrs"
+debug = True
+results_dir = "all_sets_results_test"
+seasons = ["ANN"]
+test_start_yr = '2012'
+ref_start_yr = '2012'
+test_end_yr = '2013'
+ref_end_yr = '2013'
+test_data_path = '.'
+test_file = 'TREFHT_201201_201312.nc'
+reference_data_path = '.'
+ref_file = 'TREFHT_201201_201312.nc'
+test_name = "system tests"
+variables = ["TREFHT"]
+print_statements = True

--- a/tests/system/test_diags.py
+++ b/tests/system/test_diags.py
@@ -130,6 +130,35 @@ class TestAllSets(unittest.TestCase):
                 plev=plev
             )
 
+    def check_enso_map_plots(self, case_id):
+        case_id_lower = case_id.lower()
+        nino_region_lower = 'NINO34'.lower()
+        set_name = 'enso_diags'
+        variables = ['TREFHT']
+        for variable in variables:
+            variable_lower = variable.lower()
+            png_path = '{}/{}/regression-coefficient-{}-over-{}.png'.format(
+                set_name, case_id, variable_lower, nino_region_lower)
+            full_png_path = '{}{}'.format(TestAllSets.results_dir, png_path)
+            self.assertTrue(os.path.exists(full_png_path))
+            html_path = '{}viewer/{}/map/{}/plot.html'.format(
+                TestAllSets.results_dir, set_name, case_id_lower)
+            self.check_html_image(html_path, png_path)
+
+    def check_enso_scatter_plots(self, case_id):
+        case_id_lower = case_id.lower()
+        set_name = 'enso_diags'
+        variables = ['TREFHT']
+        for variable in variables:
+            region = 'NINO3'
+            png_path = '{}/{}/feedback-{}-{}-TS-NINO3.png'.format(
+                set_name, case_id, variable, region)
+            full_png_path = '{}{}'.format(TestAllSets.results_dir, png_path)
+            self.assertTrue(os.path.exists(full_png_path))
+            html_path = '{}viewer/{}/scatter/{}/plot.html'.format(
+                TestAllSets.results_dir, set_name, case_id_lower)
+            self.check_html_image(html_path, png_path)
+
     # Test results_dir
     def test_results_dir(self):
         self.assertTrue(TestAllSets.results_dir.endswith('all_sets_results_test/'))
@@ -158,35 +187,28 @@ class TestAllSets(unittest.TestCase):
         )
 
     def test_enso_diags_map(self):
-        case_id = 'TREFHT-response'
-        case_id_lower = case_id.lower()
-        nino_region_lower = 'NINO34'.lower()
-        set_name = 'enso_diags'
-        variables = ['TREFHT']
-        for variable in variables:
-            variable_lower = variable.lower()
-            png_path = '{}/{}/regression-coefficient-{}-over-{}.png'.format(
-                set_name, case_id, variable_lower, nino_region_lower)
-            full_png_path = '{}{}'.format(TestAllSets.results_dir, png_path)
-            self.assertTrue(os.path.exists(full_png_path))
-            html_path = '{}viewer/{}/map/{}/plot.html'.format(
-                TestAllSets.results_dir, set_name, case_id_lower)
-            self.check_html_image(html_path, png_path)
+        case_id = 'TREFHT-response-map'
+        self.check_enso_map_plots(case_id)
+
+    def test_enso_diags_map_start_yrs(self):
+        case_id = 'TREFHT-response-map-start-yrs'
+        self.check_enso_map_plots(case_id)
+
+    def test_enso_diags_map_test_ref_yrs(self):
+        case_id = 'TREFHT-response-map-test-ref-yrs'
+        self.check_enso_map_plots(case_id)
 
     def test_enso_diags_scatter(self):
-        case_id = 'TREFHT'
-        case_id_lower = case_id.lower()
-        set_name = 'enso_diags'
-        variables = ['TREFHT']
-        for variable in variables:
-            region = 'NINO3'
-            png_path = '{}/{}/feedback-{}-{}-TS-NINO3.png'.format(
-                set_name, case_id, variable, region)
-            full_png_path = '{}{}'.format(TestAllSets.results_dir, png_path)
-            self.assertTrue(os.path.exists(full_png_path))
-            html_path = '{}viewer/{}/scatter/{}/plot.html'.format(
-                TestAllSets.results_dir, set_name, case_id_lower)
-            self.check_html_image(html_path, png_path)
+        case_id = 'TREFHT-response-scatter'
+        self.check_enso_scatter_plots(case_id)
+
+    def test_enso_diags_scatter_start_yrs(self):
+        case_id = 'TREFHT-response-scatter-start-yrs'
+        self.check_enso_scatter_plots(case_id)
+
+    def test_enso_diags_scatter_test_ref_yrs(self):
+        case_id = 'TREFHT-response-scatter-test-ref-yrs'
+        self.check_enso_scatter_plots(case_id)
 
     def test_lat_lon(self):
         self.check_plots_plevs('lat_lon', 'global', [850.0])


### PR DESCRIPTION
Resolves #292.

- Update derivations for `NET_FLUX_SRF` and `LHFLX`.
- Change code to use `TS` if `SST` is not available.
- Update `start_yr` and `end_yr` parameter handling.