### PR TITLE
Explicitly require that multiprocessing is with forks

### DIFF
--- a/acme_diags/acme_diags_driver.py
+++ b/acme_diags/acme_diags_driver.py
@@ -308,7 +308,8 @@ def main(parameters=[]):
             container.containerize_parameter(p)
 
     if parameters[0].multiprocessing:
-        parameters = cdp.cdp_run.multiprocess(run_diag, parameters)
+        parameters = cdp.cdp_run.multiprocess(run_diag, parameters,
+                                              context='fork')
     elif parameters[0].distributed:
         parameters = cdp.cdp_run.distribute(run_diag, parameters)
     else:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
   run:
     - python
-    - cdp 
+    - cdp >=1.6.1
     - cdms2 
     - cdutil 
     - genutil
@@ -32,7 +32,7 @@ requirements:
     - cartopy
     - beautifulsoup4
     - lxml
-    - dask 2.15.0
+    - dask
 
 about:
     home: https://github.com/E3SM-Project/e3sm_diags


### PR DESCRIPTION
The default in dask changed from "fork" to "spawn" in 2.16.0

The ability to specify "fork" as the multiprocessing context is not yet available and will require a new `cdp` release after https://github.com/CDAT/cdp/pull/53 is merged.  After that,the restriction on `dask` will no longer be required.

fixes #316 