### PR TITLE
Document change from acme_diags

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,12 @@ E3SM Diagnostics Package v2
 Welcome to the E3SM Diagnostics Package documentation hub.
 
 To change the documentation version, use the version selector in the bottom left-hand corner.
-Please note, documentation for versions ``<v2.5.0`` are not available in the version selector.
+Please note, documentation for versions ``v2.5.0`` are not available in the version selector.
+
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/quickguides/quick-guide-acme1.rst
+++ b/docs/source/quickguides/quick-guide-acme1.rst
@@ -4,6 +4,11 @@
 Acme1 quick guide for running e3sm_diags v2
 =========================================================================
 
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
+
 1. Installation
 -----------------------------------------------------------
 

--- a/docs/source/quickguides/quick-guide-anvil.rst
+++ b/docs/source/quickguides/quick-guide-anvil.rst
@@ -4,6 +4,11 @@
 Anvil quick guide for running e3sm_diags v2
 =========================================================================
 
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
+
 1. Installation
 -----------------------------------------------------------
 

--- a/docs/source/quickguides/quick-guide-chrysalis.rst
+++ b/docs/source/quickguides/quick-guide-chrysalis.rst
@@ -4,6 +4,11 @@
 Chrysalis quick guide for running e3sm_diags v2
 =========================================================================
 
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
+
 1. Installation
 -----------------------------------------------------------
 

--- a/docs/source/quickguides/quick-guide-compy.rst
+++ b/docs/source/quickguides/quick-guide-compy.rst
@@ -4,6 +4,11 @@
 Compy quick guide for running e3sm_diags v2
 =========================================================================
 
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
+
 1. Installation
 -----------------------------------------------------------
 

--- a/docs/source/quickguides/quick-guide-cori-haswell.rst
+++ b/docs/source/quickguides/quick-guide-cori-haswell.rst
@@ -4,6 +4,11 @@
 Cori-Haswell quick guide for running e3sm_diags v2
 =========================================================================
 
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
+
 1. Installation
 -----------------------------------------------------------
 
@@ -136,7 +141,7 @@ Once the session is available, launch E3SM Diagnostics, to activate ``e3sm_unifi
 
     ::
 
-        source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh 
+        source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
         python run_e3sm_diags.py --multiprocessing --num_workers=32
 
 
@@ -160,7 +165,7 @@ Copy and paste the code below into a file named ``diags.bash``.
         #SBATCH --time=01:00:00
         #SBATCH -C haswell
 
-        source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh 
+        source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
         python run_e3sm_diags.py --multiprocessing --num_workers=32
 
 And then submit it:

--- a/docs/source/quickguides/quick-guide-general.rst
+++ b/docs/source/quickguides/quick-guide-general.rst
@@ -2,6 +2,11 @@
 General quick guide for running e3sm_diags v2
 =========================================================================
 
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
+
 1. Installation
 -----------------------------------------------------------
 

--- a/docs/source/quickguides/quick-guide-generic.rst
+++ b/docs/source/quickguides/quick-guide-generic.rst
@@ -4,6 +4,11 @@
 #expand machine_name# quick guide for running e3sm_diags v2
 =========================================================================
 
+.. warning::
+    As of ``v2.6.0``, ``e3sm_diags`` should be used as the module name instead of
+    ``acme_diags``. Instances of ``acme_diags`` in the Python import statements should
+    be replaced accordingly.
+
 1. Installation
 -----------------------------------------------------------
 

--- a/docs/source/quickguides/quick-guide-multiprocessing-cori-haswell.rst
+++ b/docs/source/quickguides/quick-guide-multiprocessing-cori-haswell.rst
@@ -20,7 +20,7 @@ Once the session is available, launch E3SM Diagnostics, to activate ``e3sm_unifi
 
     ::
 
-        source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
+        source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
         python run_e3sm_diags.py --multiprocessing --num_workers=32
 
 
@@ -39,12 +39,12 @@ Copy and paste the code below into a file named ``diags.bash``.
         #SBATCH --job-name=diags
         #SBATCH --output=diags.o%j
         #SBATCH --partition=regular
-        #SBATCH --account=acme
+        #SBATCH --account=e3sm
         #SBATCH --nodes=1
         #SBATCH --time=01:00:00
         #SBATCH -C haswell
 
-        source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
+        source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
         python run_e3sm_diags.py --multiprocessing --num_workers=32
 
 And then submit it:


### PR DESCRIPTION
Document the change from `acme_diags` to `e3sm_diags` in `v2.6.0`. Note: this change only affects the `master` docs, not the `v2.6.0` docs.