### PR TITLE
Update flake8 repo URL for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,9 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  # Need to use flake8 GitHub mirror due to CentOS git issue with GitLab
+  # https://github.com/pre-commit/pre-commit/issues/1206
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8

--- a/conda/e3sm_diags_env_dev.yml
+++ b/conda/e3sm_diags_env_dev.yml
@@ -17,6 +17,7 @@ dependencies:
   - pip=21.0.1
   - python=3.7.10
   # Developer Tools
+  # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`
   - black=20.8b1
   - flake8=3.8.4
   - flake8-isort=4.0.0


### PR DESCRIPTION
This PR updates the repo URL for flake8 from GitLab to GitHub in `.pre-commit-config.yaml`.

Anvil uses `centos-7`, which has an outdated version of `git` (1.8.3.1). This version of git causes issues fetching/cloning from GitLab (possible incompatibility?).

- Closes #398  