### PR TITLE
save data for plotted variables to fix 448

### DIFF
--- a/acme_diags/driver/diurnal_cycle_driver.py
+++ b/acme_diags/driver/diurnal_cycle_driver.py
@@ -90,15 +90,22 @@ def run_diag(parameter):
                 utils.general.save_ncfiles(
                     parameter.current_set,
                     test_cmean,
-                    test_amplitude,
-                    test_maxtime,
+                    ref_cmean,
+                    None,
                     parameter,
                 )
                 utils.general.save_ncfiles(
                     parameter.current_set,
-                    ref_cmean,
+                    test_amplitude,
                     ref_amplitude,
+                    None,
+                    parameter,
+                )
+                utils.general.save_ncfiles(
+                    parameter.current_set,
+                    test_maxtime,
                     ref_maxtime,
+                    None,
                     parameter,
                 )
 

--- a/acme_diags/driver/utils/diurnal_cycle.py
+++ b/acme_diags/driver/utils/diurnal_cycle.py
@@ -130,24 +130,24 @@ def composite_diurnal_cycle(var, season, fft=True):
         # Save phase, amplitude, and mean for the first homonic,
         amplitude = MV2.zeros((nlat, nlon))
         amplitude[:, :] = maxvalue[0]
-        amplitude.id = var.id + "_diurnal_amplitude"
-        amplitude.longname = "Amplitude of diurnal cycle of " + var.id
+        amplitude.id = "PRECT_diurnal_amplitude"
+        amplitude.longname = "Amplitude of diurnal cycle of PRECT"
         amplitude.units = var.units
         amplitude.setAxis(0, lat)
         amplitude.setAxis(1, lon)
 
         maxtime = MV2.zeros((nlat, nlon))
         maxtime[:, :] = tmax[0]
-        maxtime.id = var.id + "_diurnal_phase"
-        maxtime.longname = "Phase of diurnal cycle of " + var.id
+        maxtime.id = "PRECT_diurnal_phase"
+        maxtime.longname = "Phase of diurnal cycle of PRECT"
         maxtime.units = "hour"
         maxtime.setAxis(0, lat)
         maxtime.setAxis(1, lon)
 
         cmean = MV2.zeros((nlat, nlon))
         cmean[:, :] = cycmean
-        cmean.id = var.id + "_diurnal_cycmean"
-        cmean.longname = "Mean of diurnal cycle of " + var.id
+        cmean.id = "PRECT_diurnal_cycmean"
+        cmean.longname = "Mean of diurnal cycle of PRECT"
         cmean.units = var.units
         cmean.setAxis(0, lat)
         cmean.setAxis(1, lon)

--- a/acme_diags/driver/utils/general.py
+++ b/acme_diags/driver/utils/general.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import copy
 import errno
 import os
+from pathlib import Path
 
 import cdms2
 import cdutil
@@ -321,22 +322,32 @@ def save_ncfiles(set_num, test, ref, diff, parameter):
         pth = get_output_dir(set_num, parameter)
 
         # Save test file
-        test.id = parameter.var_id
+        if test.id.startswith("variable_"):
+            test.id = parameter.var_id
         test_pth = os.path.join(pth, parameter.output_file + "_test.nc")
-        with cdms2.open(test_pth, "w+") as file_test:
+
+        cdms_arg = "w"
+
+        if Path(test_pth).is_file():
+            cdms_arg = "a"
+
+        with cdms2.open(test_pth, cdms_arg) as file_test:
             file_test.write(test)
 
         # Save reference file
-        ref.id = parameter.var_id
+        if ref.id.startswith("variable_"):
+            ref.id = parameter.var_id
         ref_pth = os.path.join(pth, parameter.output_file + "_ref.nc")
-        with cdms2.open(ref_pth, "w+") as file_ref:
+        with cdms2.open(ref_pth, cdms_arg) as file_ref:
             file_ref.write(ref)
 
         # Save difference file
-        diff.id = parameter.var_id + "(test - reference)"
-        diff_pth = os.path.join(pth, parameter.output_file + "_diff.nc")
-        with cdms2.open(diff_pth, "w+") as file_diff:
-            file_diff.write(diff)
+        if diff is not None:
+            if diff.id.startswith("variable_"):
+                diff.id = parameter.var_id + "_diff"
+            diff_pth = os.path.join(pth, parameter.output_file + "_diff.nc")
+            with cdms2.open(diff_pth, cdms_arg) as file_diff:
+                file_diff.write(diff)
 
 
 def get_output_dir(set_num, parameter, ignore_container=False):


### PR DESCRIPTION
This PR is to fix issue #448 reported by @xuezhengllnl 
The meta data for diurnal cycle plot after fixing shown as below. A test run on lat-lon map with `save_netcdf` on was conducted and saved nc files as expected. 
```
netcdf TRMM-3B43v-7_3hr-PRECT-JJA-CONUS_ref {
dimensions:
	lat = 100 ;
	bound = 2 ;
	lon = 240 ;
variables:
	double lat(lat) ;
		lat:bounds = "lat_bnds" ;
		lat:axis = "Y" ;
		lat:units = "degrees_north" ;
		lat:long_name = "Latitude" ;
		lat:standard_name = "latitude" ;
		lat:realtopology = "linear" ;
	double lat_bnds(lat, bound) ;
	double lon(lon) ;
		lon:bounds = "lon_bnds" ;
		lon:axis = "X" ;
		lon:modulo = 360. ;
		lon:topology = "circular" ;
		lon:units = "degrees_east" ;
		lon:long_name = "Longitude" ;
		lon:standard_name = "longitude" ;
		lon:realtopology = "circular" ;
	double lon_bnds(lon, bound) ;
	double PRECT_diurnal_cycmean(lat, lon) ;
		PRECT_diurnal_cycmean:longname = "Mean of diurnal cycle of PRECT" ;
		PRECT_diurnal_cycmean:units = "mm/day" ;
		PRECT_diurnal_cycmean:missing_value = 1.e+20 ;
		PRECT_diurnal_cycmean:_FillValue = 1.e+20 ;
	double PRECT_diurnal_amplitude(lat, lon) ;
		PRECT_diurnal_amplitude:longname = "Amplitude of diurnal cycle of PRECT" ;
		PRECT_diurnal_amplitude:units = "mm/day" ;
		PRECT_diurnal_amplitude:missing_value = 1.e+20 ;
		PRECT_diurnal_amplitude:_FillValue = 1.e+20 ;
	double PRECT_diurnal_phase(lat, lon) ;
		PRECT_diurnal_phase:longname = "Phase of diurnal cycle of PRECT" ;
		PRECT_diurnal_phase:units = "hour" ;
		PRECT_diurnal_phase:missing_value = 1.e+20 ;
		PRECT_diurnal_phase:_FillValue = 1.e+20 ;

// global attributes:
		:Conventions = "CF-1.0" ;
}
```
