### PR TITLE
Update `publish-docs` job in `release_workflow.yml`

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -50,8 +50,10 @@ jobs:
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/e3sm_diags.git --branch gh-pages --single-branch gh-pages
 
-          # Only copy the current tag release docs
           cd gh-pages
+          # Replace master docs to populate dropdown with latest tags
+          rm -r _build/html/master
+          # Only copy docs for master and current tag
           cp -r -n ../docs/_build/html _build/
 
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This PR updates the `publish-docs` job in `release_workflow.yml` to replace `master` docs and add current tag release docs.

Related to #496 and PR #497/#498.