### PR TITLE
Cosp variables fix for v2 like model data

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -53,8 +53,6 @@ jobs:
         shell: bash -l {0}
     timeout-minutes: 20
     steps:
-      # if conditional must be repeated in order to skip matrix jobs that are required PR checks
-      # https://github.com/fkirc/skip-duplicate-actions/issues/44#issuecomment-723430339
       - uses: actions/checkout@v2
 
       - name: Cache Conda

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,15 @@
   "python.linting.flake8Enabled": true,
   "python.linting.flake8Args": ["--config=setup.cfg"],
   "python.linting.mypyEnabled": true,
-  "python.pythonPath": "/opt/miniconda3/envs/e3sm_diags_env_dev/bin/python"
+  "python.pythonPath": "/opt/miniconda3/envs/e3sm_diags_env_dev/bin/python",
+  "python.testing.unittestArgs": [
+    "-v",
+    "-s",
+    "./tests",
+    "-p",
+    "test_*.py"
+  ],
+  "python.testing.pytestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.unittestEnabled": true
 }

--- a/examples/tutorials/run_v230_all_sets.py
+++ b/examples/tutorials/run_v230_all_sets.py
@@ -1,0 +1,108 @@
+import os
+
+from acme_diags.parameter.area_mean_time_series_parameter import (
+    AreaMeanTimeSeriesParameter,
+)
+from acme_diags.parameter.core_parameter import CoreParameter
+from acme_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+from acme_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+from acme_diags.parameter.qbo_parameter import QboParameter
+from acme_diags.parameter.streamflow_parameter import StreamflowParameter
+from acme_diags.run import runner
+
+# Define data paths for obs
+input_prefix = "/global/cfs/cdirs/e3sm/acme_diags"
+obs_climo = "/global/cfs/cdirs/e3sm/acme_diags/obs_for_e3sm_diags/climatology"
+obs_ts = "/global/cfs/cdirs/e3sm/acme_diags/obs_for_e3sm_diags/time-series"
+
+# Define data paths for test model
+test_prefix = "/global/cfs/cdirs/e3sm/zhang40/postprocessing_for_e3sm_diags"
+case = "20180215.DECKv1b_H1.ne30_oEC.edison"
+casename = case.split(".")[1] + "." + case.split(".")[2]
+
+climo_path = os.path.join(test_prefix, "climo/" + case + "/1980-2014/rgr")
+ts_path = os.path.join(test_prefix, "monthly_ts/" + case + "/1980-2014/rgr")
+dc_climo_path = os.path.join(test_prefix, "diurnal_climo/" + case + "/1980-2014/rgr")
+
+# Define parameters for core sets: 'lat_lon','zonal_mean_xy', 'zonal_mean_2d', 'polar', 'cosp_histogram', 'meridional_mean_2d'
+param = CoreParameter()
+param.reference_data_path = obs_climo
+param.test_data_path = climo_path
+param.test_name = case
+param.test_short_name = casename
+
+# Define results path.
+prefix = "/global/cfs/cdirs/e3sm/www/zhang40/tutorials/"
+param.results_dir = os.path.join(prefix, "run_v230_allsets")
+
+param.multiprocessing = True
+param.num_workers = 30
+param.seasons = ["ANN", "JJA"]
+
+# Additional parameters:
+# Short version of test model name being printed as plot titles
+# param.short_test_name = 'beta0.FC5COSP.ne30'
+# Specify run_type. Defualt is 'model_vs_obs'
+# param.run_type = 'model_vs_model'
+# Specify title of the 3rd panel plot. Defualt is 'Model - Observation'
+# param.diff_title = 'Difference'
+# Save subplots as pdf files.
+# param.output_format_subplot = ['pdf']
+# Save netcdf files being plotted.
+# param.save_netcdf = True
+
+
+# Set specific parameters for new sets
+qbo_param = QboParameter()
+qbo_param.reference_data_path = obs_ts
+qbo_param.test_data_path = ts_path
+qbo_param.test_name = casename
+qbo_param.start_yr = "1980"
+qbo_param.end_yr = "2014"
+
+
+dc_param = DiurnalCycleParameter()
+dc_param.reference_data_path = obs_climo
+dc_param.test_data_path = dc_climo_path
+dc_param.test_name = case
+dc_param.short_test_name = casename
+# Plotting diurnal cycle amplitude on different scales. Default is True
+dc_param.normalize_test_amp = False
+
+enso_param = EnsoDiagsParameter()
+enso_param.reference_data_path = obs_ts
+enso_param.test_data_path = ts_path
+enso_param.test_name = casename
+enso_param.start_yr = "1980"
+enso_param.end_yr = "2014"
+
+ts_param = AreaMeanTimeSeriesParameter()
+ts_param.reference_data_path = obs_ts
+ts_param.test_data_path = ts_path
+ts_param.test_name = casename
+ts_param.start_yr = "1980"
+ts_param.end_yr = "2014"
+
+streamflow_param = StreamflowParameter()
+streamflow_param.reference_data_path = obs_ts
+streamflow_param.test_data_path = ts_path
+streamflow_param.test_start_yr = "1980"
+streamflow_param.test_end_yr = "2014"
+# Streamflow gauge station data range from year 1986 to 1995
+streamflow_param.ref_start_yr = "1986"
+streamflow_param.ref_end_yr = "1995"
+#
+runner.sets_to_run = [
+    "lat_lon",
+    "zonal_mean_xy",
+    "zonal_mean_2d",
+    "polar",
+    "cosp_histogram",
+    "meridional_mean_2d",
+    "enso_diags",
+    "qbo",
+    "area_mean_time_series",
+    "diurnal_cycle",
+    "streamflow",
+]
+runner.run_diags([param, enso_param, qbo_param, ts_param, dc_param, streamflow_param])

