### PR TITLE
Diurnal cycle climatology

### DIFF
--- a/acme_diags/derivations/acme.py
+++ b/acme_diags/derivations/acme.py
@@ -401,6 +401,7 @@ def cosp_histogram_standardize(cld):
 
 derived_variables = {
     'PRECT': OrderedDict([
+        (('PRECT',), lambda pr: convert_units(rename(pr),target_units="mm/day")),
         (('pr',), lambda pr: qflxconvert_units(rename(pr))),
         (('PRECC', 'PRECL'), lambda precc, precl: prect(precc, precl))
     ]),

--- a/acme_diags/derivations/default_regions.py
+++ b/acme_diags/derivations/default_regions.py
@@ -55,6 +55,10 @@ regions_specs = {
     'NINO3': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(210., 270., 'ccb'))},
     'NINO34': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(190., 240., 'ccb'))},
     'NINO4': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(160., 210., 'ccb'))},
+    # Below is for additional domains for diurnal cycle of precipitation
+    'W_Pacific': {'domain': cdutil.region.domain(latitude=(-20., 20., 'ccb'), longitude=(90., 210., 'ccb'))},
+    'CONUS': {'domain': cdutil.region.domain(latitude=(25., 50., 'ccb'), longitude=(-125., -75., 'ccb'))},
+    'Amazon': {'domain': cdutil.region.domain(latitude=(-20., 5., 'ccb'), longitude=(-80., -45., 'ccb'))},
     # Below is for RRM(regionally refined model) domains.
     #'CONUS_RRM': {'domain': cdutil.region.domain(latitude=(20., 50., 'ccb'), longitude=(-125., -65., 'ccb'))},For RRM dataset, negative value won't work
     'CONUS_RRM': {'domain': cdutil.region.domain(latitude=(20., 50., 'ccb'), longitude=(235., 295., 'ccb'))},

--- a/acme_diags/derivations/default_regions.py
+++ b/acme_diags/derivations/default_regions.py
@@ -9,6 +9,7 @@ regions_specs = {
     '90S50S': {'domain': cdutil.region.domain(latitude=(-90., -50, 'ccb'))},
     '50S20S': {'domain': cdutil.region.domain(latitude=(-50., -20, 'ccb'))},
     '20S20N': {'domain': cdutil.region.domain(latitude=(-20., 20, 'ccb'))},
+    '50S50N': {'domain': cdutil.region.domain(latitude=(-50., 50, 'ccb'))},
     '5S5N': {'domain': cdutil.region.domain(latitude=(-5., 5, 'ccb'))},
     '20N50N': {'domain': cdutil.region.domain(latitude=(20., 50, 'ccb'))},
     '50N90N': {'domain': cdutil.region.domain(latitude=(50., 90, 'ccb'))},
@@ -56,7 +57,7 @@ regions_specs = {
     'NINO34': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(190., 240., 'ccb'))},
     'NINO4': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(160., 210., 'ccb'))},
     # Below is for additional domains for diurnal cycle of precipitation
-    'W_Pacific': {'domain': cdutil.region.domain(latitude=(-20., 20., 'ccb'), longitude=(90., 210., 'ccb'))},
+    'W_Pacific': {'domain': cdutil.region.domain(latitude=(-20., 20., 'ccb'), longitude=(90., 180., 'ccb'))},
     'CONUS': {'domain': cdutil.region.domain(latitude=(25., 50., 'ccb'), longitude=(-125., -75., 'ccb'))},
     'Amazon': {'domain': cdutil.region.domain(latitude=(-20., 5., 'ccb'), longitude=(-80., -45., 'ccb'))},
     # Below is for RRM(regionally refined model) domains.

