### PR TITLE
Script to download test data

### DIFF
--- a/tests/download_data.py
+++ b/tests/download_data.py
@@ -1,0 +1,74 @@
+import os
+import re
+import urllib.request
+
+
+# https://stackoverflow.com/questions/49113616/how-to-download-file-using-python
+def retrieve_file(url, file_path):
+    dir_path = os.path.join(*os.path.split(file_path)[:-1])
+    # https://stackoverflow.com/questions/12517451/automatically-creating-directories-with-file-output
+    if dir_path:
+        os.makedirs(dir_path, exist_ok=True)
+    print('Downloading {} to {}'.format(url, file_path))
+    urllib.request.urlretrieve(url, file_path)
+    return file_path
+
+
+def download_files(url_prefix, url_suffix, directory_prefix=None):
+    print('url_prefix={}'.format(url_prefix))
+    print('url_suffix={}'.format(url_suffix))
+    print('(local) directory_prefix={}'.format(directory_prefix))
+    url = os.path.join(url_prefix, url_suffix)
+    if directory_prefix:
+        links_file_path = os.path.join(directory_prefix, url_suffix)
+    else:
+        links_file_path = url_suffix
+    links_file_path = '{}.html'.format(links_file_path)
+    print('Downloading files from {}; checking for links on {}'.format(url, links_file_path))
+    html_path = retrieve_file(url, links_file_path)
+    links = []
+    with open(html_path, 'r') as html:
+        for line in html:
+            match_object = re.search('<a href="(.*)">', line)
+            if match_object:
+                link = match_object.group(1)
+                # Ignore '../'
+                if '../' not in link:
+                    links.append(link)
+    if os.path.exists(links_file_path):
+        os.remove(links_file_path)
+    print('Found the following links={}'.format(links))
+    files = []
+    directories = []
+    for link in links:
+        if link.endswith('/'):
+            # List directories to download.
+            directories.append(link)
+        else:
+            # List '.csv', '.mat', '.nc', and '.png' files to download.
+            files.append(link)
+    print('\n###Downloading files')
+    if directory_prefix:
+        new_directory_prefix = os.path.join(directory_prefix, url_suffix)
+    else:
+        new_directory_prefix = url_suffix
+    for f in files:
+        url_to_download = os.path.join(url, f)
+        file_path = os.path.join(new_directory_prefix, f)
+        retrieve_file(url_to_download, file_path)
+    print('\n###Downloading directories')
+    for d in directories:
+        new_directory = d.rstrip('/')
+        download_files(url, new_directory, directory_prefix=new_directory_prefix)
+
+
+def download():
+    print('Downloading unit_test_data')
+    download_files('https://web.lcrc.anl.gov/public/e3sm/e3sm_diags_test_data', 'unit_test_data')
+    print('Downloading unit_test_images')
+    download_files('https://web.lcrc.anl.gov/public/e3sm/e3sm_diags_test_data', 'unit_test_images')
+    print('Downloaded unit_test_data and unit_test_images')
+
+
+if __name__ == '__main__':
+    download()

--- a/tests/system/test_diags.py
+++ b/tests/system/test_diags.py
@@ -116,7 +116,13 @@ class TestAllSets(unittest.TestCase):
             print('\npath_to_actual_png={}'.format(path_to_actual_png))
             print('path_to_expected_png={}'.format(path_to_expected_png))
             print('diff has {} nonzero pixels.'.format(num_nonzero_pixels))
-            self.assertTrue(num_nonzero_pixels < 5)
+            width, height = expected_png.size
+            num_pixels = width * height
+            print('total number of pixels={}'.format(num_pixels))
+            fraction = num_nonzero_pixels/num_pixels
+            print('num_nonzero_pixels/num_pixels fraction={}'.format(fraction))
+            # Fraction of mismatched pixels should be less than 0.01%
+            self.assertTrue(fraction < 0.0001)
 
     def check_plots_generic(self, set_name, case_id, ref_name, variables, region, plev=None):
         case_id_lower = case_id.lower()

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -3,14 +3,15 @@
 # Uncomment if you want to remove the results directory from the previous test run.
 #rm -rf tests/system/all_sets_results_test/
 
-# Copy over test data and images [takes about two minutes]
-# TODO: CI tool will access data from the web
-# Change <username>
-scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_data tests/unit_test_data
-scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_images tests/unit_test_images
+cd tests
+# Copy over test data and images from the web. [Takes about four minutes]
+python download_data.py
+# To use `scp`, run the following two lines instead. Be sure to change <username>. [Takes about two minutes]
+#scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_data unit_test_data
+#scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_images unit_test_images
 
 # Use "&&" so the test will fail if either python call fails.
-cd tests/system && python -m unittest && cd .. && python -m unittest && cd ..
+cd system && python -m unittest && cd .. && python -m unittest && cd ..
 
 # Uncomment if you want to delete the test data/images copied from Blues after running the tests.
 #rm -rf tests/unit_test_data


### PR DESCRIPTION
Download test data from https://web.lcrc.anl.gov/public/e3sm/e3sm_diags_test_data/ rather than using `scp -r`, as discussed in #368. 