--- a/tests/acme_diags/derivations/test_acme.py
+++ b/tests/acme_diags/derivations/test_acme.py
@@ -1,0 +1,80 @@
+from typing import TYPE_CHECKING
+from unittest import TestCase
+from unittest.mock import Mock
+
+import numpy as np
+
+from acme_diags.derivations.acme import adjust_prs_val_units, determine_cloud_level
+
+if TYPE_CHECKING:
+    from cdms2.axis import FileAxis
+
+
+class TestAdjustPrsValUnits(TestCase):
+    def setUp(self):
+        self.mock_file_axis: "FileAxis" = Mock()
+        self.mock_file_axis.getData.return_value = np.arange(0, 1002)
+
+        self.prs_val = 1
+        self.prs_val0 = 10
+
+    def test_without_swapping_units(self):
+        actual = adjust_prs_val_units(self.mock_file_axis, self.prs_val, None)
+        expected = 1
+
+        self.assertEqual(actual, expected)
+
+    def test_swap_units_without_multiplier_if_no_matched_id(self):
+        self.mock_file_axis.id = "no_match"
+
+        actual = adjust_prs_val_units(self.mock_file_axis, self.prs_val, self.prs_val0)
+        expected = 10
+        self.assertEqual(actual, expected)
+
+    def test_swap_units_without_multiplier_if_max_less_than_1000(
+        self,
+    ):
+        self.mock_file_axis.id = "cosp_prs"
+        self.mock_file_axis.getData.return_value = np.arange(0, 1)
+
+        actual = adjust_prs_val_units(self.mock_file_axis, self.prs_val, self.prs_val0)
+        expected = 10
+        self.assertEqual(actual, expected)
+
+    def test_swap_units_and_apply_multiplier_for_all_matched_ids(self):
+        adjust_ids = {"cosp_prs": 100, "cosp_htmsir": 1000}
+
+        for id, multiplier in adjust_ids.items():
+            self.mock_file_axis.id = id
+
+            actual = adjust_prs_val_units(
+                self.mock_file_axis, self.prs_val, self.prs_val0
+            )
+            expected = self.prs_val0 * multiplier
+            self.assertEqual(actual, expected)
+
+
+class TestDetermineCloudLevel(TestCase):
+    def setUp(self):
+        self.low_bnds = (1, 2)
+        self.high_bdns = (3, 4)
+
+    def test_returns_middle_cloud_fraction(self):
+        actual = determine_cloud_level(1, 3, self.low_bnds, self.high_bdns)
+        expected = "middle cloud fraction"
+        self.assertEqual(actual, expected)
+
+    def test_returns_high_cloud_fraction(self):
+        actual = determine_cloud_level(1, 1, self.low_bnds, self.high_bdns)
+        expected = "high cloud fraction"
+        self.assertEqual(actual, expected)
+
+    def test_returns_low_cloud_fraction(self):
+        actual = determine_cloud_level(3, 3, self.low_bnds, self.high_bdns)
+        expected = "low cloud fraction"
+        self.assertEqual(actual, expected)
+
+    def test_returns_total_cloud_fraction(self):
+        actual = determine_cloud_level(0, 5, self.low_bnds, self.high_bdns)
+        expected = "total cloud fraction"
+        self.assertEqual(actual, expected)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,15 +1,22 @@
-# Run from top level directory of repository.
+# Run this script from the top level directory of the repository.
 
 # Uncomment if you want to remove the results directory from the previous test run.
 #rm -rf tests/system/all_sets_results_test/
 
+# 1. Run unit tests
+python -m unittest tests/acme_diags/*/test_*.py
+
+# 2. Enter tests directory
 cd tests
-# Copy over test data and images from the web. [Takes about four minutes]
+
+# 3. Copy over test data and images from the web. [Takes about four minutes]
 python download_data.py
+
 # To use `scp`, run the following two lines instead. Be sure to change <username>. [Takes about two minutes]
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_data unit_test_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_images unit_test_images
 
+# 4. Run integration tests
 # Use "&&" so the test will fail if either python call fails.
 cd system && python -m unittest && cd .. && python -m unittest && cd ..
 


### PR DESCRIPTION
Resolves issue #419 
Due to changes in COSP v2, MISR and MODIS variables are not shown up correctly. 
Results after fix:
For v1 data: https://portal.nersc.gov/cfs/e3sm/zhang40/tests/COSPv2_fix_lat_lon_v1data/viewer/
For v2 like data: https://portal.nersc.gov/cfs/e3sm/zhang40/tests/COSPv2_fix_lat_lon/viewer/