### PR TITLE
Use cartopy_offlinedata

### DIFF
--- a/conda/e3sm_diags_env.yml
+++ b/conda/e3sm_diags_env.yml
@@ -11,6 +11,7 @@ dependencies:
   - matplotlib=3.4.2
   - beautifulsoup4=4.9.3
   - cartopy=0.19.0
+  - cartopy_offlinedata
   - cdp=1.7.0
   - cdms2=3.1.5
   - cdtime=3.1.4

--- a/conda/e3sm_diags_env_dev.yml
+++ b/conda/e3sm_diags_env_dev.yml
@@ -11,6 +11,7 @@ dependencies:
   - matplotlib=3.4.2
   - beautifulsoup4=4.9.3
   - cartopy=0.19.0
+  - cartopy_offlinedata
   - cdp=1.7.0
   - cdms2=3.1.5
   - cdtime=3.1.4

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - netcdf4
     - matplotlib
     - cartopy
+    - cartopy_offlinedata
     - beautifulsoup4
     - lxml
     - dask

--- a/examples/run_v2_5_0_all_sets_E3SM_machines_updated_imports.py
+++ b/examples/run_v2_5_0_all_sets_E3SM_machines_updated_imports.py
@@ -226,11 +226,10 @@ if __name__ == "__main__":
     # Change <username>
 
     # Results will be at https://compy-dtn.pnl.gov/<username>/v2_5_0_all_sets/viewer/
-    # run_compy('/compyfs/www/<username>/')
+    # run_compy("/compyfs/www/<username>/")
 
     # Results will be at https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/<username>/v2_5_0_all_sets/viewer/
-    # run_lcrc('/lcrc/group/e3sm/public_html/diagnostic_output/<username>/')
+    run_lcrc("/lcrc/group/e3sm/public_html/diagnostic_output/<username>/")
 
     # Results will be at https://portal.nersc.gov/project/e3sm/<username>/v2_5_0_all_sets/viewer/
     # run_nersc("/global/cfs/cdirs/e3sm/www/<username>/")
-    run_nersc("/global/cfs/cdirs/e3sm/www/chengzhu/v2_5_0")


### PR DESCRIPTION
Use `cartopy_offlinedata` to fix bug where Tropical Cyclone images don't show up. Resolves #520.

- [ ] After this merges, follow the steps at https://e3sm-project.github.io/e3sm_diags/_build/html/master/dev_guide/testing.html#complete-run-test to update the expected images for the `complete_run`test