### PR TITLE
Update dependencies in env and recipe

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -9,9 +9,6 @@ on:
 
   workflow_dispatch:
 
-env:
-  UVCDAT_ANONYMOUS_LOG: False
-
 jobs:
   check-jobs-to-skip:
     runs-on: ubuntu-latest
@@ -86,9 +83,9 @@ jobs:
         run: pip install .
 
       - name: Run Tests
-        run: |
-          export CHECK_IMAGES=True
-          bash tests/test.sh
+        env:
+          CHECK_IMAGES: True
+        run: bash tests/test.sh
 
   publish-docs:
     if: ${{ github.event_name == 'push' }}
@@ -124,7 +121,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx==3.5.1 sphinx_rtd_theme==0.5.1 sphinx-multiversion==0.2.4 docutils==0.16
+          pip install sphinx==4.0.2 sphinx_rtd_theme==0.5.2 sphinx-multiversion==0.2.4 docutils==0.16
 
       - name: Build Sphinx Docs
         run: |

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx==3.5.1 sphinx_rtd_theme==0.5.1 sphinx-multiversion==0.2.4 docutils==0.16
+          pip install sphinx==4.0.2 sphinx_rtd_theme==0.5.2 sphinx-multiversion==0.2.4 docutils==0.16
 
       - name: Build Sphinx Docs
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         exclude: conda/meta.yaml
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.5b2
     hooks:
       - id: black
         exclude: analysis_data_preprocess
@@ -25,7 +25,7 @@ repos:
   # Need to use flake8 GitHub mirror due to CentOS git issue with GitLab
   # https://github.com/pre-commit/pre-commit/issues/1206
   - repo: https://github.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
@@ -33,8 +33,8 @@ repos:
         exclude: analysis_data_preprocess
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.812
     hooks:
       - id: mypy
         args: ["--config=setup.cfg"]
-        exclude: analysis_data_preprocess
+        exclude: (analysis_data_preprocess|examples)

--- a/acme_diags/derivations/acme.py
+++ b/acme_diags/derivations/acme.py
@@ -191,7 +191,7 @@ def rstcs(rsdt, rsutcs):
 
 
 def swcfsrf(fsns, fsnsc):
-    """Surface shortwave cloud forcing """
+    """Surface shortwave cloud forcing"""
     var = fsns - fsnsc
     var.long_name = "Surface shortwave cloud forcing"
     return var
@@ -205,42 +205,42 @@ def lwcfsrf(flns, flnsc):
 
 
 def swcf(fsntoa, fsntoac):
-    """TOA shortwave cloud forcing """
+    """TOA shortwave cloud forcing"""
     var = fsntoa - fsntoac
     var.long_name = "TOA shortwave cloud forcing"
     return var
 
 
 def lwcf(flntoa, flntoac):
-    """TOA longwave cloud forcing """
+    """TOA longwave cloud forcing"""
     var = flntoa - flntoac
     var.long_name = "TOA longwave cloud forcing"
     return var
 
 
 def netcf2(swcf, lwcf):
-    """TOA net cloud forcing """
+    """TOA net cloud forcing"""
     var = swcf + lwcf
     var.long_name = "TOA net cloud forcing"
     return var
 
 
 def netcf4(fsntoa, fsntoac, flntoa, flntoac):
-    """TOA net cloud forcing """
+    """TOA net cloud forcing"""
     var = fsntoa - fsntoac + flntoa - flntoac
     var.long_name = "TOA net cloud forcing"
     return var
 
 
 def netcf2srf(swcf, lwcf):
-    """Surface net cloud forcing """
+    """Surface net cloud forcing"""
     var = swcf + lwcf
     var.long_name = "Surface net cloud forcing"
     return var
 
 
 def netcf4srf(fsntoa, fsntoac, flntoa, flntoac):
-    """Surface net cloud forcing """
+    """Surface net cloud forcing"""
     var = fsntoa - fsntoac + flntoa - flntoac
     var.long_name = "Surface net cloud forcing"
     return var

