### PR TITLE
add units to diff plots, etc

### DIFF
--- a/acme_diags/plot/cartopy/enso_diags_plot.py
+++ b/acme_diags/plot/cartopy/enso_diags_plot.py
@@ -284,7 +284,7 @@ def plot_map(
         diff,
         parameter.diff_levels,
         parameter.diff_colormap,
-        (None, parameter.diff_title, None),
+        (None, parameter.diff_title, test.units),
         parameter,
         stats=metrics_dict["diff"],
     )

--- a/acme_diags/plot/cartopy/lat_lon_plot.py
+++ b/acme_diags/plot/cartopy/lat_lon_plot.py
@@ -279,7 +279,7 @@ def plot(reference, test, diff, metrics_dict, parameter):
         diff,
         parameter.diff_levels,
         parameter.diff_colormap,
-        (None, parameter.diff_title, None),
+        (None, parameter.diff_title, test.units),
         parameter,
         stats=(max3, mean3, min3, r, c),
     )

--- a/acme_diags/plot/cartopy/meridional_mean_2d_plot.py
+++ b/acme_diags/plot/cartopy/meridional_mean_2d_plot.py
@@ -217,7 +217,7 @@ def plot(reference, test, diff, metrics_dict, parameter):
         diff,
         parameter.diff_levels,
         parameter.diff_colormap,
-        (None, parameter.diff_title, None),
+        (None, parameter.diff_title, test.units),
         parameter,
         stats=(max3, mean3, min3, r, c),
     )

--- a/acme_diags/plot/cartopy/polar_plot.py
+++ b/acme_diags/plot/cartopy/polar_plot.py
@@ -90,17 +90,12 @@ def plot_panel(n, fig, proj, pole, var, clevels, cmap, title, parameters, stats=
     ax.coastlines(lw=0.3)
 
     # Plot titles
-    for i in range(3):
-        if title[i] is None:
-            title[i] = ""
-
-    t = ax.set_title(
-        "%s\n%s" % (title[0], title[2]), loc="left", fontdict=plotSideTitle
-    )
-
-    t = ax.set_title(title[1], fontdict=plotTitle)
-    if title[0] != "" or title[2] != "":
-        t.set_position([0.5, 1.06])
+    if title[0] is not None:
+        ax.set_title(title[0], loc="left", fontdict=plotSideTitle)
+    if title[1] is not None:
+        ax.set_title(title[1], fontdict=plotTitle)
+    if title[2] is not None:
+        ax.set_title(title[2], loc="right", fontdict=plotSideTitle)
 
     # Color bar
     cbax = fig.add_axes((panel[n][0] + 0.35, panel[n][1] + 0.0354, 0.0326, 0.1792))
@@ -229,7 +224,7 @@ def plot(reference, test, diff, metrics_dict, parameter):
             diff,
             parameter.diff_levels,
             parameter.diff_colormap,
-            [None, parameter.diff_title, None],
+            [None, parameter.diff_title, test.units],
             parameter,
             stats=(max3, mean3, min3, r, c),
         )

--- a/acme_diags/plot/cartopy/qbo_plot.py
+++ b/acme_diags/plot/cartopy/qbo_plot.py
@@ -101,7 +101,7 @@ def plot(period_new, parameter, test, ref):
     x = dict(axis_range=[0, months], axis_scale="linear", data=x_test, label=" ")
     y = dict(axis_range=[100, 1], axis_scale="log", data=y_test, label="hPa")
     z = dict(data=test["qbo"].T[:, :months])
-    title = "{} U 5S-5N ({})".format(test["name"], parameter.test_yrs)
+    title = "{} U [{}] 5S-5N ({})".format(test["name"], "m/s", parameter.test_yrs)
     ax0 = plot_panel(  # noqa
         0,
         fig,
@@ -120,7 +120,7 @@ def plot(period_new, parameter, test, ref):
     x = dict(axis_range=[0, months], axis_scale="linear", data=x_ref, label="month")
     y = dict(axis_range=[100, 1], axis_scale="log", data=y_ref, label="hPa")
     z = dict(data=ref["qbo"].T[:, :months])
-    title = "{} U 5S-5N ({})".format(ref["name"], parameter.ref_yrs)
+    title = "{} U [{}] 5S-5N ({})".format(ref["name"], "m/s", parameter.ref_yrs)
     plot_panel(
         1,
         fig,

--- a/acme_diags/plot/cartopy/zonal_mean_2d_plot.py
+++ b/acme_diags/plot/cartopy/zonal_mean_2d_plot.py
@@ -81,7 +81,9 @@ def plot_panel(n, fig, proj, var, clevels, cmap, title, parameters, stats=None):
     if title[1] is not None:
         ax.set_title(title[1], fontdict=plotTitle)
     if title[2] is not None:
-        ax.set_title(title[2], loc="right", fontdict=plotSideTitle)
+        ax.set_title(
+            title[2], loc="right", fontdict=plotSideTitle
+        )  # loc="right"  doesn't work for polar projection
     # ax.set_xticks([0, 60, 120, 180, 240, 300, 359.99], crs=ccrs.PlateCarree())
     # ax.set_xticks([-180, -120, -60, 0, 60, 120, 180], crs=ccrs.PlateCarree())
     ax.set_xticks([-90, -60, -30, 0, 30, 60, 90])  # , crs=ccrs.PlateCarree())
@@ -217,7 +219,7 @@ def plot(reference, test, diff, metrics_dict, parameter):
         diff,
         parameter.diff_levels,
         parameter.diff_colormap,
-        (None, parameter.diff_title, None),
+        (None, parameter.diff_title, test.units),
         parameter,
         stats=(max3, mean3, min3, r, c),
     )


### PR DESCRIPTION
Add units to diff plots of lat-lon, zonal-mean-2d, meridional-mean-2d. enso-map, polar plots, and QBO pressure-time contour plots. 

Updated images on lcrc for expected integration tests.
Resolves #486 