### PR TITLE
Remove setup-miniconda pinned python version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,7 +61,6 @@ jobs:
           activate-environment: e3sm_diags_env_dev
           environment-file: conda/e3sm_diags_env_dev.yml
           channel-priority: strict
-          python-version: 3.7
           auto-update-conda: true
           # IMPORTANT: This needs to be set for caching to work properly!
           use-only-tar-bz2: true


### PR DESCRIPTION
This PR fixes the build breaking due to setup-miniconda's latest release.

- Closes #428 