--- a/conda/e3sm_diags_env.yml
+++ b/conda/e3sm_diags_env.yml
@@ -2,22 +2,23 @@ name: e3sm_diags_env
 channels:
   - conda-forge
   - defaults
-  - e3sm
 dependencies:
   # Base
+  # ==============
+  - python>=3.9
+  - pip=21.1.2
+  - numpy=1.20.3
+  - matplotlib=3.4.2
   - beautifulsoup4=4.9.3
-  - cartopy=0.18.0
+  - cartopy=0.19.0
   - cdp=1.7.0
-  - cdms2==3.1.5
+  - cdms2=3.1.5
   - cdtime=3.1.4
   - cdutil=8.2.1
   - genutil=8.2.1
-  - lxml=4.6.2
-  - matplotlib=3.3.4
+  - lxml=4.6.3
   - netcdf4=1.5.6
-  - numpy=1.20.1
-  - pip=21.0.1
-  - python=3.7.10
   # Additional
+  # ==============
   - e3sm_diags=2.5.0rc1
 prefix: /opt/miniconda3/envs/e3sm_diags_env

--- a/conda/e3sm_diags_env_dev.yml
+++ b/conda/e3sm_diags_env_dev.yml
@@ -4,38 +4,42 @@ channels:
   - defaults
 dependencies:
   # Base
+  # =================
+  - python>=3.9
+  - pip=21.1.2
+  - numpy=1.20.3
+  - matplotlib=3.4.2
   - beautifulsoup4=4.9.3
-  - cartopy=0.18.0
+  - cartopy=0.19.0
   - cdp=1.7.0
   - cdms2=3.1.5
   - cdtime=3.1.4
   - cdutil=8.2.1
   - genutil=8.2.1
-  - lxml=4.6.2
-  - matplotlib=3.3.4
+  - lxml=4.6.3
   - netcdf4=1.5.6
-  - numpy=1.20.1
-  - pip=21.0.1
-  - python=3.7.10
-  # Developer Tools
+  # Quality Assurance
+  # =================
   # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`
-  - black=20.8b1
-  - flake8=3.8.4
+  - black=21.5b2
+  - flake8=3.9.2
   - flake8-isort=4.0.0
-  - mypy=0.790
-  - pre-commit=2.10.1
+  - mypy=0.812
+  - pre-commit=2.13.0
   # Testing
+  # =================
   - dask
   - scipy
   # Documentation
-  - sphinx=3.5.1
-  - sphinx_rtd_theme=0.5.1
+  # =================
+  - sphinx=4.0.2
+  - sphinx_rtd_theme=0.5.2
   # Need to pin docutils because 0.17 has a bug with unordered lists
   # https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
   - docutils=0.16
-  ## Used when converting Jupyter notebooks to import to Sphinx
+  # Used when converting Jupyter notebooks to import to Sphinx
   - nbconvert=6.0.7
-  - pandoc=2.11.4
+  - pandoc=2.14
   - pip:
       - sphinx-multiversion==0.2.4
 prefix: /opt/miniconda3/envs/e3sm_diags_env_dev

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - lxml
     - dask
     - scipy
-    - output_viewer >=1.3.1
+    - output_viewer >=1.3.3
 
 about:
     home: https://github.com/E3SM-Project/e3sm_diags

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -118,7 +118,14 @@ an SSL error unless you disable the SSL verification:
         conda config --set ssl_verify false
         binstar config --set ssl_verify False
 
-4. Once conda is properly working, you can install the **(a) Latest Stable Release** or create a **(b) Development Environment**.
+4. Configure Conda channels
+
+    ::
+
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
+
+5. Once conda is properly working, you can install the **(a) Latest Stable Release** or create a **(b) Development Environment**.
 
 .. _install_latest:
 


### PR DESCRIPTION
Closes #469, Closes #470

Summary of Changes
- Use Python 3.9 in conda envs (#470)
- Pinned latest dependencies in env (#470)
- Update `output_viewer` in conda recipe to >=1.3.3 (#469)