### PR TITLE
Plots improvement for TC

### DIFF
--- a/e3sm_diags/plot/cartopy/tc_analysis_plot.py
+++ b/e3sm_diags/plot/cartopy/tc_analysis_plot.py
@@ -17,7 +17,7 @@ plotSideTitle = {"fontsize": 9.5}
 # Position and sizes of subplot axes in page coordinates (0 to 1)
 panel = [
     (0.1691, 0.55, 0.6465, 0.2758),
-    (0.1691, 0.15, 0.6465, 0.2758),
+    (0.1691, 0.27, 0.6465, 0.2758),
 ]
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, right, top) in page coordinates
@@ -219,9 +219,9 @@ def plot(test, ref, parameter, basin_dict):
     width = 0.27
 
     ref_vals = num_ref / np.sum(num_ref)
-    rects1 = ax.bar(ind + width / 2, ref_vals, width, color="darkgrey")
+    rects2 = ax.bar(ind - width / 2, ref_vals, width, color="black")
     test_vals = num_test / np.sum(num_test)
-    rects2 = ax.bar(ind - width / 2, test_vals, width, color="black")
+    rects1 = ax.bar(ind + width / 2, test_vals, width, color="darkgrey")
     print(
         "total number based on 6 basins",
         np.sum(num_test),
@@ -243,8 +243,8 @@ def plot(test, ref, parameter, basin_dict):
     ax.legend(
         (rects2[0], rects1[0]),
         (
-            "{}: (~{})storms per year".format(test_name, int(np.sum(num_test))),
-            "{}: (~{}) storms per year".format(ref_name, int(np.sum(num_ref))),
+            "{}: (~{})storms per year".format(ref_name, int(np.sum(num_ref))),
+            "{}: (~{}) storms per year".format(test_name, int(np.sum(num_test))),
         ),
     )
     ax.set_ylabel("Fraction")


### PR DESCRIPTION
Unify the legends of TC frequency distribution and ACE distribution:
Before:
fig1:
![image](https://user-images.githubusercontent.com/13056557/132755639-b2fe16de-e39e-4e84-9415-45a0dea56387.png)
fig2:
![image](https://user-images.githubusercontent.com/13056557/132755679-cc4d3670-d78c-4e04-8918-c9b729083a6d.png)

With the fix figure 1 and figure 2 has data in legends with same order. 
Figure 1 after fix:
![image](https://user-images.githubusercontent.com/13056557/132756056-c669e9b7-7c4b-47b1-9eaa-6fb97e551a41.png)
