### PR TITLE
add example run script for v2.3.0

### DIFF
--- a/examples/tutorials/postprocessing_E3SM_data_for_e3sm_diags.sh
+++ b/examples/tutorials/postprocessing_E3SM_data_for_e3sm_diags.sh
@@ -11,41 +11,47 @@ source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified.sh
 declare -a ids=("20180215.DECKv1b_H1.ne30_oEC.edison")
 start='1980'
 end='2014'
+dest_grid='180x360_aave'
+src_grid='ne30np4'
 
 for caseid in "${ids[@]}"
 do
 echo ${caseid}
 
-drc_in=/global/cfs/cdirs/e3smpub/E3SM_simulations/${caseid}/archive/atm/hist
-drc_in_river=/global/cfs/cdirs/e3smpub/E3SM_simulations/${caseid}/archive/rof/hist
+base_dir=/global/cfs/cdirs/e3smpub/E3SM_simulations/
+
+drc_in=${base_dir}${caseid}/archive/atm/hist
+drc_in_river=${base_dir}${caseid}/archive/rof/hist
 echo $drc_in
 
-dir_out_climo=/global/cfs/cdirs/e3sm/zhang40/postprocessing_for_e3sm_diags/climo/${caseid}/${start}-${end}
-dir_out_ts=/global/cfs/cdirs/e3sm/zhang40/postprocessing_for_e3sm_diags/monthly_ts/${caseid}/${start}-${end}
-dir_out_diurnal_climo=/global/cfs/cdirs/e3sm/zhang40/postprocessing_for_e3sm_diags/diurnal_climo/${caseid}/${start}-${end}
-map_file=/global/homes/z/zender/data/maps/map_ne30np4_to_cmip6_180x360_aave.20181001.nc
+drc_out_climo=${base_dir}${caseid}/post/atm/${dest_grid}/clim/${start}-${end}
+drc_out_ts=${base_dir}${caseid}/post/atm/${dest_grid}/ts/${start}-${end}
+drc_out_diurnal_climo=${base_dir}${caseid}/post/atm/${dest_grid}/clim_dc/${start}-${end}
+drc_out=${base_dir}${caseid}/post/atm/native
+
+drc_out_ts_rof=${base_dir}${caseid}/post/rof/native/ts/${start}-${end}
+#drc_out_ts=/global/cfs/cdirs/e3sm/zhang40/postprocessing_for_e3sm_diags/monthly_ts/${caseid}/${start}-${end}
+#drc_out_diurnal_climo=/global/cfs/cdirs/e3sm/zhang40/postprocessing_for_e3sm_diags/diurnal_climo/${caseid}/${start}-${end}
+
+map_file=/global/homes/z/zender/data/maps/map_${src_grid}_to_cmip6_${dest_grid}.20181001.nc
 
 echo "Generating Climatology files"
-drc_rgr=${dir_out_climo}/rgr
-drc_out=${dir_out_climo}/native
+drc_rgr=${drc_out_climo}
 ncclimo --caseid=${caseid} --yr_srt=${start} --yr_end=${end} --drc_in=${drc_in} --drc_out=${drc_out} -O $drc_rgr --map=${map_file}
 
 echo "Generating Diurnal Cycle Climo files"
-drc_rgr=${dir_out_diurnal_climo}/rgr
-drc_out=${dir_out_diurnal_climo}/native
+drc_rgr=${drc_out_diurnal_climo}
 echo ${drc_in}
 
 cd ${drc_in};eval ls ${caseid}.cam.h4.*{${start}..${end}}*.nc | ncclimo --clm_md=hfc --caseid=${caseid}.cam.h4 -v PRECT --ypf=1 --yr_srt=${start} --yr_end=${end} --drc_out=${drc_out} -O $drc_rgr --map=${map_file}
 ##
 echo "Generating per-variable monthly time-series."
-drc_rgr=${dir_out_ts}/rgr
-drc_out=${dir_out_ts}/native
 
 echo "Variables for Streamflow"
-cd ${drc_in_river};eval ls ${caseid}*mosart.h0.*{${start}..${end}}*.nc | ncclimo  --caseid=${caseid} --var_xtr=areatotal2 -v RIVER_DISCHARGE_OVER_LAND_LIQ --yr_srt=$start --yr_end=$end --drc_out=${drc_rgr} 
+cd ${drc_in_river};eval ls ${caseid}*mosart.h0.*{${start}..${end}}*.nc | ncclimo  --caseid=${caseid} --var_xtr=areatotal2 -v RIVER_DISCHARGE_OVER_LAND_LIQ --yr_srt=$start --yr_end=$end --drc_out=${drc_out_ts_rof} 
 #
 echo "Variables for supporting diags using monthly time series as input(ENSO, QBO, etc.)"
-cd ${drc_in};eval ls ${caseid}.cam.h0.*{${start}..${end}}*.nc | ncclimo  --caseid=${caseid} --var=U,CLDHGH,CLDLOW,CLDMED,CLDTOT,FLNS,FLUT,FSNS,FSNT,FSNTOA,LANDFRAC,LHFLX,LWCF,OCNFRAC,PRECC,PRECL,PSL,QFLX,SHFLX,SWCF,T,TAUX,TAUY,TREFHT,TS --yr_srt=$start --yr_end=$end --drc_out=${drc_out} -O $drc_rgr --map=${map_file}
+cd ${drc_in};eval ls ${caseid}.cam.h0.*{${start}..${end}}*.nc | ncclimo  --caseid=${caseid} --var=U,CLDHGH,CLDLOW,CLDMED,CLDTOT,FLNS,FLUT,FSNS,FSNT,FSNTOA,LANDFRAC,LHFLX,LWCF,OCNFRAC,PRECC,PRECL,PSL,QFLX,SHFLX,SWCF,T,TAUX,TAUY,TREFHT,TS --yr_srt=$start --yr_end=$end --drc_out=${drc_out} -O ${drc_out_ts} --map=${map_file}
 done
 
 exit

