### PR TITLE
Set QBO output file automatically

### DIFF
--- a/acme_diags/driver/qbo_driver.py
+++ b/acme_diags/driver/qbo_driver.py
@@ -194,6 +194,7 @@ def run_diag(parameter):
                     test_json[key] = list(test[key])
                     ref_json[key] = list(ref[key])
 
+        parameter.output_file = 'qbo_diags'
         # TODO: Check the below works properly by using ncdump on Cori
         utils.general.save_transient_variables_to_netcdf(parameter.current_set, test_nc, 'test', parameter)
         utils.general.save_transient_variables_to_netcdf(parameter.current_set, ref_nc, 'ref', parameter)


### PR DESCRIPTION
Other diagnostics, such as ENSO diags, automatically set the `output_file` so that the user doesn't have to do so. This PR adds this functionality to QBO diagnostics.