### PR TITLE
Get tests passing for rc2

### DIFF
--- a/conda/e3sm_diags_env.yml
+++ b/conda/e3sm_diags_env.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # Base
   # ==============
-  - python>=3.9
+  - python=3.9.4
   - pip=21.1.2
   - numpy=1.20.3
   - matplotlib=3.4.2

--- a/conda/e3sm_diags_env_dev.yml
+++ b/conda/e3sm_diags_env_dev.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # Base
   # =================
-  - python>=3.9
+  - python=3.9.4
   - pip=21.1.2
   - numpy=1.20.3
   - matplotlib=3.4.2

--- a/tests/download_data.py
+++ b/tests/download_data.py
@@ -74,7 +74,7 @@ def download():
     )
     print("Downloading unit_test_images")
     download_files(
-        "https://web.lcrc.anl.gov/public/e3sm/e3sm_diags_test_data",
+        "https://web.lcrc.anl.gov/public/e3sm/e3sm_diags_test_data/system_test/expected",
         "unit_test_images",
     )
     print("Downloaded unit_test_data and unit_test_images")

--- a/tests/system/test_diags.py
+++ b/tests/system/test_diags.py
@@ -56,11 +56,14 @@ def move_to_web(machine_path_re_str, html_prefix_format_str, results_dir):
 
 def count_images(directory):
     images = []
-    for _, _, filenames in os.walk(directory):
-        for file in filenames:
-            if file.endswith(".png"):
-                images.append(file)
-    return len(images)
+    for root, _, filenames in os.walk(directory):
+        # download_data.py won't download files in the viewer directory
+        # because the webpage is more than a simple page of links.
+        if "viewer" not in root:
+            for file in filenames:
+                if file.endswith(".png"):
+                    images.append(file)
+    return len(images), images
 
 
 def compare_images(
@@ -331,8 +334,9 @@ class TestAllSets(unittest.TestCase):
 
     # Test the image count
     def test_image_count(self):
-        actual_num_images = count_images("all_sets_results_test")
-        expected_num_images = count_images("../unit_test_images")
+        actual_num_images, actual_images = count_images("all_sets_results_test")
+        expected_num_images, expected_images = count_images("../unit_test_images")
+        self.assertEqual(actual_images, expected_images)
         self.assertEqual(actual_num_images, expected_num_images)
 
     # Test sets


### PR DESCRIPTION
Get tests passing for `v2.5.0rc2`. Resolves #473. This pull request is based on #472 and should be merged after that one.

Note that this pull request is just to get the tests passing. We still need to:
- Update documentation on updating expected images for `test_diags.py`
- Refactor/restructure testing directories