### PR TITLE
Fail if any part fails

### DIFF
--- a/acme_diags/parameter/core_parameter.py
+++ b/acme_diags/parameter/core_parameter.py
@@ -80,6 +80,7 @@ class CoreParameter(cdp.cdp_parameter.CDPParameter):
         self.granulate = ["variables", "seasons", "plevs", "regions"]
         self.selectors = ["sets", "seasons"]
         self.viewer_descr = {}
+        self.fail_on_incomplete = False
 
     def check_values(self):
         # must_have_params = ['reference_data_path', 'test_data_path', 'results_dir']

--- a/docs/source/available-parameters.rst
+++ b/docs/source/available-parameters.rst
@@ -266,6 +266,7 @@ Other parameters
 -  **granulate**: Default is ``['variables', 'seasons', 'plevs', 'regions']``.
 -  **selectors**: Default is ``['sets', 'seasons']``. See :ref:`Using the selectors parameter <selector-ex>`.
 -  **viewer_descr**: Used to specify values in the viewer. Default ``{}``.
+-  **fail_on_incomplete**: Exit status will reflect failure if any parameter fails to complete. Default is ``False`` (e.g., a failing parameter will not create a failing exit code).
 
 Deprecated parameters
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Currently, E3SM Diags exits successfully if the viewer is generated, not if all sets are successfully included. This pull request makes it so that E3SM Diags fails unless every part succeeds.