### PR TITLE
Fix flipped lat of ozone obs

### DIFF
--- a/analysis_data_preprocess/create_OMI-MLS_climo.sh
+++ b/analysis_data_preprocess/create_OMI-MLS_climo.sh
@@ -35,6 +35,9 @@ for yr in {2005..2017}; do      # Loop over years
         mm=`printf "%02d" $mth`
         ncks -O -F -d time,${mth} ${tmp}sco${yyyy}.nc ${tmp}sco_${yyyy}${mm}.nc
         ncks -O -F -d time,${mth} ${tmp}tco${yyyy}.nc ${tmp}OMI-MLS_${yyyy}${mm}.nc
+        # It turned out attaching latidude depended SCO to TCO flipped latitude of TCO
+        # Add ncpdq command to flip SCO lat first
+        ncpdq -O -h -a -lat ${tmp}sco_${yyyy}${mm}.nc ${tmp}sco_${yyyy}${mm}.nc
         ncks -A ${tmp}sco_${yyyy}${mm}.nc ${tmp}OMI-MLS_${yyyy}${mm}.nc
         done
 done


### PR DESCRIPTION
@tangq reported that the TCO obs lat-lon plots seems not physical: 
i.e: misses the minimum over Tibet in JJA for the obs, which is unphysical (The model result has it).

It turns out, the latitude got flipped when SCO (without longitude) file being attached to TCO (with longitude) using ncks. I have a workaround to flip the lat back in re-processing files.

No source code change, the updated data are now on compy, 

- [x] update other machines.