--- a/examples/tutorials/run_v230_all_sets.py
+++ b/examples/tutorials/run_v230_all_sets.py
@@ -1,0 +1,95 @@
+import os
+from acme_diags.run import runner
+from acme_diags.parameter.core_parameter import CoreParameter
+from acme_diags.parameter.area_mean_time_series_parameter import AreaMeanTimeSeriesParameter
+from acme_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+from acme_diags.parameter.qbo_parameter import QboParameter
+from acme_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+from acme_diags.parameter.streamflow_parameter import StreamflowParameter
+
+
+#Define data paths for obs
+input_prefix ='/global/cfs/cdirs/e3sm/acme_diags'
+obs_climo = '/global/cfs/cdirs/e3sm/acme_diags/obs_for_e3sm_diags/climatology'
+obs_ts = '/global/cfs/cdirs/e3sm/acme_diags/obs_for_e3sm_diags/time-series'
+
+#Define data paths for test model
+test_prefix = '/global/cfs/cdirs/e3sm/zhang40/postprocessing_for_e3sm_diags'
+case = '20180215.DECKv1b_H1.ne30_oEC.edison'
+casename = case.split('.')[1]+'.'+case.split('.')[2]
+
+climo_path = os.path.join(test_prefix, 'climo/'+case+'/1980-2014/rgr')
+ts_path = os.path.join(test_prefix, 'monthly_ts/'+case+'/1980-2014/rgr')
+dc_climo_path = os.path.join(test_prefix, 'diurnal_climo/'+case+'/1980-2014/rgr')
+
+#Define parameters for core sets: 'lat_lon','zonal_mean_xy', 'zonal_mean_2d', 'polar', 'cosp_histogram', 'meridional_mean_2d' 
+param = CoreParameter()
+param.reference_data_path = obs_climo
+param.test_data_path = climo_path
+param.test_name = case
+param.test_short_name = casename
+
+#Define results path. 
+prefix = '/global/cfs/cdirs/e3sm/www/zhang40/tutorials/'
+param.results_dir = os.path.join(prefix, 'run_v230_allsets')
+
+param.multiprocessing = True
+param.num_workers = 30
+param.seasons = ['ANN', 'JJA']
+
+#Additional parameters:
+#Short version of test model name being printed as plot titles
+#param.short_test_name = 'beta0.FC5COSP.ne30'
+#Specify run_type. Defualt is 'model_vs_obs'
+#param.run_type = 'model_vs_model'
+#Specify title of the 3rd panel plot. Defualt is 'Model - Observation'
+#param.diff_title = 'Difference'
+#Save subplots as pdf files.
+#param.output_format_subplot = ['pdf']
+#Save netcdf files being plotted.
+#param.save_netcdf = True
+
+
+#Set specific parameters for new sets
+qbo_param = QboParameter()
+qbo_param.reference_data_path = obs_ts
+qbo_param.test_data_path = ts_path
+qbo_param.test_name = casename
+qbo_param.start_yr = '1980'
+qbo_param.end_yr = '2014'
+
+
+dc_param = DiurnalCycleParameter()
+dc_param.reference_data_path = obs_climo
+dc_param.test_data_path = dc_climo_path
+dc_param.test_name = case
+dc_param.short_test_name = casename
+#Plotting diurnal cycle amplitude on different scales. Default is True
+dc_param.normalize_test_amp = False              
+
+enso_param = EnsoDiagsParameter()
+enso_param.reference_data_path = obs_ts
+enso_param.test_data_path = ts_path
+enso_param.test_name = casename
+enso_param.start_yr = '1980'
+enso_param.end_yr = '2014'
+
+ts_param = AreaMeanTimeSeriesParameter()
+ts_param.reference_data_path = obs_ts
+ts_param.test_data_path = ts_path 
+ts_param.test_name = casename
+ts_param.start_yr = '1980'
+ts_param.end_yr = '2014'
+
+streamflow_param = StreamflowParameter()
+streamflow_param.reference_data_path = obs_ts
+streamflow_param.test_data_path = ts_path 
+streamflow_param.test_start_yr = '1980'
+streamflow_param.test_end_yr = '2014'
+# Streamflow gauge station data range from year 1986 to 1995
+streamflow_param.ref_start_yr = '1986'
+streamflow_param.ref_end_yr = '1995'
+#
+runner.sets_to_run = ['lat_lon','zonal_mean_xy', 'zonal_mean_2d', 'polar', 'cosp_histogram', 'meridional_mean_2d','enso_diags', 'qbo','area_mean_time_series','diurnal_cycle','streamflow']
+runner.run_diags([param, enso_param, qbo_param, ts_param,dc_param,streamflow_param])
+


### PR DESCRIPTION
Add updated example run script for all sets including newly added diurnal cycle and streamflow diags. The input data were created using the post-processed script https://github.com/E3SM-Project/e3sm_diags/blob/master/examples/tutorials/postprocessing_E3SM_data_for_e3sm_diags.sh.