### PR TITLE
Enable ability to manually update docs on `gh-pages`

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -133,14 +133,10 @@ jobs:
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/e3sm_diags.git --branch gh-pages --single-branch gh-pages
 
+          # Only replace master docs with latest changes. Docs for tags should be untouched.
           cd gh-pages
-          rm -r *
-
-          touch .nojekyll
-          # Add index.html to point to `master` branch automatically
-          printf '<meta http-equiv="refresh" content="0; url=./_build/html/master/index.html" />' >> index.html
-
-          cp -r ../docs/_build .
+          rm -r _build/html/master
+          cp -r ../docs/_build/html/master _build/html/master
 
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -50,14 +50,9 @@ jobs:
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/e3sm_diags.git --branch gh-pages --single-branch gh-pages
 
+          # Only copy the current tag release docs (using --no-clobber)
           cd gh-pages
-          rm -r *
-
-          touch .nojekyll
-          # Add index.html to point to `master` branch automatically
-          printf '<meta http-equiv="refresh" content="0; url=./_build/html/master/index.html" />' >> index.html
-
-          cp -r ../docs/_build .
+          cp -r --no-clobber ../docs/_build/html _build/html
 
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,6 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import sphinx_rtd_theme
 
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -166,5 +165,5 @@ texinfo_documents = [
 
 # -- Options sphinx-multiversion -------------------------------------------
 smv_tag_whitelist = r"^v\d+\.\d+.\d+$"  # Include tags like "tags/v2.5.0"
-smv_branch_whitelist = r'^.*$'                # Include all branches
+smv_branch_whitelist = "master"
 smv_remote_whitelist = r"^(origin|upstream)$"  # Use branches from origin


### PR DESCRIPTION
This PR updates the CI/CD workflow to allow developers to update/fix HTML builds for docs on `gh-pages` branch.

- Closes #496 

Summary of changes
- Update build workflow to only purge `master` docs and regenerate them
- Update release workflow to only copy new tag release docs
- Disable building docs for non-`master` branches

