### PR TITLE
refine plevs to include stratosphere

### DIFF
--- a/e3sm_diags/parameter/zonal_mean_2d_parameter.py
+++ b/e3sm_diags/parameter/zonal_mean_2d_parameter.py
@@ -1,5 +1,3 @@
-import numpy
-
 from e3sm_diags.driver.utils.general import monotonic
 
 from .core_parameter import CoreParameter
@@ -8,7 +6,35 @@ from .core_parameter import CoreParameter
 class ZonalMean2dParameter(CoreParameter):
     def __init__(self):
         super(ZonalMean2dParameter, self).__init__()
-        self.plevs = numpy.logspace(2.0, 3.0, num=17).tolist()
+        # self.plevs = numpy.logspace(2.0, 3.0, num=32).tolist()
+        self.plevs = [
+            10.0,
+            30.0,
+            50.0,
+            70.0,
+            100.0,
+            150.0,
+            200.0,
+            250.0,
+            300.0,
+            350.0,
+            400.0,
+            450.0,
+            500.0,
+            550.0,
+            600.0,
+            650.0,
+            700.0,
+            750.0,
+            800.0,
+            850.0,
+            875.0,
+            900.0,
+            925.0,
+            950.0,
+            975.0,
+            1000.0,
+        ]
         self.plot_log_plevs = False
         self.plot_plevs = False
         # Granulating plevs causes duplicate plots in this case.

--- a/e3sm_diags/parameter/zonal_mean_2d_parameter.py
+++ b/e3sm_diags/parameter/zonal_mean_2d_parameter.py
@@ -1,3 +1,5 @@
+import numpy
+
 from e3sm_diags.driver.utils.general import monotonic
 
 from .core_parameter import CoreParameter
@@ -6,35 +8,35 @@ from .core_parameter import CoreParameter
 class ZonalMean2dParameter(CoreParameter):
     def __init__(self):
         super(ZonalMean2dParameter, self).__init__()
-        # self.plevs = numpy.logspace(2.0, 3.0, num=32).tolist()
-        self.plevs = [
-            10.0,
-            30.0,
-            50.0,
-            70.0,
-            100.0,
-            150.0,
-            200.0,
-            250.0,
-            300.0,
-            350.0,
-            400.0,
-            450.0,
-            500.0,
-            550.0,
-            600.0,
-            650.0,
-            700.0,
-            750.0,
-            800.0,
-            850.0,
-            875.0,
-            900.0,
-            925.0,
-            950.0,
-            975.0,
-            1000.0,
-        ]
+        self.plevs = numpy.linspace(50, 1000, 20).tolist()
+        # self.plevs = numpy.logspace(2.0, 3.0, num=17).tolist()
+        # self.plevs = [
+        #    30.0,
+        #    50.0,
+        #    75.0,
+        #    100.0,
+        #    150.0,
+        #    200.0,
+        #    250.0,
+        #    300.0,
+        #    350.0,
+        #    400.0,
+        #    450.0,
+        #    500.0,
+        #    550.0,
+        #    600.0,
+        #    650.0,
+        #    700.0,
+        #    750.0,
+        #    800.0,
+        #    850.0,
+        #    875.0,
+        #    900.0,
+        #    925.0,
+        #    950.0,
+        #    975.0,
+        #    1000.0,
+        # ]
         self.plot_log_plevs = False
         self.plot_plevs = False
         # Granulating plevs causes duplicate plots in this case.

--- a/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
+++ b/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
@@ -13,7 +13,7 @@ from e3sm_diags.plot import get_colormap
 matplotlib.use("Agg")
 import matplotlib.colors as colors  # isort:skip  # noqa: E402
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
-
+import matplotlib.ticker as ticker  # isort:skip  # noqa: E402
 
 plotTitle = {"fontsize": 11.5}
 plotSideTitle = {"fontsize": 9.5}
@@ -102,6 +102,9 @@ def plot_panel(n, fig, proj, var, clevels, cmap, title, parameters, stats=None):
         plev_ticks = parameters.plevs
         # plev_ticks = plev_ticks[::-1]
         plt.yticks(plev_ticks, plev_ticks)
+    if not parameters.plot_log_plevs and not parameters.plot_plevs:
+        ax.yaxis.set_major_locator(ticker.MultipleLocator(100))
+        ax.yaxis.set_minor_locator(ticker.MultipleLocator(50))
     plt.ylabel("pressure (mb)")
     # ax.set_yscale('log')
     ax.invert_yaxis()

--- a/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
+++ b/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
@@ -13,7 +13,6 @@ from e3sm_diags.plot import get_colormap
 matplotlib.use("Agg")
 import matplotlib.colors as colors  # isort:skip  # noqa: E402
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
-import matplotlib.ticker as ticker  # isort:skip  # noqa: E402
 
 plotTitle = {"fontsize": 11.5}
 plotSideTitle = {"fontsize": 9.5}
@@ -103,8 +102,13 @@ def plot_panel(n, fig, proj, var, clevels, cmap, title, parameters, stats=None):
         # plev_ticks = plev_ticks[::-1]
         plt.yticks(plev_ticks, plev_ticks)
     if not parameters.plot_log_plevs and not parameters.plot_plevs:
-        ax.yaxis.set_major_locator(ticker.MultipleLocator(100))
-        ax.yaxis.set_minor_locator(ticker.MultipleLocator(50))
+        # Below 4 lines are to specify the pressure axis and show the 50 mb tick at the top, given default plevs np.linspace(50, 1000, 20)
+        if parameters.plevs.sort() == np.linspace(50, 1000, 20).tolist().sort():
+            plev_ticks = parameters.plevs
+            new_ticks = [plev_ticks[0]] + plev_ticks[1::2]
+            new_ticks = [int(x) for x in new_ticks]
+            plt.yticks(new_ticks, new_ticks)
+
     plt.ylabel("pressure (mb)")
     # ax.set_yscale('log')
     ax.invert_yaxis()


### PR DESCRIPTION
Partly resolves #492 

By refining default setting for plevs. Stratosphere are being included in pressure-latitude plot. 

Before:
![Screen Shot 2021-09-16 at 4 44 59 PM](https://user-images.githubusercontent.com/13056557/133702612-007e0505-f0b5-47b2-81cb-0886ff2df0f5.png)

After:

![Screen Shot 2021-09-16 at 4 44 29 PM](https://user-images.githubusercontent.com/13056557/133702620-f0c900e7-1c5c-4251-97fd-c35682f759a4.png)