### PR TITLE
v2.5.0rc2 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM continuumio/miniconda3:4.6.14
 
 LABEL maintainer="zhang40@llnl.gov"
-LABEL version="2.5.0rc1"
+LABEL version="2.5.0rc2"
 
 # Copy the entire project dir because we'll install from source.
 COPY . .

--- a/acme_diags/__init__.py
+++ b/acme_diags/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-__version__ = "v2.5.0rc1"
+__version__ = "v2.5.0rc2"
 INSTALL_PATH = os.path.join(sys.prefix, "share/e3sm_diags/")
 
 # Disable MPI in cdms2, which is not currently supported by E3SM-unified

--- a/conda/e3sm_diags_env.yml
+++ b/conda/e3sm_diags_env.yml
@@ -20,5 +20,5 @@ dependencies:
   - netcdf4=1.5.6
   # Additional
   # ==============
-  - e3sm_diags=2.5.0rc1
+  - e3sm_diags=2.5.0rc2
 prefix: /opt/miniconda3/envs/e3sm_diags_env

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "e3sm_diags" %}
-{% set version = "2.5.0rc1" %}
+{% set version = "2.5.0rc2" %}
 
 package:
     name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ data_files = [
 
 setup(
     name="e3sm_diags",
-    version="2.5.0rc1",
+    version="2.5.0rc2",
     author="Chengzhu (Jill) Zhang, Tom Vo, Ryan Forsyth, Chris Golaz and Zeshawn Shaheen",
     author_email="zhang40@llnl.gov",
     description="E3SM Diagnostics",


### PR DESCRIPTION
Update to `v2.5.0rc2`. #462 will be merged, then this will be merged, then https://github.com/E3SM-Project/e3sm_diags/releases will be updated to include `v2.5.0rc2`.