### PR TITLE
Add acme_ne30_ocean_land_mask.nc to be tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ ENV/
 
 # NetCDF files
 *.nc
+
+# NetCDF files needed
+!acme_diags/driver/acme_ne30_ocean_land_mask.nc


### PR DESCRIPTION
This PR adds `!acme_diags/driver/acme_ne30_ocean_land_mask.nc` to `.gitignore` so that file is tracked rather than ignored.

- Closes #423 