### PR TITLE
Initial support for lat-lon RRM

### DIFF
--- a/acme_diags/derivations/default_regions.py
+++ b/acme_diags/derivations/default_regions.py
@@ -55,6 +55,9 @@ regions_specs = {
     'NINO3': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(210., 270., 'ccb'))},
     'NINO34': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(190., 240., 'ccb'))},
     'NINO4': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(160., 210., 'ccb'))},
+    # Below is for RRM(regionally refined model) domains.
+    #'CONUS_RRM': {'domain': cdutil.region.domain(latitude=(20., 50., 'ccb'), longitude=(-125., -65., 'ccb'))},For RRM dataset, negative value won't work
+    'CONUS_RRM': {'domain': cdutil.region.domain(latitude=(20., 50., 'ccb'), longitude=(235., 295., 'ccb'))},
     # Below is for debugging. A smaller latitude range reduces processing time.
     'DEBUG': {'domain': cdutil.region.domain(latitude=(-2., 2, 'ccb'))}
 }

--- a/acme_diags/plot/cartopy/lat_lon_plot.py
+++ b/acme_diags/plot/cartopy/lat_lon_plot.py
@@ -86,7 +86,7 @@ def plot_panel(n, fig, proj, var, clevels, cmap,
     lon_west, lon_east, lat_south, lat_north = (0, 360, -90, 90)
     if 'longitude' in kargs:
         lon_west, lon_east, _ = kargs['longitude']
-        # Note cartopy Problem with gridlines across the dateline:https://github.com/SciTools/cartopy/issues/821. Region cross dataline is not supported yet.
+        # Note cartopy Problem with gridlines across the dateline:https://github.com/SciTools/cartopy/issues/821. Region cross dateline is not supported yet.
         if lon_west>180 and lon_east>180:
             lon_west = lon_west - 360
             lon_east = lon_east - 360

--- a/acme_diags/plot/cartopy/lat_lon_plot.py
+++ b/acme_diags/plot/cartopy/lat_lon_plot.py
@@ -8,6 +8,9 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+from acme_diags.derivations.default_regions import regions_specs
+import cdutil
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
 from acme_diags.driver.utils.general import get_output_dir
 from acme_diags.plot import get_colormap
@@ -39,6 +42,19 @@ def get_ax_size(fig, ax):
     return width, height
 
 
+def determine_tick_step(degrees_covered):
+    if degrees_covered > 180:
+        return 60
+    if degrees_covered > 60:
+        return 30
+    elif degrees_covered > 30:
+        return 10
+    elif degrees_covered > 20:
+        return 5
+    else:
+        return 1    
+
+
 def plot_panel(n, fig, proj, var, clevels, cmap,
                title, parameters, stats=None):
 
@@ -54,9 +70,45 @@ def plot_panel(n, fig, proj, var, clevels, cmap,
         levels = [-1.0e8] + clevels + [1.0e8]
         norm = colors.BoundaryNorm(boundaries=levels, ncolors=256)
 
+    #ax.set_global()
+    region_str = parameters.regions[0]
+    region = regions_specs[region_str]
+    global_domain = True
+    if 'domain' in region.keys():
+        # Get domain to plot
+        domain = region['domain']
+        global_domain = False
+    else:
+        # Assume global domain
+        domain = cdutil.region.domain(latitude=(-90., 90, 'ccb'))
+        proj = ccrs.PlateCarree(central_longitude=180)
+    kargs = domain.components()[0].kargs
+    lon_west, lon_east, lat_south, lat_north = (0, 360, -90, 90)
+    if 'longitude' in kargs:
+        lon_west, lon_east, _ = kargs['longitude']
+        # Note cartopy Problem with gridlines across the dateline:https://github.com/SciTools/cartopy/issues/821. Region cross dataline is not supported yet.
+        if lon_west>180 and lon_east>180:
+            lon_west = lon_west - 360
+            lon_east = lon_east - 360
+            
+    if 'latitude' in kargs:
+        lat_south, lat_north, _ = kargs['latitude']
+    lon_covered = lon_east - lon_west
+    lon_step = determine_tick_step(lon_covered)
+    xticks = np.arange(lon_west, lon_east, lon_step)
+    # Subtract 0.50 to get 0 W to show up on the right side of the plot.
+    # If less than 0.50 is subtracted, then 0 W will overlap 0 E on the left side of the plot.
+    # If a number is added, then the value won't show up at all.
+    if global_domain:
+        xticks = np.append(xticks, lon_east-0.50)
+    lat_covered = lat_north - lat_south
+    lat_step = determine_tick_step(lat_covered)
+    yticks = np.arange(lat_south, lat_north, lat_step)
+    yticks = np.append(yticks, lat_north)
+
     # Contour plot
     ax = fig.add_axes(panel[n], projection=proj)
-    ax.set_global()
+    ax.set_extent([lon_west, lon_east, lat_south, lat_north], crs=proj)
     cmap = get_colormap(cmap, parameters)
     p1 = ax.contourf(lon, lat, var,
                      transform=ccrs.PlateCarree(),
@@ -66,17 +118,22 @@ def plot_panel(n, fig, proj, var, clevels, cmap,
                      extend='both',
                      )
     
-    ax.set_aspect('auto')
+    #ax.set_aspect('auto')
+    # Full world would be aspect 360/(2*180) = 1
+    ax.set_aspect((lon_east - lon_west)/(2*(lat_north - lat_south)))
     ax.coastlines(lw=0.3)
+    if not global_domain:
+        ax.coastlines(resolution='50m', color='black', linewidth=1)
+        state_borders = cfeature.NaturalEarthFeature(category='cultural', name='admin_1_states_provinces_lakes', scale='50m', facecolor='none')
+        ax.add_feature(state_borders, edgecolor='black')
     if title[0] is not None:
         ax.set_title(title[0], loc='left', fontdict=plotSideTitle)
     if title[1] is not None:
         ax.set_title(title[1], fontdict=plotTitle)
     if title[2] is not None:
         ax.set_title(title[2], loc='right', fontdict=plotSideTitle)
-    ax.set_xticks([0, 60, 120, 180, 240, 300, 359.99], crs=ccrs.PlateCarree())
-    # ax.set_xticks([-180, -120, -60, 0, 60, 120, 180], crs=ccrs.PlateCarree())
-    ax.set_yticks([-90, -60, -30, 0, 30, 60, 90], crs=ccrs.PlateCarree())
+    ax.set_xticks(xticks, crs=ccrs.PlateCarree())
+    ax.set_yticks(yticks, crs=ccrs.PlateCarree())
     lon_formatter = LongitudeFormatter(
         zero_direction_label=True, number_format='.0f')
     lat_formatter = LatitudeFormatter()
@@ -124,12 +181,19 @@ def plot_panel(n, fig, proj, var, clevels, cmap,
         fig.text(panel[n][0] + 0.7635, panel[n][1] - 0.0105, "%.2f\n%.2f" %
                  stats[3:5], ha='right', fontdict=plotSideTitle)
 
+    # grid resolution info:
+    if n == 2 and 'RRM' in region_str:
+        dlat = lat[2]-lat[1]
+        dlon = lon[2]-lon[1]
+        fig.text(panel[n][0] + 0.4635, panel[n][1] - 0.04,
+                 "Resolution: {:.2f}x{:.2f}".format(dlat,dlon), ha='left', fontdict=plotSideTitle)
 
 def plot(reference, test, diff, metrics_dict, parameter):
 
     # Create figure, projection
     fig = plt.figure(figsize=parameter.figsize, dpi=parameter.dpi)
-    proj = ccrs.PlateCarree(central_longitude=180)
+    #proj = ccrs.PlateCarree(central_longitude=180)
+    proj = ccrs.PlateCarree()
 
     # First two panels
     min1 = metrics_dict['test']['min']

--- a/tests/system/all_sets.cfg
+++ b/tests/system/all_sets.cfg
@@ -84,6 +84,8 @@ test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 backend = "mpl"
 results_dir = "all_sets_results_test"
 debug = True
+regions=["CONUS_RRM","global"]
+
 
 
 [polar]

--- a/tests/system/all_sets.py
+++ b/tests/system/all_sets.py
@@ -1,5 +1,5 @@
 # Running the software with the API:
-#    python all_sets_api.py -d all_sets.py
+#    python all_sets.py -d all_sets.py
 import numpy
 from acme_diags.parameter.area_mean_time_series_parameter import AreaMeanTimeSeriesParameter
 from acme_diags.parameter.core_parameter import CoreParameter

--- a/tests/system/test_diags.py
+++ b/tests/system/test_diags.py
@@ -238,6 +238,9 @@ class TestAllSets(unittest.TestCase):
     def test_zonal_mean_xy(self):
         self.check_plots_plevs('zonal_mean_xy', 'global', [200.0])
 
+    def test_lat_lon_regional(self):
+        self.check_plots_plevs('lat_lon', 'CONUS_RRM', [850.0])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Initial support for lat-lon plot of Regional Refined Model data.
-Lat-lon plot script is adjusted to be able to to zoom in on a region, with horizontal grids resolution on the difference map
-CONUS_RRM domain is added as a default region ( other RRM regions can be added accordingly.)
An example to run with a configuration file specific for data required by RRM testing:run_lat_lon.py -d lat_lon_rrm.cfg 
https://portal.nersc.gov/cfs/e3sm/zhang40/lat_lon_rrm_test_Qi_ERA5/
(reference diags and datasets: https://gmd.copernicus.org/articles/12/2679/2019/#&gid=1&pid=1).


