### PR TITLE
Stop tests if unit tests fail

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,5 +1,7 @@
 # Run this script from the top level directory of the repository.
 
+set -e # Fail if any line fails
+
 # Uncomment if you want to remove the results directory from the previous test run.
 #rm -rf tests/system/all_sets_results_test/
 


### PR DESCRIPTION
Currently, if a unit test fails, then the integration tests still run, meaning the return value of running the test script is still 0 (i.e., success). This change will fail the script if the unit tests fail.