--- a/acme_diags/derivations/default_regions.py
+++ b/acme_diags/derivations/default_regions.py
@@ -58,7 +58,7 @@ regions_specs = {
     'NINO4': {'domain': cdutil.region.domain(latitude=(-5., 5., 'ccb'), longitude=(160., 210., 'ccb'))},
     # Below is for additional domains for diurnal cycle of precipitation
     'W_Pacific': {'domain': cdutil.region.domain(latitude=(-20., 20., 'ccb'), longitude=(90., 180., 'ccb'))},
-    'CONUS': {'domain': cdutil.region.domain(latitude=(25., 50., 'ccb'), longitude=(-125., -75., 'ccb'))},
+    'CONUS': {'domain': cdutil.region.domain(latitude=(25., 50., 'ccb'), longitude=(-125., -65., 'ccb'))},
     'Amazon': {'domain': cdutil.region.domain(latitude=(-20., 5., 'ccb'), longitude=(-80., -45., 'ccb'))},
     # Below is for RRM(regionally refined model) domains.
     #'CONUS_RRM': {'domain': cdutil.region.domain(latitude=(20., 50., 'ccb'), longitude=(-125., -65., 'ccb'))},For RRM dataset, negative value won't work

--- a/acme_diags/driver/default_diags/diurnal_cycle_model_vs_model.cfg
+++ b/acme_diags/driver/default_diags/diurnal_cycle_model_vs_model.cfg
@@ -1,0 +1,6 @@
+[#]
+sets = ["diurnal_cycle"]
+case_id = "model_vs_model"
+variables = ["PRECT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["CONUS", "20S20N", "W_Pacific", "Amazon","global"]

--- a/acme_diags/driver/default_diags/diurnal_cycle_model_vs_obs.cfg
+++ b/acme_diags/driver/default_diags/diurnal_cycle_model_vs_obs.cfg
@@ -1,0 +1,8 @@
+[#]
+sets = ["diurnal_cycle"]
+case_id = "TRMM-3B43v-7_3hr"
+variables = ["PRECT"]
+ref_name = "TRMM-3B43v-7_3hr"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["CONUS", "20S20N", "W_Pacific", "Amazon"]
+reference_name = "TRMM-3B43v-7"

--- a/acme_diags/driver/default_diags/diurnal_cycle_model_vs_obs.cfg
+++ b/acme_diags/driver/default_diags/diurnal_cycle_model_vs_obs.cfg
@@ -4,5 +4,5 @@ case_id = "TRMM-3B43v-7_3hr"
 variables = ["PRECT"]
 ref_name = "TRMM-3B43v-7_3hr"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["CONUS", "20S20N", "W_Pacific", "Amazon"]
+regions = ["CONUS", "20S20N", "W_Pacific", "Amazon","global","50S50N"]
 reference_name = "TRMM-3B43v-7"

--- a/acme_diags/driver/diurnal_cycle_driver.py
+++ b/acme_diags/driver/diurnal_cycle_driver.py
@@ -41,11 +41,9 @@ def run_diag(parameter):
             test = test_data.get_climo_variable(var, season)
             ref = ref_data.get_climo_variable(var, season)
             
-
             parameter.var_id = var
             parameter.viewer_descr[var] = test.long_name if hasattr(
                 test, 'long_name') else 'No long_name attr in test data.'
-
 
             for region in regions:
                 #print("Selected region: {}".format(region))
@@ -57,19 +55,17 @@ def run_diag(parameter):
                     [ref_name, var, season, region])
                 parameter.main_title = str(' '.join([var, 'Diurnal Cycle ', season, region]))
 
-                test_cmean,test_amplitude, test_maxtime = utils.diurnal_cycle.composite_diurnal_cycle(test_domain, season)
-                ref_cmean,ref_amplitude, ref_maxtime = utils.diurnal_cycle.composite_diurnal_cycle(ref_domain, season)
+                test_cmean ,test_amplitude, test_maxtime = utils.diurnal_cycle.composite_diurnal_cycle(test_domain, season)
+                ref_cmean ,ref_amplitude, ref_maxtime = utils.diurnal_cycle.composite_diurnal_cycle(ref_domain, season)
 
-#
                 metrics_dict = {}
                 parameter.var_region = region
                 plot(parameter.current_set, test_maxtime, test_amplitude, 
                                    ref_maxtime, ref_amplitude,parameter)
                 utils.general.save_ncfiles(parameter.current_set,
-                                   test_cmean,test_amplitude, test_maxtime, parameter)
+                                   test_cmean, test_amplitude, test_maxtime, parameter)
                 utils.general.save_ncfiles(parameter.current_set,
                                    ref_cmean,ref_amplitude, ref_maxtime, parameter)
-
 
     return parameter
 

--- a/acme_diags/driver/diurnal_cycle_driver.py
+++ b/acme_diags/driver/diurnal_cycle_driver.py
@@ -1,0 +1,76 @@
+from __future__ import print_function
+
+import os
+import json
+import cdms2
+import MV2
+import acme_diags
+from acme_diags.plot import plot
+from acme_diags.derivations import acme
+from acme_diags.metrics import rmse, corr, min_cdms, max_cdms, mean, std
+from acme_diags.driver import utils
+
+def run_diag(parameter):
+    variables = parameter.variables
+    seasons = parameter.seasons
+    ref_name = getattr(parameter, 'ref_name', '')
+    regions = parameter.regions
+
+    test_data = utils.dataset.Dataset(parameter, test=True)
+    ref_data = utils.dataset.Dataset(parameter, ref=True)    
+
+    for season in seasons:
+        # Get the name of the data, appended with the years averaged.
+        parameter.test_name_yrs = utils.general.get_name_and_yrs(parameter, test_data, season)
+        parameter.ref_name_yrs = utils.general.get_name_and_yrs(parameter, ref_data, season)
+
+        # Get land/ocean fraction for masking.
+        try:
+            land_frac = test_data.get_climo_variable('LANDFRAC', season)
+            ocean_frac = test_data.get_climo_variable('OCNFRAC', season)
+        except:
+            mask_path = os.path.join(acme_diags.INSTALL_PATH, 'acme_ne30_ocean_land_mask.nc')
+            with cdms2.open(mask_path) as f:
+                land_frac = f('LANDFRAC')
+                ocean_frac = f('OCNFRAC')
+
+        for var in variables:
+            print('Variable: {}'.format(var))
+            #test = test_data.get_timeseries_variable(var)
+            #ref = ref_data.get_timeseries_variable(var)
+            test = test_data.get_climo_variable(var, season)
+            ref = ref_data.get_climo_variable(var, season)
+            
+
+            parameter.var_id = var
+            parameter.viewer_descr[var] = test.long_name if hasattr(
+                test, 'long_name') else 'No long_name attr in test data.'
+
+
+            for region in regions:
+                #print("Selected region: {}".format(region))
+
+                test_domain = utils.general.select_region(region, test, land_frac, ocean_frac, parameter)
+                ref_domain = utils.general.select_region(region, ref, land_frac, ocean_frac, parameter)
+
+                parameter.output_file = '-'.join(
+                    [ref_name, var, season, region])
+                parameter.main_title = str(' '.join([var, 'Diurnal Cycle ', season, region]))
+
+                test_cmean,test_amplitude, test_maxtime = utils.diurnal_cycle.composite_diurnal_cycle(test_domain, season)
+                ref_cmean,ref_amplitude, ref_maxtime = utils.diurnal_cycle.composite_diurnal_cycle(ref_domain, season)
+
+#
+                metrics_dict = {}
+                parameter.var_region = region
+                plot(parameter.current_set, test_maxtime, test_amplitude, 
+                                   ref_maxtime, ref_amplitude,parameter)
+                utils.general.save_ncfiles(parameter.current_set,
+                                   test_cmean,test_amplitude, test_maxtime, parameter)
+                utils.general.save_ncfiles(parameter.current_set,
+                                   ref_cmean,ref_amplitude, ref_maxtime, parameter)
+
+
+    return parameter
+
+

--- a/acme_diags/driver/utils/__init__.py
+++ b/acme_diags/driver/utils/__init__.py
@@ -1,2 +1,3 @@
 from . import general
 from . import dataset
+from . import diurnal_cycle

--- a/acme_diags/driver/utils/diurnal_cycle.py
+++ b/acme_diags/driver/utils/diurnal_cycle.py
@@ -149,6 +149,5 @@ def fastAllGridFT(x, t):
         tmax[n] = tmax[n] * 12.0 / (numpy.pi * (n + 1))  # Radians to hours
         tmax[n] = tmax[n] + t[0]  # GMT to LST
         tmax[n] = tmax[n] % (24 / (n + 1))
-    print(c,maxvalue,tmax)
     return c, maxvalue, tmax
 

--- a/acme_diags/driver/utils/diurnal_cycle.py
+++ b/acme_diags/driver/utils/diurnal_cycle.py
@@ -63,7 +63,6 @@ def composite_diurnal_cycle(var, season):
         var_season[n,] = v[idx]
     var_daily = numpy.reshape(var_season,(ncycle,int(var_season.shape[1]/time_freq),time_freq,var_season.shape[2],var_season.shape[3]))
     var_diurnal = ma.average(var_daily,axis=1).squeeze()
-    print(var_diurnal.shape)
    
     #Convert GMT to local time
     nlat = var.shape[1]
@@ -124,7 +123,7 @@ def fastAllGridFT(x, t):
                 Curt Covey, PCMDI/LLNL                                      December 2016
     '''
 
-    print('Creating output arrays ...')
+    #print('Creating output arrays ...')
     nx = x.shape[1]
     ny = x.shape[2]
     # time  of maximum for nth component (n=0 => diurnal, n=1 => semi...)
@@ -132,11 +131,11 @@ def fastAllGridFT(x, t):
     # value of maximum for nth component (= 1/2 peak-to-peak amplitude)
     maxvalue = numpy.zeros((3, nx, ny))
 
-    print('Calling numpy FFT function ...')
+    print('Calling numpy FFT function and converting from complex-valued FFT to real-valued amplitude and phase')
     X = numpy.fft.ifft(x, axis=0)
     print(X.shape)
 
-    print('Converting from complex-valued FFT to real-valued amplitude and phase ...')
+    #print('Converting from complex-valued FFT to real-valued amplitude and phase ...')
     a = X.real
     b = X.imag
     S = numpy.sqrt(a**2 + b**2)

--- a/acme_diags/driver/utils/diurnal_cycle.py
+++ b/acme_diags/driver/utils/diurnal_cycle.py
@@ -1,0 +1,154 @@
+import numpy 
+import numpy.ma as ma
+import cdms2
+import MV2
+
+
+def composite_diurnal_cycle(var, season):
+    """
+    Compute the composite diurnal cycle for var for the given season.
+    Return mean + amplitudes and times-of-maximum of the first Fourier harmonic component as three transient variables.  
+    """
+    season_idx = {
+        '01': [1,0,0,0,0,0,0,0,0,0,0,0],
+        '02': [0,1,0,0,0,0,0,0,0,0,0,0],
+        '03': [0,0,1,0,0,0,0,0,0,0,0,0],
+        '04': [0,0,0,1,0,0,0,0,0,0,0,0],
+        '05': [0,0,0,0,1,0,0,0,0,0,0,0],
+        '06': [0,0,0,0,0,1,0,0,0,0,0,0],
+        '07': [0,0,0,0,0,0,1,0,0,0,0,0],
+        '08': [0,0,0,0,0,0,0,1,0,0,0,0],
+        '09': [0,0,0,0,0,0,0,0,1,0,0,0],
+        '10': [0,0,0,0,0,0,0,0,0,1,0,0],
+        '11': [0,0,0,0,0,0,0,0,0,0,1,0],
+        '12': [0,0,0,0,0,0,0,0,0,0,0,1],
+        'DJF':[1,1,0,0,0,0,0,0,0,0,0,1],
+        'MAM':[0,0,1,1,1,0,0,0,0,0,0,0],
+        'JJA':[0,0,0,0,0,1,1,1,0,0,0,0],
+        'SON':[0,0,0,0,0,0,0,0,1,1,1,0],
+        'ANN':[1,1,1,1,1,1,1,1,1,1,1,1],
+    }
+
+    # Redefine time to be in the middle of the time interval
+    var_time = var.getTime()
+    if var_time is None:
+        # Climo cannot be ran on this variable.
+        return var
+
+#    tbounds = var_time.getBounds()
+#    var_time[:] = 0.5*(tbounds[:,0]+tbounds[:,1]) #time bounds for h1-h4 are problematic
+    var_time_absolute = var_time.asComponentTime()
+    time_freq = int(24/(var_time_absolute[1].hour - var_time_absolute[0].hour)) #This only valid for time interval >= 1hour
+    start_time = var_time_absolute[0].hour
+    print('start_time',var_time_absolute[0],var_time_absolute[0].hour)
+    print('var_time_freq',time_freq)
+
+    # Convert to masked array
+    v = var.asma()
+
+    # select specified seasons:
+    if season == 'ANNUALCYCLE':  #Not supported yet!
+        cycle = ['01','02','03','04','05','06','07','08','09','10','11','12']
+    elif season == 'SEASONALCYCLE': #Not supported yet!
+        cycle = ['DJF','MAM','JJA','SON']
+    else:
+        cycle = [season]
+
+    ncycle = len(cycle)
+    for n in range(ncycle):
+        idx = numpy.array( [ season_idx[cycle[n]][var_time_absolute[i].month-1]
+                          for i in range(len(var_time_absolute)) ], dtype=numpy.int).nonzero()
+
+        var_season = ma.zeros([ncycle]+[len(idx[0])]+list(numpy.shape(v))[1:])
+        var_season[n,] = v[idx]
+    var_daily = numpy.reshape(var_season,(ncycle,int(var_season.shape[1]/time_freq),time_freq,var_season.shape[2],var_season.shape[3]))
+    var_diurnal = ma.average(var_daily,axis=1).squeeze()
+    print(var_diurnal.shape)
+   
+    #Convert GMT to local time
+    nlat = var.shape[1]
+    nlon = var.shape[2]
+    lat = var.getLatitude()
+    lon =  var.getLongitude()
+    nt=time_freq
+    lst = numpy.zeros((nt,nlat,nlon))
+    for it, itime in enumerate(numpy.arange(0,24,int(24/nt))):
+        for ilon in range(nlon):
+            lst[it,:,ilon] = (itime + start_time + lon[ilon]/360*24)%24 #convert GMT to LST
+
+    #Compute mean, amplitude and max time of the first three Fourier components.
+    cycmean, maxvalue, tmax = fastAllGridFT(var_diurnal,lst)
+
+    #Save phase, amplitude, and mean for the first homonic,
+    amplitude = MV2.zeros((nlat,nlon))
+    amplitude[:,:] = maxvalue[0]
+    amplitude.id = var.id +'_diurnal_amplitude'
+    amplitude.longname = 'Amplitude of diurnal cycle of '+var.id
+    amplitude.units = var.units
+    amplitude.setAxis(0, lat)
+    amplitude.setAxis(1, lon)
+
+    maxtime = MV2.zeros((nlat,nlon))
+    maxtime[:,:] = tmax[0]
+    maxtime.id = var.id +'_diurnal_phase'
+    maxtime.longname = 'Phase of diurnal cycle of '+var.id
+    maxtime.units = 'hour'
+    maxtime.setAxis(0, lat)
+    maxtime.setAxis(1, lon)
+   
+    cmean = MV2.zeros((nlat,nlon))
+    cmean[:,:] = cycmean
+    cmean.id = var.id +'_diurnal_cycmean'
+    cmean.longname = 'Mean of diurnal cycle of '+var.id
+    cmean.units = var.units
+    cmean.setAxis(0, lat)
+    cmean.setAxis(1, lon)
+
+    return cmean,amplitude, maxtime
+
+
+
+def fastAllGridFT(x, t):
+    '''
+    This version of fastFT (see above) does all gridpoints at once.
+    Use a Numerical Python function to compute a FAST Fourier transform -- which should give the same result as a simple
+    SLOW Fourier integration via the trapezoidal rule.
+    Return mean + amplitudes and times-of-maximum of the first three Fourier harmonic components of a time series x(t).
+    Do NOT detrend the time series first, in order to retain the "sawtooth" frequency implied by the inumpy.t length of the
+    time series (e.g. the 24-hour period from a composite-diurnal cycle).
+    On inumpy.t: x[k,i,j] = values      at each gridpoint (i,j) for N times (k), e.g. N = 8 for a 3-hr composite-diurnal cycle
+          t[k,i,j] = timepoints  at each gridpoint (i,j) for N times (k), e.g. Local Standard Times
+    On output: c[i,j] = mean value at each gridpoint (i,j) in the time series ("zeroth" term in Fourier series)
+           maxvalue[n,i,j] = amplitude       at each gridpoint (i,j) for each Fourier harmonic (n)
+           tmax    [n,i,j] = time of maximum at each gridpoint (i,j) for each Fourier harmonic (n)
+                Curt Covey, PCMDI/LLNL                                      December 2016
+    '''
+
+    print('Creating output arrays ...')
+    nx = x.shape[1]
+    ny = x.shape[2]
+    # time  of maximum for nth component (n=0 => diurnal, n=1 => semi...)
+    tmax = numpy.zeros((3, nx, ny))
+    # value of maximum for nth component (= 1/2 peak-to-peak amplitude)
+    maxvalue = numpy.zeros((3, nx, ny))
+
+    print('Calling numpy FFT function ...')
+    X = numpy.fft.ifft(x, axis=0)
+    print(X.shape)
+
+    print('Converting from complex-valued FFT to real-valued amplitude and phase ...')
+    a = X.real
+    b = X.imag
+    S = numpy.sqrt(a**2 + b**2)
+    #print(a.shape,b.shape,S.shape)
+    c = S[0]  # Zeroth harmonic = mean-value "constant term" in Fourier series.
+    for n in range(3):
+        # Adding first + last terms, second + second-to-last, ...
+        maxvalue[n] = S[n + 1] + S[-n - 1]
+        tmax[n] = numpy.arctan2(b[n + 1], a[n + 1])
+        tmax[n] = tmax[n] * 12.0 / (numpy.pi * (n + 1))  # Radians to hours
+        tmax[n] = tmax[n] + t[0]  # GMT to LST
+        tmax[n] = tmax[n] % (24 / (n + 1))
+    print(c,maxvalue,tmax)
+    return c, maxvalue, tmax
+

--- a/acme_diags/parameter/__init__.py
+++ b/acme_diags/parameter/__init__.py
@@ -5,6 +5,7 @@ from .area_mean_time_series_parameter import AreaMeanTimeSeriesParameter
 from .enso_diags_parameter import EnsoDiagsParameter
 from .qbo_parameter import QboParameter
 from .streamflow_parameter import StreamflowParameter
+from .diurnal_cycle_parameter import DiurnalCycleParameter
 
 SET_TO_PARAMETERS = {
     'zonal_mean_xy': CoreParameter,
@@ -16,5 +17,6 @@ SET_TO_PARAMETERS = {
     'area_mean_time_series': AreaMeanTimeSeriesParameter,
     'enso_diags': EnsoDiagsParameter,
     'qbo': QboParameter,
-    'streamflow': StreamflowParameter
+    'streamflow': StreamflowParameter,
+    'diurnal_cycle': DiurnalCycleParameter
 }

--- a/acme_diags/parameter/core_parameter.py
+++ b/acme_diags/parameter/core_parameter.py
@@ -16,7 +16,7 @@ class CoreParameter(cdp.cdp_parameter.CDPParameter):
 
         self.sets = ['zonal_mean_xy', 'zonal_mean_2d', 'meridional_mean_2d',
                      'lat_lon', 'polar', 'area_mean_time_series', 'cosp_histogram',
-                     'enso_diags', 'qbo', 'streamflow']
+                     'enso_diags', 'qbo', 'streamflow','diurnal_cycle']
         self.dataset = ''
         self.run_type = 'model_vs_obs'
         self.variables = []

--- a/acme_diags/parameter/diurnal_cycle_parameter.py
+++ b/acme_diags/parameter/diurnal_cycle_parameter.py
@@ -5,44 +5,6 @@ class DiurnalCycleParameter(CoreParameter):
     def __init__(self):
         super(DiurnalCycleParameter, self).__init__()
         self.print_statements = False
-#        self.ref_timeseries_input = True
-#        self.test_timeseries_input = True
-#
-#    def check_values(self):
-#
-#        test_ref_start_yr_both_set = hasattr(self, 'test_start_yr') and hasattr(self, 'ref_start_yr')
-#        if hasattr(self, 'start_yr'):
-#            # Use `start_yr` as a default value for other parameters.
-#            if not hasattr(self, 'test_start_yr'):
-#                self.test_start_yr = self.start_yr
-#            if not hasattr(self, 'ref_start_yr'):
-#                self.ref_start_yr = self.start_yr
-#        elif test_ref_start_yr_both_set and self.test_start_yr == self.ref_start_yr:
-#            # Derive the value of self.start_yr
-#            self.start_yr = self.test_start_yr
-#
-#        test_ref_end_yr_both_set = hasattr(self, 'test_end_yr') and hasattr(self, 'ref_end_yr')
-#        if hasattr(self, 'end_yr'):
-#            # Use `end_yr` as a default value for other parameters.
-#            if not hasattr(self, 'test_end_yr'):
-#                self.test_end_yr = self.end_yr
-#            if not hasattr(self, 'ref_end_yr'):
-#                self.ref_end_yr = self.end_yr
-#        elif test_ref_end_yr_both_set and self.test_end_yr == self.ref_end_yr:
-#            # Derive the value of self.end_yr
-#            self.end_yr = self.test_end_yr
-#
-#        if hasattr(self, 'start_yr'):
-#            # We need to re-evaluate this variable, since these attributes could have been set.
-#            test_ref_end_yr_both_set = hasattr(self, 'test_end_yr') and hasattr(self, 'ref_end_yr')
-#            if not (hasattr(self, 'end_yr') or test_ref_end_yr_both_set):
-#                msg = "To use 'start_yr' you need to also define 'end_yr' or both 'test_end_yr' and 'ref_end_yr'."
-#                raise RuntimeError(msg)
-#
-#        if hasattr(self, 'end_yr'):
-#            # We need to re-evaluate this variable, since these attributes could have been set.
-#            test_ref_start_yr_both_set = hasattr(self, 'test_start_yr') and hasattr(self, 'ref_start_yr')
-#            if not (hasattr(self, 'start_yr') or test_ref_start_yr_both_set):
-#                msg = "To use 'end_yr' you need to also define 'start_yr' or both 'test_start_yr' and 'ref_start_yr'."
-#                raise RuntimeError(msg)
-#
+        self.normalize_test_amp = True
+        self.ref_timeseries_input = False
+        self.test_timeseries_input = False

--- a/acme_diags/parameter/diurnal_cycle_parameter.py
+++ b/acme_diags/parameter/diurnal_cycle_parameter.py
@@ -1,0 +1,48 @@
+from .core_parameter import CoreParameter
+
+
+class DiurnalCycleParameter(CoreParameter):
+    def __init__(self):
+        super(DiurnalCycleParameter, self).__init__()
+        self.print_statements = False
+#        self.ref_timeseries_input = True
+#        self.test_timeseries_input = True
+#
+#    def check_values(self):
+#
+#        test_ref_start_yr_both_set = hasattr(self, 'test_start_yr') and hasattr(self, 'ref_start_yr')
+#        if hasattr(self, 'start_yr'):
+#            # Use `start_yr` as a default value for other parameters.
+#            if not hasattr(self, 'test_start_yr'):
+#                self.test_start_yr = self.start_yr
+#            if not hasattr(self, 'ref_start_yr'):
+#                self.ref_start_yr = self.start_yr
+#        elif test_ref_start_yr_both_set and self.test_start_yr == self.ref_start_yr:
+#            # Derive the value of self.start_yr
+#            self.start_yr = self.test_start_yr
+#
+#        test_ref_end_yr_both_set = hasattr(self, 'test_end_yr') and hasattr(self, 'ref_end_yr')
+#        if hasattr(self, 'end_yr'):
+#            # Use `end_yr` as a default value for other parameters.
+#            if not hasattr(self, 'test_end_yr'):
+#                self.test_end_yr = self.end_yr
+#            if not hasattr(self, 'ref_end_yr'):
+#                self.ref_end_yr = self.end_yr
+#        elif test_ref_end_yr_both_set and self.test_end_yr == self.ref_end_yr:
+#            # Derive the value of self.end_yr
+#            self.end_yr = self.test_end_yr
+#
+#        if hasattr(self, 'start_yr'):
+#            # We need to re-evaluate this variable, since these attributes could have been set.
+#            test_ref_end_yr_both_set = hasattr(self, 'test_end_yr') and hasattr(self, 'ref_end_yr')
+#            if not (hasattr(self, 'end_yr') or test_ref_end_yr_both_set):
+#                msg = "To use 'start_yr' you need to also define 'end_yr' or both 'test_end_yr' and 'ref_end_yr'."
+#                raise RuntimeError(msg)
+#
+#        if hasattr(self, 'end_yr'):
+#            # We need to re-evaluate this variable, since these attributes could have been set.
+#            test_ref_start_yr_both_set = hasattr(self, 'test_start_yr') and hasattr(self, 'ref_start_yr')
+#            if not (hasattr(self, 'start_yr') or test_ref_start_yr_both_set):
+#                msg = "To use 'end_yr' you need to also define 'start_yr' or both 'test_start_yr' and 'ref_start_yr'."
+#                raise RuntimeError(msg)
+#

--- a/acme_diags/parser/__init__.py
+++ b/acme_diags/parser/__init__.py
@@ -5,6 +5,7 @@ from .area_mean_time_series_parser import AreaMeanTimeSeriesParser
 from .enso_diags_parser import EnsoDiagsParser
 from .qbo_parser import QboParser
 from .streamflow_parser import StreamflowParser
+from .diurnal_cycle_parser import DiurnalCycleParser
 
 SET_TO_PARSER = {
     'zonal_mean_xy': CoreParser,
@@ -16,6 +17,7 @@ SET_TO_PARSER = {
     'area_mean_time_series': AreaMeanTimeSeriesParser,
     'enso_diags': EnsoDiagsParser,
     'qbo': QboParser,
-    'streamflow': StreamflowParser
+    'streamflow': StreamflowParser,
+    'diurnal_cycle': DiurnalCycleParser
 }
 

--- a/acme_diags/parser/diurnal_cycle_parser.py
+++ b/acme_diags/parser/diurnal_cycle_parser.py
@@ -41,3 +41,9 @@ class DiurnalCycleParser(CoreParser):
             dest='end_yr',
             help="End year for the timeseries files.",
             required=False)
+
+        self.add_argument(
+            '--normalize_test_amp',
+            dest='normalize_test_amp',
+            help="Normalize test data by maximum diurnal cycle amplitude from reference data",
+            required=False)

--- a/acme_diags/parser/diurnal_cycle_parser.py
+++ b/acme_diags/parser/diurnal_cycle_parser.py
@@ -1,0 +1,43 @@
+from .core_parser import CoreParser
+from acme_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+
+
+class DiurnalCycleParser(CoreParser):
+    def __init__(self, *args, **kwargs):
+        if 'parameter_cls' in kwargs:
+            super().__init__(*args, **kwargs)
+        else:
+            super().__init__(parameter_cls=DiurnalCycleParameter, *args, **kwargs)
+
+
+    def load_default_args(self, files=[]):
+        # This has '-p' and '--parameter' reserved.
+        super().load_default_args(files)
+
+        self.add_argument(
+            '--ref_timeseries_input',
+            dest='ref_timeseries_input',
+            help='The input reference data are timeseries files.',
+            action='store_const',
+            const=True,
+            required=False)
+
+        self.add_argument(
+            '--test_timeseries_input',
+            dest='test_timeseries_input',
+            help='The input test data are timeseries files.',
+            action='store_const',
+            const=True,
+            required=False)
+
+        self.add_argument(
+            '--start_yr',
+            dest='start_yr',
+            help="Start year for the timeseries files.",
+            required=False)
+
+        self.add_argument(
+            '--end_yr',
+            dest='end_yr',
+            help="End year for the timeseries files.",
+            required=False)

--- a/acme_diags/plot/cartopy/diurnal_cycle_plot.py
+++ b/acme_diags/plot/cartopy/diurnal_cycle_plot.py
@@ -56,16 +56,25 @@ def determine_tick_step(degrees_covered):
         return 1    
 
 
-def plot_panel(n, fig, proj,var, amp,
+def plot_panel(n, fig, proj,var, amp,amp_ref,
                title, parameter):
 
+    scale_to_ref = False
     lon = var.getLongitude()
     lat = var.getLatitude()
     var = ma.squeeze(var.asma())
     max_amp = amp.max()
+    max_amp_ref = amp_ref.max()
     amp = ma.squeeze(amp.asma())
+    amp_ref = ma.squeeze(amp_ref.asma())
+    #print(max_amp,max_amp_ref,'max_amp')
     #Convert to rgb image
-    img = np.dstack(((var/24-0.5)%1,(amp/max_amp)**0.5,np.ones_like(amp)))
+    #img = np.dstack(((var/24-0.5)%1,(amp/max_amp)**0.5,np.ones_like(amp)))
+    if scale_to_ref:
+        img = np.dstack(((var/24-0.5)%1,(amp/max_amp*(max_amp/max_amp_ref))**0.5,np.ones_like(amp)))
+        max_amp = max_amp_ref
+    else:
+        img = np.dstack(((var/24-0.5)%1,(amp/max_amp)**0.5,np.ones_like(amp)))
     img = hsv_to_rgb(img)
 
 
@@ -171,7 +180,14 @@ def plot_panel(n, fig, proj,var, amp,
     bar_ax.tick_params(axis='both', labelsize=7,pad=0,length=0)
     bar_ax.text(0.2, -0.3, 'Local Time', transform=bar_ax.transAxes, fontsize=7,
             verticalalignment='center')
-    bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp,'mm/day'), transform=bar_ax.transAxes, fontsize=7,
+    #bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp_ref,'mm/d'), transform=bar_ax.transAxes, fontsize=7,fontweight='bold',
+    #        verticalalignment='center')
+    bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp,'mm/d'), transform=bar_ax.transAxes, fontsize=7,fontweight='bold',
+            verticalalignment='center')
+    #bar_ax.text(-0.1, 1.4, '{}\\textbf{:.2f}{}'.format('\033[1m',max_amp_ref,'\033[0m'), transform=bar_ax.transAxes, fontsize=7,
+    bar_ax.text(-0.1, -0.5, 'DC phase (Hue)', transform=bar_ax.transAxes, fontsize=7,
+            verticalalignment='center')
+    bar_ax.text(-0.1, -0.7, 'DC amplitude (Saturation)', transform=bar_ax.transAxes, fontsize=7,
             verticalalignment='center')
     color = image.reshape((image.shape[0]*image.shape[1],image.shape[2]))
     pc = bar_ax.pcolormesh(theta, R, np.zeros_like(R),color = color,shading='auto')
@@ -188,10 +204,10 @@ def plot(test_tmax,test_amp, ref_tmax,ref_amp, parameter):
 
 
     # First panel
-    plot_panel(0, fig, proj,test_tmax,test_amp, (parameter.test_name_yrs,parameter.test_title),parameter) 
+    plot_panel(0, fig, proj,test_tmax,test_amp, ref_amp, (parameter.test_name_yrs,parameter.test_title),parameter) 
 
     # Second panel
-    plot_panel(1, fig, proj,ref_tmax,ref_amp, (parameter.ref_name_yrs,parameter.reference_title),parameter) 
+    plot_panel(1, fig, proj,ref_tmax,ref_amp, ref_amp, (parameter.ref_name_yrs,parameter.reference_title),parameter) 
 
 
     # Figure title

--- a/acme_diags/plot/cartopy/diurnal_cycle_plot.py
+++ b/acme_diags/plot/cartopy/diurnal_cycle_plot.py
@@ -59,7 +59,7 @@ def determine_tick_step(degrees_covered):
 def plot_panel(n, fig, proj,var, amp,amp_ref,
                title, parameter):
 
-    scale_to_ref = True
+    normalize_test_amp = parameter.normalize_test_amp
     lon = var.getLongitude()
     lat = var.getLatitude()
     var = ma.squeeze(var.asma())
@@ -68,7 +68,7 @@ def plot_panel(n, fig, proj,var, amp,amp_ref,
     amp = ma.squeeze(amp.asma())
     amp_ref = ma.squeeze(amp_ref.asma())
 
-    if scale_to_ref:
+    if normalize_test_amp:
         img = np.dstack(((var/24-0.5)%1,(amp/max_amp*(max_amp/max_amp_ref))**0.5,np.ones_like(amp)))
         max_amp = max_amp_ref
     else:

--- a/acme_diags/plot/cartopy/diurnal_cycle_plot.py
+++ b/acme_diags/plot/cartopy/diurnal_cycle_plot.py
@@ -65,7 +65,7 @@ def plot_panel(n, fig, proj,var, amp,
     max_amp = amp.max()
     amp = ma.squeeze(amp.asma())
     #Convert to rgb image
-    img = np.dstack((var/24,amp/max_amp,np.ones_like(amp)))
+    img = np.dstack(((var/24-0.5)%1,(amp/max_amp)**0.5,np.ones_like(amp)))
     img = hsv_to_rgb(img)
 
 
@@ -159,8 +159,8 @@ def plot_panel(n, fig, proj,var, amp,
     # Color bar
     bar_ax = fig.add_axes((panel[n][0] + 0.67, panel[n][1] + 0.15, 0.07, 0.07), polar=True)
     theta, R = np.meshgrid(np.linspace(0,2*np.pi,24),np.linspace(0,1,8))
-    H, S = np.meshgrid(np.linspace(0,1,23), np.linspace(0,1,8))
-    image = np.dstack((H, S, np.ones_like(S)*0.8))
+    H, S = np.meshgrid(np.linspace(0,1,24), np.linspace(0,1,8))
+    image = np.dstack(((H-0.5)%1, S**0.5, np.ones_like(S)))
     image = hsv_to_rgb(image)
     #bar_ax.set_theta_zero_location('N')
     bar_ax.set_theta_direction(-1)
@@ -174,7 +174,7 @@ def plot_panel(n, fig, proj,var, amp,
     bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp,'mm/hr'), transform=bar_ax.transAxes, fontsize=7,
             verticalalignment='center')
     color = image.reshape((image.shape[0]*image.shape[1],image.shape[2]))
-    pc = bar_ax.pcolormesh(theta, R, np.zeros_like(R),color = color)
+    pc = bar_ax.pcolormesh(theta, R, np.zeros_like(R),color = color,shading='auto')
     pc.set_array(None)
 
 

--- a/acme_diags/plot/cartopy/diurnal_cycle_plot.py
+++ b/acme_diags/plot/cartopy/diurnal_cycle_plot.py
@@ -75,7 +75,6 @@ def plot_panel(n, fig, proj,var, amp,amp_ref,
         img = np.dstack(((var/24-0.5)%1,(amp/max_amp)**0.5,np.ones_like(amp)))
     img = hsv_to_rgb(img)
 
-
     # imshow plot
     ax = fig.add_axes(panel[n], projection=proj)
 
@@ -122,7 +121,6 @@ def plot_panel(n, fig, proj,var, amp,amp_ref,
 
     ax.set_extent([lon_west, lon_east, lat_south, lat_north])#, crs=proj)
     
-
     # Full world would be aspect 360/(2*180) = 1
     #ax.set_aspect((lon_east - lon_west)/(2*(lat_north - lat_south)))
     ax.coastlines(lw=0.3)

--- a/acme_diags/plot/cartopy/diurnal_cycle_plot.py
+++ b/acme_diags/plot/cartopy/diurnal_cycle_plot.py
@@ -59,7 +59,7 @@ def determine_tick_step(degrees_covered):
 def plot_panel(n, fig, proj,var, amp,amp_ref,
                title, parameter):
 
-    scale_to_ref = False
+    scale_to_ref = True
     lon = var.getLongitude()
     lat = var.getLatitude()
     var = ma.squeeze(var.asma())
@@ -67,9 +67,7 @@ def plot_panel(n, fig, proj,var, amp,amp_ref,
     max_amp_ref = amp_ref.max()
     amp = ma.squeeze(amp.asma())
     amp_ref = ma.squeeze(amp_ref.asma())
-    #print(max_amp,max_amp_ref,'max_amp')
-    #Convert to rgb image
-    #img = np.dstack(((var/24-0.5)%1,(amp/max_amp)**0.5,np.ones_like(amp)))
+
     if scale_to_ref:
         img = np.dstack(((var/24-0.5)%1,(amp/max_amp*(max_amp/max_amp_ref))**0.5,np.ones_like(amp)))
         max_amp = max_amp_ref
@@ -135,8 +133,6 @@ def plot_panel(n, fig, proj,var, amp,amp_ref,
     ax.set_xticks(xticks, crs=ccrs.PlateCarree())
     #ax.set_xticks([0, 60, 120, 180, 240, 300, 359.99], crs=ccrs.PlateCarree())
     ax.set_yticks(yticks, crs=ccrs.PlateCarree())
-    #ax.set_xticks(xticks, crs=proj)
-    #ax.set_yticks(yticks, crs=proj)
     lon_formatter = LongitudeFormatter(
         zero_direction_label=True, number_format='.0f')
     lat_formatter = LatitudeFormatter()
@@ -166,7 +162,7 @@ def plot_panel(n, fig, proj,var, amp,amp_ref,
         ax.add_feature(state_borders, edgecolor='black')
 
     # Color bar
-    bar_ax = fig.add_axes((panel[n][0] + 0.67, panel[n][1] + 0.15, 0.07, 0.07), polar=True)
+    bar_ax = fig.add_axes((panel[n][0] + 0.67, panel[n][1] + 0.2, 0.07, 0.07), polar=True)
     theta, R = np.meshgrid(np.linspace(0,2*np.pi,24),np.linspace(0,1,8))
     H, S = np.meshgrid(np.linspace(0,1,24), np.linspace(0,1,8))
     image = np.dstack(((H-0.5)%1, S**0.5, np.ones_like(S)))
@@ -175,16 +171,15 @@ def plot_panel(n, fig, proj,var, amp,amp_ref,
     bar_ax.set_theta_direction(-1)
     bar_ax.set_theta_offset(np.pi/2)
     bar_ax.set_xticklabels(['0h', '3h', '6h', '9h', '12h', '15h', '18h', '21h'])
-    bar_ax.set_yticklabels([])
+    bar_ax.set_yticklabels(['', '', '{:.2f}'.format(max_amp)])
+    bar_ax.set_rlabel_position(340)
+    bar_ax.get_yticklabels()[-2].set_weight("bold")
     # We change the fontsize of minor ticks label 
     bar_ax.tick_params(axis='both', labelsize=7,pad=0,length=0)
     bar_ax.text(0.2, -0.3, 'Local Time', transform=bar_ax.transAxes, fontsize=7,
             verticalalignment='center')
-    #bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp_ref,'mm/d'), transform=bar_ax.transAxes, fontsize=7,fontweight='bold',
-    #        verticalalignment='center')
-    bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp,'mm/d'), transform=bar_ax.transAxes, fontsize=7,fontweight='bold',
+    bar_ax.text(-0.1, -0.9, 'Max DC amp {:.2f}{}'.format(amp.max(),'mm/d'), transform=bar_ax.transAxes, fontsize=7,fontweight='bold',
             verticalalignment='center')
-    #bar_ax.text(-0.1, 1.4, '{}\\textbf{:.2f}{}'.format('\033[1m',max_amp_ref,'\033[0m'), transform=bar_ax.transAxes, fontsize=7,
     bar_ax.text(-0.1, -0.5, 'DC phase (Hue)', transform=bar_ax.transAxes, fontsize=7,
             verticalalignment='center')
     bar_ax.text(-0.1, -0.7, 'DC amplitude (Saturation)', transform=bar_ax.transAxes, fontsize=7,

--- a/acme_diags/plot/cartopy/diurnal_cycle_plot.py
+++ b/acme_diags/plot/cartopy/diurnal_cycle_plot.py
@@ -1,0 +1,239 @@
+from __future__ import print_function
+
+import matplotlib
+import numpy as np
+import numpy.ma as ma
+import os
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from matplotlib.colors import hsv_to_rgb
+import cartopy.feature as cfeature
+import cartopy.crs as ccrs
+from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+import cdutil
+from acme_diags.derivations.default_regions import regions_specs
+from acme_diags.driver.utils.general import get_output_dir
+
+plotTitle = {'fontsize': 11.5}
+plotSideTitle = {'fontsize': 9.5}
+
+# Position and sizes of subplot axes in page coordinates (0 to 1)
+panel = [(0.1691, 0.55, 0.6465, 0.2758),
+         (0.1691, 0.15, 0.6465, 0.2758),
+         ]
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+border = (-0.06, -0.03, 0.13, 0.03)
+
+
+def add_cyclic(var):
+    lon = var.getLongitude()
+    return var(longitude=(lon[0], lon[0] + 360.0, 'coe'))
+
+
+def get_ax_size(fig, ax):
+    bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
+    width, height = bbox.width, bbox.height
+    width *= fig.dpi
+    height *= fig.dpi
+    return width, height
+
+
+def determine_tick_step(degrees_covered):
+    if degrees_covered > 180:
+        return 60
+    if degrees_covered > 60:
+        return 30
+    elif degrees_covered > 30:
+        return 10
+    elif degrees_covered > 20:
+        return 5
+    else:
+        return 1    
+
+
+def plot_panel(n, fig, proj,var, amp,
+               title, parameter):
+
+    lon = var.getLongitude()
+    lat = var.getLatitude()
+    var = ma.squeeze(var.asma())
+    max_amp = amp.max()
+    amp = ma.squeeze(amp.asma())
+    #Convert to rgb image
+    img = np.dstack((var/24,amp/max_amp,np.ones_like(amp)))
+    img = hsv_to_rgb(img)
+
+
+    # imshow plot
+    ax = fig.add_axes(panel[n], projection=proj)
+
+    region_str = parameter.regions[0]
+    region = regions_specs[region_str]
+    global_domain = True
+    full_lon = True
+    if 'domain' in region.keys():
+        # Get domain to plot
+        domain = region['domain']
+        global_domain = False
+    else:
+        # Assume global domain
+        domain = cdutil.region.domain(latitude=(-90., 90, 'ccb'))
+    kargs = domain.components()[0].kargs
+    lon_west, lon_east, lat_south, lat_north = (0, 360, -90, 90)
+    if 'longitude' in kargs:
+        full_lon = False
+        lon_west, lon_east, _ = kargs['longitude']
+        # Note cartopy Problem with gridlines across the dateline:https://github.com/SciTools/cartopy/issues/821. Region cross dateline is not supported yet.
+        if lon_west>180 and lon_east>180:
+            lon_west = lon_west - 360
+            lon_east = lon_east - 360
+
+    if 'latitude' in kargs:
+        lat_south, lat_north, _ = kargs['latitude']
+    lon_covered = lon_east - lon_west
+    lon_step = determine_tick_step(lon_covered)
+    xticks = np.arange(lon_west, lon_east, lon_step)
+    # Subtract 0.50 to get 0 W to show up on the right side of the plot.
+    # If less than 0.50 is subtracted, then 0 W will overlap 0 E on the left side of the plot.
+    # If a number is added, then the value won't show up at all.
+    if global_domain or full_lon:
+        xticks = np.append(xticks, lon_east-0.50)
+        proj = ccrs.PlateCarree(central_longitude=180)
+    else:
+        xticks = np.append(xticks, lon_east)
+
+    lat_covered = lat_north - lat_south
+    lat_step = determine_tick_step(lat_covered)
+    yticks = np.arange(lat_south, lat_north, lat_step)
+    yticks = np.append(yticks, lat_north)
+
+    ax.set_extent([lon_west, lon_east, lat_south, lat_north], crs=proj)
+
+    # Full world would be aspect 360/(2*180) = 1
+    ax.set_aspect((lon_east - lon_west)/(2*(lat_north - lat_south)))
+    # Get the right most position for setting color bars
+    ax.apply_aspect()
+    pos = ax.get_position(original=False).get_points()
+    pos_x1 = pos[1,0] 
+    ax.coastlines(lw=0.3)
+    if title[0] is not None:
+        ax.set_title(title[0], loc='left', fontdict=plotSideTitle)
+    if title[1] is not None:
+        ax.set_title(title[1], fontdict=plotTitle)
+    ax.set_xticks(xticks, crs=ccrs.PlateCarree())
+    ax.set_yticks(yticks, crs=ccrs.PlateCarree())
+    lon_formatter = LongitudeFormatter(
+        zero_direction_label=True, number_format='.0f')
+    lat_formatter = LatitudeFormatter()
+    ax.xaxis.set_major_formatter(lon_formatter)
+    ax.yaxis.set_major_formatter(lat_formatter)
+    ax.tick_params(labelsize=8.0, direction='out', width=1)
+    ax.xaxis.set_ticks_position('bottom')
+    ax.yaxis.set_ticks_position('left')
+    # set a margin around the data
+    ax.set_xmargin(0.05)
+    ax.set_ymargin(0.10)
+    
+    # add the image. Because this image was a tif, the "origin" of the image is in the
+    # upper left corner
+    img_extent = [lon_west, lon_east, lat_south, lat_north] 
+    ax.imshow(img, origin='lower', extent=img_extent, transform=ccrs.PlateCarree())
+    ax.coastlines(resolution='50m', color='black', linewidth=1)
+    state_borders = cfeature.NaturalEarthFeature(category='cultural', name='admin_1_states_provinces_lakes', scale='50m', facecolor='none')
+    ax.add_feature(state_borders, edgecolor='black')
+
+    # Color bar
+    #bar_ax = fig.add_axes((panel[n][0] + 0.63, panel[n][1] + 0.15, 0.1, 0.1), polar=True)
+    bar_ax = fig.add_axes((pos_x1+0.07, panel[n][1] + 0.15, 0.1, 0.1), polar=True)
+    theta, R = np.meshgrid(np.linspace(0,2*np.pi,24),np.linspace(0,1,8))
+    H, S = np.meshgrid(np.linspace(0,1,23), np.linspace(0,1,8))
+    image = np.dstack((H, S, np.ones_like(S)*0.8))
+    image = hsv_to_rgb(image)
+    #bar_ax.set_theta_zero_location('N')
+    bar_ax.set_theta_direction(-1)
+    bar_ax.set_theta_offset(np.pi/2)
+    bar_ax.set_xticklabels(['0h', '3h', '6h', '9h', '12h', '15h', '18h', '21h'])
+    bar_ax.set_yticklabels([])
+    # We change the fontsize of minor ticks label 
+    bar_ax.tick_params(axis='both', labelsize=7,pad=0,length=0)
+    bar_ax.text(0.2, -0.2, 'Local Time', transform=bar_ax.transAxes, fontsize=7,
+            verticalalignment='center')
+    bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp,'mm/hr'), transform=bar_ax.transAxes, fontsize=7,
+            verticalalignment='center')
+    color = image.reshape((image.shape[0]*image.shape[1],image.shape[2]))
+    pc = bar_ax.pcolormesh(theta, R, np.zeros_like(R),color = color)
+    pc.set_array(None)
+
+
+def plot(test_tmax,test_amp, ref_tmax,ref_amp, parameter):
+    if parameter.backend not in ['cartopy', 'mpl', 'matplotlib']:
+        return
+
+    # Create figure, projection
+    fig = plt.figure(figsize=[8.5, 8.5], dpi=parameter.dpi)
+    proj = ccrs.PlateCarree()
+
+
+    # First panel
+    plot_panel(0, fig, proj,test_tmax,test_amp, (parameter.test_name_yrs,parameter.test_title),parameter) 
+
+    # Second panel
+    plot_panel(1, fig, proj,ref_tmax,ref_amp, (parameter.ref_name_yrs,parameter.reference_title),parameter) 
+
+
+    # Figure title
+    fig.suptitle(parameter.main_title, x=0.5, y=0.9, fontsize=14)
+
+    # Prepare to save figure
+    # get_output_dir => {parameter.results_dir}/{set_name}/{parameter.case_id}
+    # => {parameter.results_dir}/enso_diags/{parameter.case_id} 
+    output_dir = get_output_dir(parameter.current_set, parameter)
+    if parameter.print_statements:
+        print('Output dir: {}'.format(output_dir))
+    # get_output_dir => {parameter.orig_results_dir}/{set_name}/{parameter.case_id}
+    # => {parameter.orig_results_dir}/enso_diags/{parameter.case_id} 
+    original_output_dir = get_output_dir(parameter.current_set, parameter, ignore_container=True)
+    if parameter.print_statements:
+        print('Original output dir: {}'.format(original_output_dir))
+    # parameter.output_file is defined in acme_diags/driver/enso_diags_driver.py
+    # {parameter.results_dir}/enso_diags/{parameter.case_id}/{parameter.output_file}
+    file_path = os.path.join(output_dir, parameter.output_file)
+    # {parameter.orig_results_dir}/enso_diags/{parameter.case_id}/{parameter.output_file}
+    original_file_path = os.path.join(original_output_dir, parameter.output_file)
+    
+    # Save figure
+    for f in parameter.output_format:
+        f = f.lower().split('.')[-1]
+        plot_suffix = '.' + f
+        plot_file_path = file_path + plot_suffix
+        plt.savefig(plot_file_path)
+        # Get the filename that the user has passed in and display that.
+        # When running in a container, the paths are modified.
+        original_plot_file_path = original_file_path + plot_suffix
+        print('Plot saved in: ' + original_plot_file_path)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2,2)
+            subpage[1,:] = subpage[0,:] + subpage[1,:]
+            subpage = subpage + np.array(border).reshape(2,2)
+            subpage = list(((subpage)*page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save subplot
+            subplot_suffix = '.%i.' %(i) + f
+            subplot_file_path = file_path + subplot_suffix
+            plt.savefig(subplot_file_path, bbox_inches=extent)
+            # Get the filename that the user has passed in and display that.
+            # When running in a container, the paths are modified. 
+            original_subplot_file_path = original_file_path + subplot_suffix
+            print('Sub-plot saved in: ' + original_subplot_file_path)
+            i += 1
+
+    plt.close()
+
+

--- a/acme_diags/plot/cartopy/diurnal_cycle_plot.py
+++ b/acme_diags/plot/cartopy/diurnal_cycle_plot.py
@@ -171,7 +171,7 @@ def plot_panel(n, fig, proj,var, amp,
     bar_ax.tick_params(axis='both', labelsize=7,pad=0,length=0)
     bar_ax.text(0.2, -0.3, 'Local Time', transform=bar_ax.transAxes, fontsize=7,
             verticalalignment='center')
-    bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp,'mm/hr'), transform=bar_ax.transAxes, fontsize=7,
+    bar_ax.text(-0.1, 1.3, 'Max DC amp {:.2f}{}'.format(max_amp,'mm/day'), transform=bar_ax.transAxes, fontsize=7,
             verticalalignment='center')
     color = image.reshape((image.shape[0]*image.shape[1],image.shape[2]))
     pc = bar_ax.pcolormesh(theta, R, np.zeros_like(R),color = color,shading='auto')

--- a/acme_diags/viewer/default_viewer.py
+++ b/acme_diags/viewer/default_viewer.py
@@ -20,6 +20,7 @@ SET_TO_NAME = {
     'lat_lon': 'Latitude-Longitude contour maps',
     'polar': 'Polar contour maps',
     'cosp_histogram': 'CloudTopHeight-Tau joint histograms',
+    'diurnal_cycle': 'Diurnal cycle phase maps',
 }
 
 # The ordering of the columns in the viewer.

--- a/acme_diags/viewer/main.py
+++ b/acme_diags/viewer/main.py
@@ -16,7 +16,8 @@ SET_TO_VIEWER = {
     'area_mean_time_series': area_mean_time_series_viewer.create_viewer,
     'enso_diags': enso_diags_viewer.create_viewer,
     'qbo': qbo_viewer.create_viewer,
-    'streamflow': streamflow_viewer.create_viewer
+    'streamflow': streamflow_viewer.create_viewer,
+    'diurnal_cycle': default_viewer.create_viewer
 }
 
 def create_index(root_dir, title_and_url_list):

--- a/analysis_data_preprocess/create_TRMM-3B43v-7_3hr_climo.sh
+++ b/analysis_data_preprocess/create_TRMM-3B43v-7_3hr_climo.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+source /usr/local/e3sm_unified/envs/load_latest_e3sm_unified.sh
+
+# Low-res Cori simulations
+#drc_in=/p/user_pub/PCMDIobs/PCMDIobs2/atmos/3hr/pr/TRMM-3B43v-7/gn/v20200707
+drc_in=/p/user_pub/e3sm/zhang40/analysis_data_e3sm_diags/TRMM/original
+
+drc_out=/p/user_pub/e3sm/zhang40/analysis_data_e3sm_diags/TRMM/climatology_diurnal_cycle
+caseid=pr_3hr_TRMM-3B43v-7_BE_gn_v20200707
+
+cd ${drc_in};ls ${caseid}*.nc | ncclimo --var=pr --clm_md=hfc --caseid=TRMM-3B43v-7_3hr --ypf=1 --yr_srt=1998 --yr_end=2013 --drc_out=${drc_out}

--- a/analysis_data_preprocess/fix_units_TRMM-3B43v-7_3hr.py
+++ b/analysis_data_preprocess/fix_units_TRMM-3B43v-7_3hr.py
@@ -1,0 +1,32 @@
+import cdms2
+from pathlib import Path
+
+
+datapath='/p/user_pub/e3sm/zhang40/analysis_data_e3sm_diags/TRMM/climatology_diurnal_cycle/'
+for path in Path(datapath).rglob('*.nc'):
+    print(path.name)
+    print(path)
+    filename = path.name.split("/")[-1]
+    print(filename)
+
+    #filename ='TRMM-3B43v-7_3hr_ANN_199801_201312_climo.nc'
+    f_in = cdms2.open(datapath+filename)
+    var = f_in('pr')
+    var = var/3600.0*1000/1000.0
+    var.id = 'pr'
+    f_out = cdms2.open(datapath+'units_fix_'+filename,'w')
+    f_out.write(var)
+
+
+    att_keys = list(f_in.attributes.keys())
+    att_dic = {}
+    for i in range(len(att_keys)):
+        att_dic[i]=att_keys[i],f_in.attributes[att_keys[i]]
+        to_out = att_dic[i]
+        setattr(f_out,to_out[0],to_out[1])
+    print(var.mean())
+    f_in.close()
+    f_out.close()
+
+
+

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,8 @@ cosp_histogram_files += get_all_files_in_dir('acme_diags/driver/default_diags/le
 area_mean_time_series = get_all_files_in_dir('acme_diags/driver/default_diags', 'area_mean_time_series*')
 qbo = get_all_files_in_dir('acme_diags/driver/default_diags', 'qbo*')
 streamflow = get_all_files_in_dir('acme_diags/driver/default_diags', 'streamflow*')
-
 enso_diags_files = get_all_files_in_dir('acme_diags/driver/default_diags', 'enso_*')
-
+diurnal_cycle_files = get_all_files_in_dir('acme_diags/driver/default_diags', 'diurnal_cycle_*')
 rgb_files = get_all_files_in_dir('acme_diags/plot/colormaps', '*.rgb')
 control_runs_files = get_all_files_in_dir('acme_diags/driver/control_runs', '*.csv')
 
@@ -72,6 +71,10 @@ data_files = [
     (os.path.join(INSTALL_PATH, 'streamflow'),
      streamflow
      ),
+    (os.path.join(INSTALL_PATH, 'diurnal_cycle'),
+     diurnal_cycle_files
+     ),
+
     (INSTALL_PATH,
      ['acme_diags/driver/acme_ne30_ocean_land_mask.nc',
       'misc/e3sm_logo.png'


### PR DESCRIPTION
This PR is to add diurnal cycle phase map:
* TRMM 0.25 degree data is pre-processed for monthly diurnal cycle and added.
*Default regions include: "CONUS", "20S20N", "W_Pacific", "Amazon","global","50S50N"
*example results: https://portal.nersc.gov/cfs/e3sm/zhang40/tests/diurnal_cycle_climo/viewer/diurnal_cycle/index.html
**updated results** with `normalize_test_amp = False`: https://portal.nersc.gov/cfs/e3sm/zhang40/tests/diurnal_cycle_climo_no_scale_test/viewer/

To post-process model output files to create monthly diurnal cycle that E3SM Diags could read, use the new NCO sub-monthly capability. Example scripts on Cori:
```
#!/bin/bash
  
source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified.sh

# Low-res Cori simulations
drc_in=/global/cfs/cdirs/e3smpub/E3SM_simulations/20180215.DECKv1b_H1.ne30_oEC.edison/archive/atm/hist

drc_out=/global/cfs/cdirs/e3sm/zhang40/nco_scripts/results/diurnal_climo/native
drc_rgr=/global/cfs/cdirs/e3sm/zhang40/nco_scripts/results/diurnal_climo/rgr
caseid=20180215.DECKv1b_H1.ne30_oEC.edison.cam.h4

#cd ${drc_in};ls ${caseid}*.nc | ncclimo --var=PRECT --clm_md=hfc --caseid=$caseid --ypf=1 --yr_srt=2000 --yr_end=2004 --drc_out=${drc_out} -O $drc_rgr --map=/global/homes/z/zender/data/maps/map_ne30np4_to_cmip6_180x360_aave.20181001.nc
cd ${drc_in};ls ${caseid}*200*.nc | ncclimo --clm_md=hfc --caseid=$caseid --ypf=1 --yr_srt=2000 --yr_end=2009 --drc_out=${drc_out} -O $drc_rgr --map=/global/homes/z/zender/data/maps/map_ne30np4_to_cmip6_180x360_aave.20181001.nc
```

Notes here for improvements:
Use same scale for test and ref data, and to make a parameter so that user can choose to use different scales for test and ref. 
The CONUS domain range needs to be revised.