### PR TITLE
add annual cycle zonal mean contour plots

### DIFF
--- a/acme_diags/driver/annual_cycle_zonal_mean_driver.py
+++ b/acme_diags/driver/annual_cycle_zonal_mean_driver.py
@@ -75,7 +75,7 @@ def run_diag(parameter):
 
         parameter.var_id = var
         parameter.output_file = "-".join([ref_name, var, "Annual-Cycle"])
-        parameter.main_title = str(" ".join([var, "Annual-Cycle"]))
+        parameter.main_title = str(" ".join([var, "Zonel Mean Annual Cycle"]))
 
         parameter.viewer_descr[var] = (
             test_ac.long_name

--- a/acme_diags/driver/annual_cycle_zonal_mean_driver.py
+++ b/acme_diags/driver/annual_cycle_zonal_mean_driver.py
@@ -1,0 +1,104 @@
+from __future__ import print_function
+
+from typing import Any, Dict
+
+import cdms2
+import cdutil
+import MV2
+
+from acme_diags.driver import utils
+from acme_diags.plot import plot
+
+
+def create_annual_cycle(dataset, variable):
+    month_list = [f"{x:02}" for x in list(range(1, 13))]
+
+    for imon, month in enumerate(month_list):
+        # fin = cdms2.open(file_path)
+        # var = fin(variable)
+        # fin.close()
+        var = dataset.get_climo_variable(variable, month)
+        if month == "01":
+            var_ac = MV2.zeros([12] + list(var.shape)[:])
+            var_ac.id = var.id
+            var_ac.long_name = var.long_name
+            var_ac.units = var.units
+            time = cdms2.createAxis(range(1, 13))
+            time.id = "time"
+            var_ac.setAxis(0, time)
+            time.designateTime()
+            var_ac.setAxis(1, var.getAxis(0))
+            var_ac.setAxis(2, var.getAxis(1))
+
+            var_ac[
+                0,
+            ] = var
+        else:
+            var_ac[
+                imon,
+            ] = var
+
+    return var_ac
+
+
+def run_diag(parameter):
+    variables = parameter.variables
+    ref_name = getattr(parameter, "ref_name", "")
+
+    test_data = utils.dataset.Dataset(parameter, test=True)
+    ref_data = utils.dataset.Dataset(parameter, ref=True)
+
+    parameter.test_name_yrs = utils.general.get_name_and_yrs(parameter, test_data, "01")
+    parameter.ref_name_yrs = utils.general.get_name_and_yrs(parameter, ref_data, "01")
+
+    for var in variables:
+        test_ac = create_annual_cycle(test_data, var)
+        ref_ac = create_annual_cycle(ref_data, var)
+
+        test_ac_reg, ref_ac_reg = utils.general.regrid_to_lower_res(
+            test_ac,
+            ref_ac,
+            parameter.regrid_tool,
+            parameter.regrid_method,
+        )
+
+        test_ac_zonal_mean = cdutil.averager(test_ac, axis="x", weights="generate")
+        ref_ac_zonal_mean = cdutil.averager(ref_ac, axis="x", weights="generate")
+        test_ac_reg_zonal_mean = cdutil.averager(
+            test_ac_reg, axis="x", weights="generate"
+        )
+        ref_ac_reg_zonal_mean = cdutil.averager(
+            ref_ac_reg, axis="x", weights="generate"
+        )
+
+        diff_ac = test_ac_reg_zonal_mean - ref_ac_reg_zonal_mean
+
+        parameter.var_id = var
+        parameter.output_file = "-".join([ref_name, var, "Annual-Cycle"])
+        parameter.main_title = str(" ".join([var, "Annual-Cycle"]))
+
+        parameter.viewer_descr[var] = (
+            test_ac.long_name
+            if hasattr(test_ac, "long_name")
+            else "No long_name attr in test data."
+        )
+
+        metrics_dict: Dict[str, Any] = {}
+
+        plot(
+            parameter.current_set,
+            ref_ac_zonal_mean,
+            test_ac_zonal_mean,
+            diff_ac,
+            metrics_dict,
+            parameter,
+        )
+        utils.general.save_ncfiles(
+            parameter.current_set,
+            ref_ac_zonal_mean,
+            test_ac_zonal_mean,
+            diff_ac,
+            parameter,
+        )
+
+    return parameter

--- a/acme_diags/driver/default_diags/annual_cycle_zonal_mean_model_vs_model.cfg
+++ b/acme_diags/driver/default_diags/annual_cycle_zonal_mean_model_vs_model.cfg
@@ -1,0 +1,271 @@
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["PRECT"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
+diff_levels = [-2.5, -2, -1.5, -1, -0.5, -0.25, 0.25, 0.5, 1, 1.5, 2, 2.5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["SST"]
+contour_levels = [-1, 0, 1, 3, 6, 9, 12, 15, 18, 20, 22, 24, 26, 28, 29]
+diff_levels = [-2.5, -2, -1.5, -1, -0.5, -0.1, 0.1, 0.5, 1, 1.5, 2.0, 2.5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["SOLIN"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-2.5, -2, -1.5, -1, -0.5, -0.25, 0.25, 0.5, 1, 1.5, 2, 2.5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["ALBEDO"]
+contour_levels = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75]
+diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["ALBEDOC"]
+contour_levels = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75]
+diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["RESTOM"]
+contour_levels = [-120, -100, -80, -60, -40, -20, 0, 20, 40, 60, 80]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FLUT"]
+contour_levels = [120, 140, 160, 180, 200, 220, 240, 260, 280, 300]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FLUTC"]
+contour_levels = [120, 140, 160, 180, 200, 220, 240, 260, 280, 300]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FSNTOA"]
+contour_levels = [50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FSNTOAC"]
+contour_levels = [50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["SWCF"]
+contour_levels = [-120, -110, -100, -90, -80, -70, -60, -50, -40, -30, -20, -10, 0]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["LWCF"]
+contour_levels = [0, 10, 20, 30, 40, 50, 60, 70, 80]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["NETCF"]
+contour_levels = [-70, -60, -50, -40, -30, -20, -10, 0, 10, 20]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["ALBEDO_SRF"]
+contour_levels = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75]
+diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["SWCFSRF"]
+contour_levels = [-170, -150, -135, -120, -105, -90, -75, -60, -45, -30, -15, 0, 15, 30, 45]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["LWCFSRF"]
+contour_levels = [0, 10, 20, 30, 40, 50, 60, 70, 80]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["NETCF_SRF"]
+contour_levels = [-135, -120, -105, -90, -75, -60, -45, -30, -15, 0, 15, 30, 45]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FLDS"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FLDSC"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FLNS"]
+contour_levels = [0, 20, 40, 60, 80, 100, 120, 140, 160]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FLNSC"]
+contour_levels = [0, 20, 40, 60, 80, 100, 120, 140, 160]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FSDS"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FSDSC"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FSNS"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["FSNSC"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400]
+diff_levels = [-30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["LHFLX"]
+contour_levels = [0,5, 15, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300]
+diff_levels = [-75, -50, -25, -10, -5, -2, 2, 5, 10, 25, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["SHFLX"]
+contour_levels = [-100, -75, -50, -25, -10, 0, 10, 25, 50, 75, 100, 125, 150]
+diff_levels = [-75, -50, -25, -10, -5, -2, 2, 5, 10, 25, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["NET_FLUX_SRF"]
+contour_levels = [-200, -160, -120, -80, -40, 0, 40, 80, 120, 160, 200]
+diff_levels = [-75, -50, -25, -10, -5, -2, 2, 5, 10, 25, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["TMQ"]
+contour_levels = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
+diff_levels = [-12, -9, -6, -4, -3, -2, -1, 1, 2, 3, 4, 6, 9, 12]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["PSL"]
+contour_levels = [955, 965, 975,980, 985, 990, 995, 1000, 1005, 1010, 1015, 1020, 1025, 1035]
+diff_levels = [ -16, -12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12, 16]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["AODVIS"]
+test_colormap = "Oranges"
+reference_colormap = "Oranges"
+diff_colormap = "BrBG_r"
+contour_levels = [0., 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]
+diff_levels = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, -0.02, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["TREFHT"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "model_vs_model"
+variables = ["TAUXY"]
+test_colormap = "Purples"
+reference_colormap = "Purples"
+diff_colormap = "RdBu"
+contour_levels = [0., 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5]
+diff_levels = [-0.1, -0.08, -0.06, -0.05, -0.04, -0.02, -0.01,  0.01, 0.02, 0.04, 0.05, 0.06, 0.08, 0.1]

--- a/acme_diags/driver/default_diags/annual_cycle_zonal_mean_model_vs_obs.cfg
+++ b/acme_diags/driver/default_diags/annual_cycle_zonal_mean_model_vs_obs.cfg
@@ -1,0 +1,439 @@
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "GPCP_v2.2"
+variables = ["PRECT"]
+ref_name = "GPCP_v2.2"
+reference_name = "GPCP_v2.2"
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "GPCP_v2.3"
+variables = ["PRECT"]
+ref_name = "GPCP_v2.3"
+reference_name = "GPCP_v2.3"
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "SST_CL_HadISST"
+variables = ["SST"]
+ref_name = "HadISST_CL"
+reference_name = "HadISST/OI.v2 (Climatology)"
+contour_levels = [-1, 0, 1, 3, 6, 9, 12, 15, 18, 20, 22, 24, 26, 28, 29]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["SOLIN"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["ALBEDO"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75]
+diff_levels = [-0.25, -0.2, -0.15, -0.1, -0.07, -0.05, -0.02, 0.02, 0.05, 0.07, 0.1, 0.15, 0.2, 0.25]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["ALBEDOC"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75]
+diff_levels = [-0.25, -0.2, -0.15, -0.1, -0.07, -0.05, -0.02, 0.02, 0.05, 0.07, 0.1, 0.15, 0.2, 0.25]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["RESTOM"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [-120, -100, -80, -60, -40, -20, 0, 20, 40, 60, 80]
+diff_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["FLUT"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [100, 120, 140, 160, 180, 200, 220, 240, 260, 280, 300, 320]
+diff_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["FLUTC"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [100, 120, 140, 160, 180, 200, 220, 240, 260, 280, 300, 320]
+diff_levels = [-35, -30, -25, -20, -15, -10, -5, -2.5, 2.5, 5, 10, 15, 20, 25, 30, 35]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["FSNTOA"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 25, 50, 75, 100, 125, 150, 175, 200, 240, 280, 320, 360, 400, 440]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["FSNTOAC"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["SWCF"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [-180, -160, -140, -120, -100, -80, -60, -40, -20,  0]
+diff_levels = [-60, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 60]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["LWCF"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 10, 20, 30, 40, 50, 60, 70, 80]
+diff_levels = [-35, -30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30, 35]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-TOA-v4.1"
+variables = ["NETCF"]
+ref_name = "ceres_ebaf_toa_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [-70, -60, -50, -40, -30, -20, -10, 0, 10, 20]
+diff_levels = [-60, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 60]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["ALBEDO_SRF"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75]
+diff_levels = [-0.25, -0.2, -0.15, -0.1, -0.07, -0.05, -0.02, 0.02, 0.05, 0.07, 0.1, 0.15, 0.2, 0.25]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["SWCFSRF"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [-170, -150, -135, -120, -105, -90, -75, -60, -45, -30, -15, 0, 15, 30, 45]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["LWCFSRF"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 10, 20, 30, 40, 50, 60, 70, 80]
+diff_levels = [-35, -30, -25, -20, -15, -10, -5, 5, 10, 15, 20, 25, 30, 35]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["NETCF_SRF"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [-135, -120, -105, -90, -75, -60, -45, -30, -15, 0, 15, 30, 45]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FLDS"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FLDSC"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FLNS"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 20, 40, 60, 80, 100, 120, 140, 160]
+diff_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FLNSC"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 20, 40, 60, 80, 100, 120, 140, 160]
+diff_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FSDS"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FSDSC"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FSNS"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "CERES-EBAF-surface-v4.1"
+variables = ["FSNSC"]
+ref_name = "ceres_ebaf_surface_v4.1"
+reference_name = "CERES-EBAF v4.1"
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "ERA-Interim"
+variables = ["LHFLX"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+contour_levels = [0,5, 15, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300]
+diff_levels = [-150, -120, -90, -60, -30, -20, -10, -5, 5, 10, 20, 30, 60, 90, 120, 150]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "ERA-Interim"
+variables = ["SHFLX"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+contour_levels = [-100, -75, -50, -25, -10, 0, 10, 25, 50, 75, 100, 125, 150]
+diff_levels = [-100, -80, -60, -40, -20, -10, -5, 5, 10, 20, 40, 60, 80, 100]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "ERA-Interim"
+variables = ["PSL"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+contour_levels = [955, 965, 975,980, 985, 990, 995, 1000, 1005, 1010, 1015, 1020, 1025, 1035]
+diff_levels = [ -16, -12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12, 16]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "ERA-Interim"
+variables = ["PRECT"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "ERA-Interim"
+variables = ["TMQ"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+contour_levels = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
+diff_levels = [-12, -9, -6, -4, -3, -2, -1, 1, 2, 3, 4, 6, 9, 12]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "MERRA2"
+variables = ["LHFLX"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+contour_levels = [0,5, 15, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300]
+diff_levels = [-150, -120, -90, -60, -30, -20, -10, -5, 5, 10, 20, 30, 60, 90, 120, 150]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "MERRA2"
+variables = ["SHFLX"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+contour_levels = [-100, -75, -50, -25, -10, 0, 10, 25, 50, 75, 100, 125, 150]
+diff_levels = [-100, -80, -60, -40, -20, -10, -5, 5, 10, 20, 40, 60, 80, 100]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "MERRA2"
+variables = ["PSL"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+contour_levels = [955, 965, 975,980, 985, 990, 995, 1000, 1005, 1010, 1015, 1020, 1025, 1035]
+diff_levels = [ -16, -12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12, 16]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "MERRA2"
+variables = ["PRECT"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "MERRA2"
+variables = ["TMQ"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+contour_levels = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
+diff_levels = [-12, -9, -6, -4, -3, -2, -1, 1, 2, 3, 4, 6, 9, 12]
+
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "AOD_550"
+variables = ["AODVIS"]
+ref_name = "AOD_550"
+reference_name = "AERONET-composite AOD"
+test_colormap = "Oranges"
+reference_colormap = "Oranges"
+diff_colormap = "BrBG_r"
+contour_levels = [0., 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]
+diff_levels = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, -0.02, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "ERA-Interim"
+variables = ["TREFHT"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 5, 10, 15]
+
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "MERRA2"
+variables = ["TREFHT"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 5, 10, 15]
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "GPCP_OAFLux"
+variables = ["PminusE"]
+ref_name = "GPCP_OAFLux"
+reference_name = "PRECT(GPCP) minus QFLX(OAFLux)"
+test_colormap = "RdBu"
+reference_colormap = "RdBu"
+diff_colormap = "RdBu"
+contour_levels = [-16, -11, -7, -4,-2,-1,1,2,4,7,11,16]
+diff_levels = [-10, -7, -4, -2, -1,-0.5,0.5, 1, 2, 4, 7, 10]
+
+[#]
+sets = ["annual_cycle_zonal_mean"]
+case_id = "COREv2_Flux"
+variables = ["PminusE"]
+ref_name = "COREv2_Flux"
+reference_name = "COREv2_Flux"
+test_colormap = "RdBu"
+reference_colormap = "RdBu"
+diff_colormap = "RdBu"
+contour_levels = [-16, -11, -7, -4,-2,-1,1,2,4,7,11,16]
+diff_levels = [-10, -7, -4, -2, -1,-0.5,0.5, 1, 2, 4, 7, 10]

--- a/acme_diags/parameter/__init__.py
+++ b/acme_diags/parameter/__init__.py
@@ -1,3 +1,4 @@
+from .annual_cycle_zonal_mean_parameter import ACzonalmeanParameter
 from .area_mean_time_series_parameter import AreaMeanTimeSeriesParameter
 from .arm_diags_parameter import ARMDiagsParameter
 from .core_parameter import CoreParameter
@@ -23,4 +24,5 @@ SET_TO_PARAMETERS = {
     "diurnal_cycle": DiurnalCycleParameter,
     "arm_diags": ARMDiagsParameter,
     "tc_analysis": TCAnalysisParameter,
+    "annual_cycle_zonal_mean": ACzonalmeanParameter,
 }

--- a/acme_diags/parameter/annual_cycle_zonal_mean_parameter.py
+++ b/acme_diags/parameter/annual_cycle_zonal_mean_parameter.py
@@ -1,0 +1,8 @@
+from .core_parameter import CoreParameter
+
+
+class ACzonalmeanParameter(CoreParameter):
+    def __init__(self):
+        super(ACzonalmeanParameter, self).__init__()
+        # A list of the reference names to run the diags on.
+        self.granulate.remove("seasons")

--- a/acme_diags/parameter/core_parameter.py
+++ b/acme_diags/parameter/core_parameter.py
@@ -26,6 +26,7 @@ class CoreParameter(cdp.cdp_parameter.CDPParameter):
             "diurnal_cycle",
             "arm_diags",
             "tc_analysis",
+            "annual_cycle_zonal_mean",
         ]
         self.dataset = ""
         self.run_type = "model_vs_obs"

--- a/acme_diags/parser/__init__.py
+++ b/acme_diags/parser/__init__.py
@@ -23,4 +23,5 @@ SET_TO_PARSER = {
     "diurnal_cycle": DiurnalCycleParser,
     "arm_diags": ARMDiagsParser,
     "tc_analysis": TCAnalysisParser,
+    "annual_cycle_zonal_mean": CoreParser,
 }

--- a/acme_diags/plot/__init__.py
+++ b/acme_diags/plot/__init__.py
@@ -30,8 +30,10 @@ def _get_plot_fcn(backend, set_name):
 
 
 def plot(set_name, ref, test, diff, metrics_dict, parameter):
-    """Based on set_name and parameter.backend,
-    call the correct plotting function."""
+    """Based on set_name and parameter.backend, call the correct plotting function.
+
+    #TODO: Make metrics_dict a kwarg and update the other plot() functions
+    """
     if hasattr(parameter, "plot"):
         parameter.plot(ref, test, diff, metrics_dict, parameter)
     else:

--- a/acme_diags/plot/cartopy/annual_cycle_zonal_mean_plot.py
+++ b/acme_diags/plot/cartopy/annual_cycle_zonal_mean_plot.py
@@ -41,7 +41,6 @@ def plot_panel(n, fig, var, clevels, cmap, title, parameters, stats=None):
 
     mon = var.getTime()
     lat = var.getLatitude()
-    # var = ma.squeeze(var.asma())
     var = np.transpose(var)
 
     # Contour levels
@@ -70,8 +69,7 @@ def plot_panel(n, fig, var, clevels, cmap, title, parameters, stats=None):
         ax.set_title(title[1], fontdict=plotTitle)
     if title[2] is not None:
         ax.set_title(title[2], loc="right", fontdict=plotSideTitle)
-    # ax.set_xticks(xticks, crs=ccrs.PlateCarree())
-    # ax.set_yticks(yticks, crs=ccrs.PlateCarree())
+
     mon_xticks = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"]
     plt.xticks(mon, mon_xticks)
     lat_formatter = LatitudeFormatter()
@@ -106,8 +104,6 @@ def plot_panel(n, fig, var, clevels, cmap, title, parameters, stats=None):
 
 
 def plot(reference, test, diff, metrics_dict, parameter):
-
-    # Create figure, projection
     fig = plt.figure(figsize=parameter.figsize, dpi=parameter.dpi)
 
     plot_panel(
@@ -130,7 +126,6 @@ def plot(reference, test, diff, metrics_dict, parameter):
         parameter,
     )
 
-    # Third panel
     plot_panel(
         2,
         fig,
@@ -141,7 +136,6 @@ def plot(reference, test, diff, metrics_dict, parameter):
         parameter,
     )
 
-    # Figure title
     fig.suptitle(parameter.main_title, x=0.5, y=0.96, fontsize=18)
 
     # Save figure

--- a/acme_diags/plot/cartopy/annual_cycle_zonal_mean_plot.py
+++ b/acme_diags/plot/cartopy/annual_cycle_zonal_mean_plot.py
@@ -1,0 +1,191 @@
+from __future__ import print_function
+
+import os
+
+import matplotlib
+import numpy as np
+from cartopy.mpl.ticker import LatitudeFormatter
+
+from acme_diags.driver.utils.general import get_output_dir
+from acme_diags.plot import get_colormap
+
+matplotlib.use("Agg")
+import matplotlib.colors as colors  # isort:skip  # noqa: E402
+import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
+
+
+plotTitle = {"fontsize": 11.5}
+plotSideTitle = {"fontsize": 9.5}
+
+# Position and sizes of subplot axes in page coordinates (0 to 1)
+panel = [
+    (0.1691, 0.6810, 0.6465, 0.2258),
+    (0.1691, 0.3961, 0.6465, 0.2258),
+    (0.1691, 0.1112, 0.6465, 0.2258),
+]
+
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+border = (-0.06, -0.03, 0.13, 0.03)
+
+
+def get_ax_size(fig, ax):
+    bbox = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
+    width, height = bbox.width, bbox.height
+    width *= fig.dpi
+    height *= fig.dpi
+    return width, height
+
+
+def plot_panel(n, fig, var, clevels, cmap, title, parameters, stats=None):
+
+    mon = var.getTime()
+    lat = var.getLatitude()
+    # var = ma.squeeze(var.asma())
+    var = np.transpose(var)
+
+    # Contour levels
+    levels = None
+    norm = None
+    if len(clevels) > 0:
+        levels = [-1.0e8] + clevels + [1.0e8]
+        norm = colors.BoundaryNorm(boundaries=levels, ncolors=256)
+
+    # Contour plot
+    ax = fig.add_axes(panel[n])
+    cmap = get_colormap(cmap, parameters)
+    p1 = ax.contourf(
+        mon,
+        lat,
+        var,
+        norm=norm,
+        levels=levels,
+        cmap=cmap,
+        extend="both",
+    )
+
+    if title[0] is not None:
+        ax.set_title(title[0], loc="left", fontdict=plotSideTitle)
+    if title[1] is not None:
+        ax.set_title(title[1], fontdict=plotTitle)
+    if title[2] is not None:
+        ax.set_title(title[2], loc="right", fontdict=plotSideTitle)
+    # ax.set_xticks(xticks, crs=ccrs.PlateCarree())
+    # ax.set_yticks(yticks, crs=ccrs.PlateCarree())
+    mon_xticks = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"]
+    plt.xticks(mon, mon_xticks)
+    lat_formatter = LatitudeFormatter()
+    ax.yaxis.set_major_formatter(lat_formatter)
+    ax.tick_params(labelsize=8.0, direction="out", width=1)
+    ax.xaxis.set_ticks_position("bottom")
+    ax.yaxis.set_ticks_position("left")
+
+    # Color bar
+    cbax = fig.add_axes((panel[n][0] + 0.6635, panel[n][1] + 0.0215, 0.0326, 0.1792))
+    cbar = fig.colorbar(p1, cax=cbax)
+    w, h = get_ax_size(fig, cbax)
+
+    if levels is None:
+        cbar.ax.tick_params(labelsize=9.0, length=0)
+
+    else:
+        maxval = np.amax(np.absolute(levels[1:-1]))
+        if maxval < 10.0:
+            fmt = "%5.2f"
+            pad = 25
+        elif maxval < 100.0:
+            fmt = "%5.1f"
+            pad = 25
+        else:
+            fmt = "%6.1f"
+            pad = 30
+        cbar.set_ticks(levels[1:-1])
+        labels = [fmt % level for level in levels[1:-1]]
+        cbar.ax.set_yticklabels(labels, ha="right")
+        cbar.ax.tick_params(labelsize=9.0, pad=pad, length=0)
+
+
+def plot(reference, test, diff, metrics_dict, parameter):
+
+    # Create figure, projection
+    fig = plt.figure(figsize=parameter.figsize, dpi=parameter.dpi)
+
+    plot_panel(
+        0,
+        fig,
+        test,
+        parameter.contour_levels,
+        parameter.test_colormap,
+        (parameter.test_name_yrs, parameter.test_title, test.units),
+        parameter,
+    )
+
+    plot_panel(
+        1,
+        fig,
+        reference,
+        parameter.contour_levels,
+        parameter.reference_colormap,
+        (parameter.ref_name_yrs, parameter.reference_title, reference.units),
+        parameter,
+    )
+
+    # Third panel
+    plot_panel(
+        2,
+        fig,
+        diff,
+        parameter.diff_levels,
+        parameter.diff_colormap,
+        (None, parameter.diff_title, None),
+        parameter,
+    )
+
+    # Figure title
+    fig.suptitle(parameter.main_title, x=0.5, y=0.96, fontsize=18)
+
+    # Save figure
+    for f in parameter.output_format:
+        f = f.lower().split(".")[-1]
+        fnm = os.path.join(
+            get_output_dir(parameter.current_set, parameter),
+            parameter.output_file + "." + f,
+        )
+        plt.savefig(fnm)
+        # Get the filename that the user has passed in and display that.
+        # When running in a container, the paths are modified.
+        fnm = os.path.join(
+            get_output_dir(parameter.current_set, parameter, ignore_container=True),
+            parameter.output_file + "." + f,
+        )
+        print("Plot saved in: " + fnm)
+
+    # Save individual subplots
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(
+            get_output_dir(parameter.current_set, parameter),
+            parameter.output_file,
+        )
+        page = fig.get_size_inches()
+        i = 0
+        for p in panel:
+            # Extent of subplot
+            subpage = np.array(p).reshape(2, 2)
+            subpage[1, :] = subpage[0, :] + subpage[1, :]
+            subpage = subpage + np.array(border).reshape(2, 2)
+            subpage = list(((subpage) * page).flatten())
+            extent = matplotlib.transforms.Bbox.from_extents(*subpage)
+            # Save subplot
+            fname = fnm + ".%i." % (i) + f
+            plt.savefig(fname, bbox_inches=extent)
+
+            orig_fnm = os.path.join(
+                get_output_dir(parameter.current_set, parameter, ignore_container=True),
+                parameter.output_file,
+            )
+            fname = orig_fnm + ".%i." % (i) + f
+            print("Sub-plot saved in: " + fname)
+
+            i += 1
+
+    plt.close()

--- a/acme_diags/viewer/annual_cycle_zonal_mean_viewer.py
+++ b/acme_diags/viewer/annual_cycle_zonal_mean_viewer.py
@@ -8,18 +8,15 @@ from .utils import add_header, h1_to_h3
 
 def create_viewer(root_dir, parameters):
     """
-    Given a set of parameters for a the diff_diags set,
-    create a single webpage.
+    Given a set of parameters for a the diff_diags set, create a single webpage.
 
     Return the title and url for this page.
     """
     viewer = OutputViewer(path=root_dir)
-
-    # The name that's displayed on the viewer.
     display_name = "Annual Cycle Zonal Mean Contour Plots"
     set_name = "annual_cycle_zonal_mean"
-    # The title of the colums on the webpage.
     cols = ["Description", "Plot"]
+
     viewer.add_page(display_name, short_name=set_name, columns=cols)
     viewer.add_group("Variable")
 

--- a/acme_diags/viewer/annual_cycle_zonal_mean_viewer.py
+++ b/acme_diags/viewer/annual_cycle_zonal_mean_viewer.py
@@ -1,0 +1,46 @@
+import os
+
+from cdp.cdp_viewer import OutputViewer
+
+from .default_viewer import create_metadata
+from .utils import add_header, h1_to_h3
+
+
+def create_viewer(root_dir, parameters):
+    """
+    Given a set of parameters for a the diff_diags set,
+    create a single webpage.
+
+    Return the title and url for this page.
+    """
+    viewer = OutputViewer(path=root_dir)
+
+    # The name that's displayed on the viewer.
+    display_name = "Annual Cycle Zonal Mean Contour Plots"
+    set_name = "annual_cycle_zonal_mean"
+    # The title of the colums on the webpage.
+    cols = ["Description", "Plot"]
+    viewer.add_page(display_name, short_name=set_name, columns=cols)
+    viewer.add_group("Variable")
+
+    for param in parameters:
+        for var in param.variables:
+            viewer.add_row("{} {}".format(var, param.ref_name))
+            # Adding the description for this var to the current row.
+            # This was obtained and stored in the driver for this plotset.
+            viewer.add_col(param.viewer_descr[var])
+
+            file_name = "{}-{}-{}.png".format(param.ref_name, var, "Annual-Cycle")
+            # We need to make sure we have relative paths, and not absolute ones.
+            # This is why we don't use get_output_dir() as in the plotting script
+            # to get the file name.
+            file_name = os.path.join("..", set_name, param.case_id, file_name)
+            viewer.add_col(
+                file_name, is_file=True, title="Plot", meta=create_metadata(param)
+            )
+
+    url = viewer.generate_page()
+    add_header(root_dir, os.path.join(root_dir, url), parameters)
+    h1_to_h3(os.path.join(root_dir, url))
+
+    return display_name, url

--- a/acme_diags/viewer/main.py
+++ b/acme_diags/viewer/main.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 import acme_diags
 
 from . import (
+    annual_cycle_zonal_mean_viewer,
     area_mean_time_series_viewer,
     arm_diags_viewer,
     default_viewer,
@@ -33,6 +34,7 @@ SET_TO_VIEWER = {
     "diurnal_cycle": default_viewer.create_viewer,
     "arm_diags": arm_diags_viewer.create_viewer,
     "tc_analysis": tc_analysis_viewer.create_viewer,
+    "annual_cycle_zonal_mean": annual_cycle_zonal_mean_viewer.create_viewer,
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ arm_diags_files = get_all_files_in_dir("acme_diags/driver/default_diags", "arm_d
 tc_analysis_files = get_all_files_in_dir(
     "acme_diags/driver/default_diags", "tc_analysis_*"
 )
+annual_cycle_zonal_mean_files = get_all_files_in_dir(
+    "acme_diags/driver/default_diags", "annual_cycle_zonal_mean_*"
+)
 rgb_files = get_all_files_in_dir("acme_diags/plot/colormaps", "*.rgb")
 control_runs_files = get_all_files_in_dir("acme_diags/driver/control_runs", "*.csv")
 
@@ -86,6 +89,10 @@ data_files = [
     (os.path.join(INSTALL_PATH, "diurnal_cycle"), diurnal_cycle_files),
     (os.path.join(INSTALL_PATH, "arm_diags"), arm_diags_files),
     (os.path.join(INSTALL_PATH, "tc_analysis"), tc_analysis_files),
+    (
+        os.path.join(INSTALL_PATH, "annual_cycle_zonal_mean"),
+        annual_cycle_zonal_mean_files,
+    ),
     (
         INSTALL_PATH,
         [

--- a/tests/acme_diags/derivations/test_acme.py
+++ b/tests/acme_diags/derivations/test_acme.py
@@ -89,17 +89,53 @@ class TestDetermineTau(TestCase):
         self.mock_file_axis: "FileAxis" = Mock()
         self.mock_file_axis.getData.return_value = np.arange(0, 1002)
 
-    def test_low_none(self):
-        actual = determine_tau(self.mock_file_axis, None, 10)
-        expected = "tau <10"
-        self.assertEqual(actual, expected)
+        # Need to mock __getitem__ in order to provide list value
+        self.mock_file_axis.__getitem__ = Mock()
+        self.mock_file_axis.__getitem__.side_effect = [0, 10]
 
-    def test_high_none(self):
-        actual = determine_tau(self.mock_file_axis, 5, None)
-        expected = "5< tau"
-        self.assertEqual(actual, expected)
+    def test_low_arg_only(self):
+        expected_high = 10
+        expected_low = 5
+        expected_lim = "tau >5"
 
-    def test_low_high(self):
-        actual = determine_tau(self.mock_file_axis, 5, 10)
-        expected = "5< tau < 10"
-        self.assertEqual(actual, expected)
+        actual_high, actual_low, actual_lim = determine_tau(
+            self.mock_file_axis, 5, None
+        )
+        self.assertEqual(actual_high, expected_high)
+        self.assertEqual(actual_low, expected_low)
+        self.assertEqual(actual_lim, expected_lim)
+
+    def test_high_arg_only(self):
+        expected_high = 10
+        expected_low = 0
+        expected_lim = "tau <10"
+
+        actual_high, actual_low, actual_lim = determine_tau(
+            self.mock_file_axis, None, 10
+        )
+
+        self.assertEqual(actual_high, expected_high)
+        self.assertEqual(actual_low, expected_low)
+        self.assertEqual(actual_lim, expected_lim)
+
+    def test_low_and_high_args(self):
+        expected_high = 10
+        expected_low = 5
+        expected_lim = "5< tau < 10"
+
+        actual_high, actual_low, actual_lim = determine_tau(self.mock_file_axis, 5, 10)
+        self.assertEqual(actual_high, expected_high)
+        self.assertEqual(actual_low, expected_low)
+        self.assertEqual(actual_lim, expected_lim)
+
+    def test_no_args(self):
+        expected_high = 10
+        expected_low = 0
+        expected_lim = "0< tau < 10"
+
+        actual_high, actual_low, actual_lim = determine_tau(
+            self.mock_file_axis, None, None
+        )
+        self.assertEqual(actual_high, expected_high)
+        self.assertEqual(actual_low, expected_low)
+        self.assertEqual(actual_lim, expected_lim)

--- a/tests/acme_diags/drivers/test_annual_cycle_zonal_mean_driver.py
+++ b/tests/acme_diags/drivers/test_annual_cycle_zonal_mean_driver.py
@@ -1,0 +1,51 @@
+from unittest.case import TestCase
+from unittest.mock import Mock
+
+import numpy as np
+from cdms2.axis import TransientAxis
+from cdms2.tvariable import TransientVariable
+
+from acme_diags.driver.annual_cycle_zonal_mean_driver import _create_annual_cycle
+
+
+class TestCreateAnnualCycle(TestCase):
+    def test_returns_annual_cycle_for_a_dataset_variable(self):
+        # Mock a Dataset object and get_climo_variable()
+        dataset_mock = Mock()
+        dataset_mock.get_climo_variable.return_value = TransientVariable(
+            data=np.zeros((2, 2)),
+            attributes={"id": "PRECNT", "long_name": "long_name", "units": "units"},
+            axes=[
+                TransientAxis(np.zeros(2), id="latitude"),
+                TransientAxis(np.zeros(2), id="longitude"),
+            ],
+        )
+
+        # Generate expected and result
+        expected = TransientVariable(
+            data=np.zeros((12, 2, 2)),
+            attributes={"id": "PRECNT", "long_name": "long_name", "units": "units"},
+            axes=[
+                TransientAxis(
+                    np.arange(1, 13),
+                    id="time",
+                    attributes={"axis": "T", "calendar": "gregorian"},
+                ),
+                TransientAxis(np.zeros(2), id="latitude"),
+                TransientAxis(np.zeros(2), id="longitude"),
+            ],
+        )
+        result = _create_annual_cycle(dataset_mock, variable="PRECNT")
+
+        # Check data are equal
+        np.array_equal(result.data, expected.data)
+
+        # Check attributes are equal. Must delete "name" attribute since they differ.
+        result.deleteattribute("name")
+        expected.deleteattribute("name")
+        self.assertDictEqual(result.attributes, expected.attributes)
+
+        # Check time, latitude, and longitude axes are equal
+        np.array_equal(result.getAxis(0)[:], expected.getAxis(0)[:])
+        np.array_equal(result.getLatitude()[:], expected.getLatitude()[:])
+        np.array_equal(result.getLongitude()[:], expected.getLongitude()[:])


### PR DESCRIPTION
This PR adds annual cycle zonal mean contour plots requested by #395 
Note that variables included in this set are a subset of standard variables from lat-lon set. The column integrated ozone quantities will be calculated online during a model run. They will be later added to the standard .cfg files.
