### PR TITLE
Patch the conda build with the new version number

### DIFF
--- a/conda/0001-one-more-change-on-version-before-releasing.patch
+++ b/conda/0001-one-more-change-on-version-before-releasing.patch
@@ -1,0 +1,20 @@
+From 8b3b50b804aba393896addcd90fa740ae338d70e Mon Sep 17 00:00:00 2001
+From: chengzhuzhang <zhang40@llnl.gov>
+Date: Sun, 19 Jul 2020 23:09:48 -0700
+Subject: [PATCH] one more change on version before releasing
+
+---
+ acme_diags/__init__.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/acme_diags/__init__.py b/acme_diags/__init__.py
+index db469b6d..ca4b7477 100644
+--- a/acme_diags/__init__.py
++++ b/acme_diags/__init__.py
+@@ -1,5 +1,5 @@
+ import os
+ import sys
+ 
+-__version__ = 'v2.0.0'
++__version__ = 'v2.1.0'
+ INSTALL_PATH = os.path.join(sys.prefix, 'share/e3sm_diags/')

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -7,10 +7,12 @@ package:
 
 source:
     url: https://github.com/E3SM-Project/e3sm_diags/archive/v{{ version }}.tar.gz
-    sha256: 9c169c27fcdfec870b4e20fd71c24a3a426136424c32003bb9a714af157a3cb5 
+    sha256: 9c169c27fcdfec870b4e20fd71c24a3a426136424c32003bb9a714af157a3cb5
+    patches:
+      - 0001-one-more-change-on-version-before-releasing.patch
 
 build:
-    number: 1
+    number: 2
     noarch: python
     script: {{ PYTHON }} -m pip install . --no-deps -vv
 


### PR DESCRIPTION
Commit 8b3b50b804aba393896addcd90fa740ae338d70e went in after the v2.1.0 release but is needed so E3SM_Diags includes the correct version number in the metadata.