### PR TITLE
fix artificial warm bias zonal mean 2d

### DIFF
--- a/e3sm_diags/driver/zonal_mean_2d_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_driver.py
@@ -156,6 +156,15 @@ def run_diag(parameter):
                 mv2_p = utils.general.convert_to_pressure_levels(
                     mv2, plevs, ref_data, var, season
                 )
+                # Regrid towards the lower resolution of the two
+                # variables for calculating the difference.
+                mv1_p_reg, mv2_p_reg = utils.general.regrid_to_lower_res(
+                    mv1_p,
+                    mv2_p,
+                    parameter.regrid_tool,
+                    parameter.regrid_method,
+                )
+                diff_p = mv1_p_reg - mv2_p_reg
 
                 mv1_p = cdutil.averager(mv1_p, axis="x")
                 mv2_p = cdutil.averager(mv2_p, axis="x")
@@ -187,7 +196,8 @@ def run_diag(parameter):
                     mv1_reg = mv1_p
                     mv2_reg = mv2_p
 
-                diff = mv1_reg - mv2_reg
+                # diff = mv1_reg - mv2_reg
+                diff = cdutil.averager(diff_p, axis="x")
                 metrics_dict = create_metrics(mv2_p, mv1_p, mv2_reg, mv1_reg, diff)
 
                 parameter.var_region = "global"

--- a/e3sm_diags/driver/zonal_mean_2d_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_driver.py
@@ -165,39 +165,25 @@ def run_diag(parameter):
                     parameter.regrid_method,
                 )
                 diff_p = mv1_p_reg - mv2_p_reg
+                diff = cdutil.averager(diff_p, axis="x")
 
                 mv1_p = cdutil.averager(mv1_p, axis="x")
                 mv2_p = cdutil.averager(mv2_p, axis="x")
+
+                # Make sure mv1_p_reg and mv2_p_reg have same mask
+                mv1_p_reg = mv2_p_reg + diff_p
+                mv2_p_reg = mv1_p_reg - diff_p
+
+                mv1_reg = cdutil.averager(mv1_p_reg, axis="x")
+                mv2_reg = cdutil.averager(mv2_p_reg, axis="x")
 
                 parameter.output_file = "-".join(
                     [ref_name, var, season, parameter.regions[0]]
                 )
                 parameter.main_title = str(" ".join([var, season]))
 
-                # Regrid towards the lower resolution of the two
-                # variables for calculating the difference.
-                if len(mv1_p.getLatitude()) < len(mv2_p.getLatitude()):
-                    mv1_reg = mv1_p
-                    lev_out = mv1_p.getLevel()
-                    lat_out = mv1_p.getLatitude()
-                    mv2_reg = mv2_p.crossSectionRegrid(lev_out, lat_out)
-                    # Apply the mask back, since crossSectionRegrid
-                    # doesn't preserve the mask.
-                    mv2_reg = MV2.masked_where(mv2_reg == mv2_reg.fill_value, mv2_reg)
-                elif len(mv1_p.getLatitude()) > len(mv2_p.getLatitude()):
-                    mv2_reg = mv2_p
-                    lev_out = mv2_p.getLevel()
-                    lat_out = mv2_p.getLatitude()
-                    mv1_reg = mv1_p.crossSectionRegrid(lev_out, lat_out)
-                    # Apply the mask back, since crossSectionRegrid
-                    # doesn't preserve the mask.
-                    mv1_reg = MV2.masked_where(mv1_reg == mv1_reg.fill_value, mv1_reg)
-                else:
-                    mv1_reg = mv1_p
-                    mv2_reg = mv2_p
-
-                # diff = mv1_reg - mv2_reg
-                diff = cdutil.averager(diff_p, axis="x")
+                # Use mv2_p and mv1_p on the original horizonal grids for visualization and their own metrics
+                # Use mv2_reg and mv1_reg for rmse and correlation coefficient calculation
                 metrics_dict = create_metrics(mv2_p, mv1_p, mv2_reg, mv1_reg, diff)
 
                 parameter.var_region = "global"

--- a/e3sm_diags/plot/cartopy/tc_analysis_plot.py
+++ b/e3sm_diags/plot/cartopy/tc_analysis_plot.py
@@ -17,7 +17,7 @@ plotSideTitle = {"fontsize": 9.5}
 # Position and sizes of subplot axes in page coordinates (0 to 1)
 panel = [
     (0.1691, 0.55, 0.6465, 0.2758),
-    (0.1691, 0.15, 0.6465, 0.2758),
+    (0.1691, 0.27, 0.6465, 0.2758),
 ]
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, right, top) in page coordinates
@@ -219,9 +219,9 @@ def plot(test, ref, parameter, basin_dict):
     width = 0.27
 
     ref_vals = num_ref / np.sum(num_ref)
-    rects1 = ax.bar(ind + width / 2, ref_vals, width, color="darkgrey")
+    rects2 = ax.bar(ind - width / 2, ref_vals, width, color="black")
     test_vals = num_test / np.sum(num_test)
-    rects2 = ax.bar(ind - width / 2, test_vals, width, color="black")
+    rects1 = ax.bar(ind + width / 2, test_vals, width, color="darkgrey")
     print(
         "total number based on 6 basins",
         np.sum(num_test),
@@ -243,8 +243,8 @@ def plot(test, ref, parameter, basin_dict):
     ax.legend(
         (rects2[0], rects1[0]),
         (
-            "{}: (~{})storms per year".format(test_name, int(np.sum(num_test))),
-            "{}: (~{}) storms per year".format(ref_name, int(np.sum(num_ref))),
+            "{}: (~{})storms per year".format(ref_name, int(np.sum(num_ref))),
+            "{}: (~{}) storms per year".format(test_name, int(np.sum(num_test))),
         ),
     )
     ax.set_ylabel("Fraction")

--- a/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
+++ b/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
@@ -103,7 +103,7 @@ def plot_panel(n, fig, proj, var, clevels, cmap, title, parameters, stats=None):
         plt.yticks(plev_ticks, plev_ticks)
     if not parameters.plot_log_plevs and not parameters.plot_plevs:
         # Below 4 lines are to specify the pressure axis and show the 50 mb tick at the top, given default plevs np.linspace(50, 1000, 20)
-        if parameters.plevs.sort() == np.linspace(50, 1000, 20).tolist().sort():
+        if parameters.plevs == np.linspace(50, 1000, 20).tolist():
             plev_ticks = parameters.plevs
             new_ticks = [plev_ticks[0]] + plev_ticks[1::2]
             new_ticks = [int(x) for x in new_ticks]


### PR DESCRIPTION
Resolves #522 
Now, first take the difference between 3d data (to assure both datasets have same mask), then apply zonal average. 

Typically (oirinally) zonal means are computed first for model and obs (reanalysis), separately, which are then used to compute the differences.

The artificial warm bias is reduced after the fix.
Before:
![Screen Shot 2021-09-16 at 2 10 47 PM](https://user-images.githubusercontent.com/13056557/133686191-2963e2c2-8e56-4518-ae6f-0fbef98554f6.png)
After:
![Screen Shot 2021-09-16 at 2 11 09 PM](https://user-images.githubusercontent.com/13056557/133686206-f32f4fb2-73ea-410a-994e-781bea1fd028.png)

@wlin7 I think the result is align with @zhangshixuan1987's. Please let me know if it looks reasonable.



