### PR TITLE
Rename CI/CD build and update docs

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -1,4 +1,4 @@
-name: CI/CD Workflow
+name: CI/CD Build Workflow
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,43 +1,52 @@
 # E3SM Diagnostics Package
 
-[![Install](https://anaconda.org/e3sm/e3sm_diags/badges/installer/conda.svg)](https://anaconda.org/e3sm/e3sm_diags)
-[![Downloads](https://anaconda.org/e3sm/e3sm_diags/badges/downloads.svg)](https://anaconda.org/e3sm/e3sm_diags)
-[![Version](https://anaconda.org/e3sm/e3sm_diags/badges/version.svg)](https://anaconda.org/e3sm/e3sm_diags)
+[![Anaconda Version](https://anaconda.org/e3sm/e3sm_diags/badges/version.svg)](https://anaconda.org/e3sm/e3sm_diags)
+[![Anaconda Downloads](https://anaconda.org/e3sm/e3sm_diags/badges/downloads.svg)](https://anaconda.org/e3sm/e3sm_diags)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1009157.svg)](https://doi.org/10.5281/zenodo.1009157)
-[![Docker Badge](https://images.microbadger.com/badges/version/e3sm/e3sm_diags.svg)](https://hub.docker.com/r/e3sm/e3sm_diags/)
-![GitHub Actions CI/CD](https://github.com/E3SM-Project/e3sm_diags/workflows/CI%2FCD%20Workflow/badge.svg)
+[![Docker Version](https://images.microbadger.com/badges/version/e3sm/e3sm_diags.svg)](https://hub.docker.com/r/e3sm/e3sm_diags/)
+
+[![CI/CD Build Workflow](https://github.com/E3SM-Project/e3sm_diags/actions/workflows/build_workflow.yml/badge.svg)](https://github.com/E3SM-Project/e3sm_diags/actions/workflows/build_workflow.yml)
+[![CI/CD Release Workflow](https://github.com/E3SM-Project/e3sm_diags/actions/workflows/release_workflow.yml/badge.svg)](https://github.com/E3SM-Project/e3sm_diags/actions/workflows/release_workflow.yml)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![flake8](https://img.shields.io/badge/flake8-enabled-green)](https://github.com/PyCQA/flake8)
+[![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
 ## Table of Contents
+
 1. [Documentation](#doc)
 2. [Overview](#overview)
 3. [Current State](#current-state)
 
 ## Documentation <a name="doc"></a>
-* [Documentation Website](https://e3sm-project.github.io/e3sm_diags)
-* [Sample Output, Historical H1 (2011-2013) vs Historical H1 (1850-1852)](https://e3sm-project.github.io/e3sm_diags/sample_output/modTS_vs_modTS_3years/viewer/index.html)
-* Quick Start Guides:
-  * [Quick Start Guide for NERSC Cori](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-cori.html)
-  * [Quick Start Guide for NERSC Edison](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-edison-shifter.html)
-  * [Quick Start Guide for AIMS4/ACME1](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-aims4.html)
-  * [Quick Start Guide for OLCF Rhea](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-rhea.html)
-* Examples:
-  * [Model Time-series vs Model Time-series](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_ts-vs-model_ts.html)
-  * [Model Time-series vs Model Time-series with CMIP data](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_ts-vs-model_ts-CMIP.html)
-  * [Model Time-series vs Observation Time-series with CMIP data](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_ts-vs-obs_ts-CMIP.html)
-  * [Model Climo vs Model Climo Comparison](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_climo-vs-model_climo.html)
-  * [Model Climo vs Observation Climo Comparison](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_climo-vs-obs_climo.html)
-  * [Observation vs Observation Comparison](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/obs_climo-vs-obs_climo.html)
+
+- [Documentation Website](https://e3sm-project.github.io/e3sm_diags)
+- [Sample Output, Historical H1 (2011-2013) vs Historical H1 (1850-1852)](https://e3sm-project.github.io/e3sm_diags/sample_output/modTS_vs_modTS_3years/viewer/index.html)
+- Quick Start Guides:
+  - [Quick Start Guide for NERSC Cori](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-cori.html)
+  - [Quick Start Guide for NERSC Edison](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-edison-shifter.html)
+  - [Quick Start Guide for AIMS4/ACME1](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-aims4.html)
+  - [Quick Start Guide for OLCF Rhea](https://e3sm-project.github.io/e3sm_diags/docs/html/quickguides/quick-guide-rhea.html)
+- Examples:
+  - [Model Time-series vs Model Time-series](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_ts-vs-model_ts.html)
+  - [Model Time-series vs Model Time-series with CMIP data](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_ts-vs-model_ts-CMIP.html)
+  - [Model Time-series vs Observation Time-series with CMIP data](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_ts-vs-obs_ts-CMIP.html)
+  - [Model Climo vs Model Climo Comparison](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_climo-vs-model_climo.html)
+  - [Model Climo vs Observation Climo Comparison](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/model_climo-vs-obs_climo.html)
+  - [Observation vs Observation Comparison](https://e3sm-project.github.io/e3sm_diags/docs/html/examples/obs_climo-vs-obs_climo.html)
 
 ## Overview<a name="overview"></a>
+
 This diagnostics package is constructed for supporting the diagnostics task of DOE's [Energy Exascale Earth System Model (E3SM) project](https://climatemodeling.science.energy.gov/projects/accelerated-climate-modeling-energy). The goal of this work is to develop a comprehensive diagnostics package that:
 
-* fully integrates the functionality of NCAR's AMWG diagnostics package.
-* utilizes most updated observational datasets, including remote sensing, reanalysis and in-situ datasets.
-* interfaces with diagnostics developed from different E3SM focus groups: atmosphere group, coupled simulation group, land group.
-* interacts effectively with the PCMDI's metrics package and the ARM diagnostics package through a unifying framework: [Community Diagnostics Package (CDP)](https://github.com/CDAT/cdp).
-* is flexible for user specified diagnostics and being configured for use by other climate models.
+- fully integrates the functionality of NCAR's AMWG diagnostics package.
+- utilizes most updated observational datasets, including remote sensing, reanalysis and in-situ datasets.
+- interfaces with diagnostics developed from different E3SM focus groups: atmosphere group, coupled simulation group, land group.
+- interacts effectively with the PCMDI's metrics package and the ARM diagnostics package through a unifying framework: [Community Diagnostics Package (CDP)](https://github.com/CDAT/cdp).
+- is flexible for user specified diagnostics and being configured for use by other climate models.
 
 ## Current State <a name="current-state"></a>
+
 Algorithm and visualization codes for the AMWG Set 5, 7, 4, 3, 13, 1, 14 diagnostics, namely lat-lon contour plots (Figure 1), polar contour plots (Figure 2), zonal mean 2d plots (Figure 3), zonal mean line plots (Figure 4), 2d joint histogram for COSP cloud simulator output (Figure 5), tables (Figure 6) and Taylor Diagrams (Figure 7) summarizing metrics, for climatology seasonal means, are implemented.
 
 The package features built-in user diagnostics, by specifying user desired diagnostics regions and pressure levels for variables with the vertical dimension.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -89,7 +89,7 @@ Once this pull request is merged and GitHub Actions finishes building the docs, 
 `e3sm_diags documentation page <https://e3sm-project.github.io/e3sm_diags/>`_.
 
 How Documentation is Versioned
-----------------------------
+------------------------------
 The `sphinx-multiversion <https://github.com/Holzhaus/sphinx-multiversion>`_ package manages documentation versioning.
 
 ``sphinx-multiversion`` is configured to generate versioned docs for available tags and
@@ -110,7 +110,7 @@ they can easily be converted to rst format: ::
    $ jupyter nbconvert mygreatnotebook.ipynb --to rst
 
 Initial setup (obsolete/for reference only)
-----------------------------------
+-------------------------------------------
 
 The instructions below only apply for the initial configuration of the
 Sphinx documentation on the Github repository. They are documented here

--- a/docs/source/dev_guide/project-standards.rst
+++ b/docs/source/dev_guide/project-standards.rst
@@ -99,23 +99,23 @@ Assuming that you followed :ref:`"(b) Development Environment" <dev-env>`:
     git rebase <upstream-origin>/master
     git push -f <fork-origin> master
 
-2. Rebase branch onto ``master`` ::
-
-    git checkout <branch-name>
-    git rebase master # If you have merge conflicts, it may be easier to `git rebase --abort` and first do step 4 with SHA of the last commit before your work
-    git push -f <fork-origin> <branch-name>
-
-3. Get the SHA of the commit OR number of commits to rebase to ::
+2. Get the SHA of the commit OR number of commits to rebase to ::
 
     git log --graph --decorate --pretty=oneline --abbrev-commit
 
-4. Squash commits::
+3. Squash commits::
 
     git rebase -i [SHA]
 
     # OR
 
     git rebase -i HEAD~[NUMBER OF COMMITS]
+
+4. Rebase branch onto ``master`` ::
+
+    git checkout <branch-name>
+    git rebase master
+    git push -f <fork-origin> <branch-name>
 
 5. Make sure your squashed commit messages are refined
 

--- a/docs/source/dev_guide/project-standards.rst
+++ b/docs/source/dev_guide/project-standards.rst
@@ -36,7 +36,7 @@ Source: https://gist.github.com/jbenet/ee6c9ac48068889b0912
 Pre-commit
 ~~~~~~~~~~
 The repository uses the ``pre-commit`` package to manage pre-commit hooks.
-These hooks help enforce QA standards and identify simple issues
+These hooks help enforce quality assurance standards and identify simple issues
 at the commit level before submitting code reviews.
 
 .. figure:: pre-commit-flow.svg
@@ -151,13 +151,26 @@ Run a tool
 Continuous Integration / Continuous Delivery (CI/CD)
 ----------------------------------------------------
 
-This project uses `GitHub Actions <https://github.com/E3SM-Project/e3sm_diags/actions>`_ to run the CI/CD build. The build is triggered by Git ``pull_request`` and ``push`` (merging PRs) events to the the main repo's ``master``.
+This project uses `GitHub Actions <https://github.com/E3SM-Project/e3sm_diags/actions>`_ to run two CI/CD workflows.
 
-The CI/CD workflow has three jobs:
+1. CI/CD Build Workflow
 
-1. Run ``pre-commit`` for formatting, linting, and type checking
-2. Run test suite in a conda environment
-3. Publish to Anaconda using a conda environment (Only if #2 succeeds and :ref:`tagging a release <prepare-release>`)
+  This workflow is triggered by Git ``pull_request`` and ``push`` (merging PRs) events to the the main repo's ``master``.
+
+  Jobs:
+
+    1. Run ``pre-commit`` for formatting, linting, and type checking
+    2. Run test suite in a conda environment
+    3. Publish latest `master` docs (depends on jobs 1 and 2)
+
+2. CI/CD Release Workflow
+
+  This workflow is triggered by the Git ``publish`` event, which occurs when a new release is tagged.
+
+  Jobs:
+
+    1. Publish new release docs
+    2. Publish Anaconda package
 
 Style Guide
 -----------

--- a/docs/source/dev_guide/releasing-e3sm-diags.rst
+++ b/docs/source/dev_guide/releasing-e3sm-diags.rst
@@ -12,7 +12,6 @@ In this guide, we'll cover:
 * creating a new version of the documentation
 * building and releasing the Docker image
 
-
 Preparing The Code For Release
 ------------------------------
 
@@ -25,7 +24,6 @@ It's usually ``master``.
 
         git fetch <upstream-origin> master
         git checkout -b <branch-name> <upstream-origin>/master
-
 
 2. Edit the ``version`` argument in ``setup.py`` to the new version.
 Don't prefix this with a "v".
@@ -48,13 +46,11 @@ Don't prefix this with a "v".
             ]}
         )
 
-
 3. Edit the ``version`` label in the ``Dockerfile`` as well.
 
     ::
 
         label version="1.1.0"  # Change this line.
-
 
 4. Edit ``__version__`` in ``acme_diags/__init__.py``.
 We use ``__version__`` when generating the webpages.
@@ -63,14 +59,14 @@ We use ``__version__`` when generating the webpages.
 
         __version__ = 'v1.1.0'
 
-
 5. Change the ``version`` and ``git_rev`` tag in ``conda/meta.yaml``.
 ``version`` is what the version of the software will be on Anaconda and
 ``git_rev`` is the tag that we'll setup on GitHub in the next section.
 
-When running ``conda build``, ``conda`` will download the code tagged by ``git_rev``.
-Even though ``meta.yaml`` is in your local clone of the repo, running ``conda build``
-from here **does not** build the package based on your local code.
+    .. note::
+        When running ``conda build``, ``conda`` will download the code tagged by ``git_rev``.
+        Even though ``meta.yaml`` is in your local clone of the repo, running ``conda build``
+        from here **does not** build the package based on your local code.
 
     ::
 
@@ -82,7 +78,6 @@ from here **does not** build the package based on your local code.
             git_url: git://github.com/E3SM-Project/e3sm_diags
             git_rev: v1.1.0
 
-
 6. Now in ``conda/e3sm_diags_env.yml``, change the version of ``e3sm_diags`` under the
 ``dependencies`` tag to whatever version is in the previous step.
 
@@ -93,7 +88,6 @@ of ``e3sm_diags`` installed in the environment for that yml file.
 
         dependencies:
         - e3sm_diags=1.1.0
-
 
 7. Commit and push your changes.
 
@@ -184,8 +178,6 @@ the E3SM Unified environment. This is almost certainly one of the versions liste
 “Next versions”. If you are uncertain of which to update, leave a comment on the page
 asking.
 
-
-
 Creating a New Version of the Documentation
 -------------------------------------------
 
@@ -198,7 +190,6 @@ This triggers the CI/CD workflow that handles publishing documentation versions.
 3. Changes will be available on the
 `e3sm_diags documentation page <https://e3sm-project.github.io/e3sm_diags/>`_.
 
-
 How To Build and Release The Docker Image
 -----------------------------------------
 
@@ -206,7 +197,6 @@ A Docker image of ``e3sm_diags`` needs to be created and released as well.
 This Docker image can be ran as a container via Docker, Shifter, or Singularity.
 
 We'll build the image, test it, and then release it.
-
 
 Prerequisites
 ^^^^^^^^^^^^^
@@ -229,7 +219,6 @@ Building
     ::
 
         export E3SM_DIAGS_VERSION=v1.5.0
-
 
 A Temporary Diversion
 """""""""""""""""""""
@@ -256,7 +245,6 @@ Due to this, open ``setup.py`` and change the ``INSTALL_PATH`` to be ``os.path.j
                 # pip install --user . && \
                 python setup.py install && \
                 rm -r build/
-
 
 Back to Building the Image
 """"""""""""""""""""""""""
@@ -293,7 +281,6 @@ You should see something like this:
         continuumio/miniconda    4.5.4               16e4fbac86ce        7 weeks ago         544MB
         hello-world              latest              e38bc07ac18e        5 months ago        1.85kB
 
-
 Testing
 """""""
 
@@ -326,7 +313,6 @@ results after each run to ensure that everything was created without errors.
 11. If you do find an error, it could be with the script ``e3sm_diags_container.py`` or with ``e3sm_diags`` itself.
 Please fix this. You might need to delete the release, or release a bug-fix version.
 
-
 Releasing
 """""""""
 
@@ -339,7 +325,6 @@ Releasing
 
 
 13. Congratulations, you're done! You can go home/nap for the day, I won't tell.
-
 
 Optional: Cleanup
 """""""""""""""""

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -159,8 +159,9 @@ an SSL error unless you disable the SSL verification:
 Unlike the latest stable release (i.e., the user environment), the development environment does not include E3SM Diags (``e3sm-diags``).
 Instead, the developer will ``pip install .`` to build ``e3sm-diags`` with changes (see step 6 below).
 
-Furthermore, the dev environment includes QA tools such as code formatters, linters, and ``pre-commit``.
-**NOTE**: These QA tools are enforced using ``pre-commit`` checks in the CI/CD build, so you must use the dev environment for all contributions
+.. note::
+    The dev environment includes quality assurance (QA) tools such as code formatters, linters, and ``pre-commit``.
+    **You must use the dev environment for all contributions** because these QA tools are enforced using ``pre-commit`` checks in the continuous integration/continuous deployment build.
 
 1. Follow :ref:`"Others/Local" <conda_environment_others>` section for installing conda.
 


### PR DESCRIPTION
Summary of Changes

- Rename the "CI/CD Workflow" to "CI/CD Build Workflow"
- Update docs to easily distinguish between the different workflows.
- Update ordering of squash and rebase steps in docs
- Update README.md badges

Issues

- Closes #432 
- Closes #418 