### PR TITLE
Add CDMS_NO_MPI env variable

### DIFF
--- a/acme_diags/__init__.py
+++ b/acme_diags/__init__.py
@@ -3,3 +3,15 @@ import sys
 
 __version__ = "v2.5.0rc1"
 INSTALL_PATH = os.path.join(sys.prefix, "share/e3sm_diags/")
+
+# Disable MPI in cdms2, which is not currently supported by E3SM-unified
+os.environ["CDMS_NO_MPI"] = "True"
+# Must be done before any CDAT library is called.
+os.environ["UVCDAT_ANONYMOUS_LOG"] = "no"
+os.environ["CDAT_ANONYMOUS_LOG"] = "no"
+# Needed for when using hdf5 >= 1.10.0,
+# without this, errors are thrown on Edison compute nodes.
+os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+# Used by numpy, causes too many threads to spawn otherwise.
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["OMP_NUM_THREADS"] = "1"

--- a/acme_diags/acme_diags_driver.py
+++ b/acme_diags/acme_diags_driver.py
@@ -1,24 +1,13 @@
 #!/usr/bin/env python
 from __future__ import print_function
-from typing import Dict, Tuple
-import os
-
-# Must be done before any CDAT library is called.
-os.environ["UVCDAT_ANONYMOUS_LOG"] = "no"
-os.environ["CDAT_ANONYMOUS_LOG"] = "no"
-# Needed for when using hdf5 >= 1.10.0,
-# without this, errors are thrown on Edison compute nodes.
-os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
-# Used by numpy, causes too many threads to spawn otherwise.
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
-os.environ["OMP_NUM_THREADS"] = "1"
 
 import importlib
+import os
 import subprocess
 import sys
 import traceback
+from typing import Dict, Tuple
 
-import cdms2.tvariable
 import cdp.cdp_run
 
 import acme_diags
@@ -27,9 +16,6 @@ from acme_diags.parameter.core_parameter import CoreParameter
 from acme_diags.parser import SET_TO_PARSER
 from acme_diags.parser.core_parser import CoreParser
 from acme_diags.viewer.main import create_viewer
-
-# turn off MPI in cdms2 -- not currently supported by e3sm_diags
-cdms2.tvariable.HAVE_MPI = False
 
 
 def get_default_diags_path(set_name, run_type, print_path=True):

--- a/acme_diags/acme_diags_vars.py
+++ b/acme_diags/acme_diags_vars.py
@@ -10,15 +10,11 @@ import os
 from typing import Any, Dict, List
 
 import cdms2
-import cdms2.tvariable
 
 import acme_diags
 from acme_diags.acme_diags_driver import get_parameters
 from acme_diags.derivations.acme import derived_variables
 from acme_diags.parser.core_parser import CoreParser
-
-# turn off MPI in cdms2 -- not currently supported by e3sm_diags
-cdms2.tvariable.HAVE_MPI = False
 
 
 def main():

--- a/analysis_data_preprocess/create_OAFLUX_climo.py
+++ b/analysis_data_preprocess/create_OAFLUX_climo.py
@@ -295,25 +295,19 @@ for fi in fisc:
             if ji == "shtfl":
                 outputdattable.id = "SHFLX"
                 outputdattable.units = "W m-2"
-                outputdattable.standard_name = (
-                    "surface_upward_sensible_heat_flux"
-                )
+                outputdattable.standard_name = "surface_upward_sensible_heat_flux"
                 # print ji,' modified'
             if ji == "lhtfl":
                 outputdattable.id = "LHFLX"
                 outputdattable.units = "W m-2"
-                outputdattable.standard_name = (
-                    "surface_upward_latent_heat_flux"
-                )
+                outputdattable.standard_name = "surface_upward_latent_heat_flux"
                 # print ji,' modified'
             f_out.write(outputdattable)
 
     time_axis = f_out.getAxis("time")
     bnds_axis = f_out.getAxis("bound")
     climatology = None
-    climo_start = "".join(
-        [startyear, clim_edges[clim_edge_values[f_index, 0]]]
-    )
+    climo_start = "".join([startyear, clim_edges[clim_edge_values[f_index, 0]]])
     climo_end = "".join([endyear, clim_edges[clim_edge_values[f_index, 1]]])
     # climatology_bnds_value={climo_start, climo_end}
 
@@ -402,9 +396,7 @@ for fi in fisc:
         shell=True,
     )
     call(
-        "".join(
-            ["ncatted -a _FillValue,'^bounds',d,, ", output_hostANDfilename]
-        ),
+        "".join(["ncatted -a _FillValue,'^bounds',d,, ", output_hostANDfilename]),
         shell=True,
     )
     call(

--- a/analysis_data_preprocess/create_PminusE_GPCP-OAFlux_timeseries.py
+++ b/analysis_data_preprocess/create_PminusE_GPCP-OAFlux_timeseries.py
@@ -29,9 +29,7 @@ qflux = fin2("QFLX", time=("1979-01-15", "2013-12-15", "ccb"))
 # print(prect.getTime().asComponentTime())
 # print(qflux.getTime().asComponentTime())
 
-qflux_reg = qflux.regrid(
-    prect.getGrid(), regridTool="esmf", regridMethod="linear"
-)
+qflux_reg = qflux.regrid(prect.getGrid(), regridTool="esmf", regridMethod="linear")
 
 PminusE = prect / 24.0 / 3600.0 - qflux_reg  # conver to kg/m2/s
 PminusE.setAxis(0, prect.getTime())
@@ -51,7 +49,9 @@ delattr(PminusE, "dataset")
 delattr(PminusE, "var_desc")
 delattr(PminusE, "valid_range")
 
-output_path = "/p/user_pub/e3sm/zhang40/analysis_data_e3sm_diags/GPCP_OAFLux/time_series/"
+output_path = (
+    "/p/user_pub/e3sm/zhang40/analysis_data_e3sm_diags/GPCP_OAFLux/time_series/"
+)
 output_filename = "PminusE_197901_201312.nc"
 fout = cdms2.open(output_path + output_filename, "w")
 fout.write(PminusE)

--- a/analysis_data_preprocess/fix_units_TRMM-3B43v-7_3hr.py
+++ b/analysis_data_preprocess/fix_units_TRMM-3B43v-7_3hr.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 import cdms2
 
-datapath = "/p/user_pub/e3sm/zhang40/analysis_data_e3sm_diags/TRMM/climatology_diurnal_cycle/"
+datapath = (
+    "/p/user_pub/e3sm/zhang40/analysis_data_e3sm_diags/TRMM/climatology_diurnal_cycle/"
+)
 for path in Path(datapath).rglob("*.nc"):
     print(path.name)
     print(path)


### PR DESCRIPTION
This PR adds `os.environ["CDMS_NO_MPI"] = "True"` and existing env vars from `acme_diags_driver.py` to `acme_diags/__init__.py`.

- Closes #465, Closes #324 
- Related to https://github.com/conda-forge/cdms2-feedstock/commit/d82ae7aeb62586f99fb85aee6d4b0a7bfa21ac4c
- Merged in `v2.5.0rc2`

