### PR TITLE
Fix missing “CLDLOW_TAU*_MISR in lat-lon

### DIFF
--- a/e3sm_diags/derivations/acme.py
+++ b/e3sm_diags/derivations/acme.py
@@ -329,7 +329,7 @@ def adjust_prs_val_units(
     """Adjust the prs_val units based on the prs.id"""
     # COSP v2 cosp_pr in units Pa instead of hPa as in v1
     # COSP v2 cosp_htmisr in units m instead of km as in v1
-    adjust_ids = {"cosp_prs": 100, "cosp_htmsir": 1000}
+    adjust_ids = {"cosp_prs": 100, "cosp_htmisr": 1000}
 
     if prs_val0:
         prs_val = prs_val0

--- a/tests/e3sm_diags/derivations/test_acme.py
+++ b/tests/e3sm_diags/derivations/test_acme.py
@@ -46,7 +46,7 @@ class TestAdjustPrsValUnits(TestCase):
         self.assertEqual(actual, expected)
 
     def test_swap_units_and_apply_multiplier_for_all_matched_ids(self):
-        adjust_ids = {"cosp_prs": 100, "cosp_htmsir": 1000}
+        adjust_ids = {"cosp_prs": 100, "cosp_htmisr": 1000}
 
         for id, multiplier in adjust_ids.items():
             self.mock_file_axis.id = id


### PR DESCRIPTION
@zyuying noted that variables “CLDLOW_TAU*_MISR" were missing from lat-lon plot-set. 

The errors can be reproduced by:
```
e3sm_diags lat_lon --no_viewer --case_id 'Cloud MISR' --sets 'lat_lon' --run_type 'model_vs_obs' --variables 'CLDLOW_TAU1.3_MISR' --seasons 'ANN' --regions 'global' --regrid_tool 'esmf' --regrid_method 'conservative' --main_title 'CLDLOW_TAU1.3_MISR ANN global' --backend 'mpl' --output_format 'png' --canvas_size_w '1212' --canvas_size_h '1628' --figsize '8.5' '11.0' --dpi '150' --arrows --contour_levels '5' '15' '25' '35' '45' '55' '65' '75' '85' '95' --test_name '20210813.PhaseII.F20TR-SHOC.NGD.ne30pg2.v2.compy' --short_test_name 'SHOC+ZM' --test_colormap 'Blues' --ref_name 'MISRCOSP' --reference_name 'MISR Simulator' --reference_colormap 'Blues' --diff_title 'Model - Observation' --diff_colormap 'RdBu' --diff_levels '-30' '-25' '-20' '-15' '-10' '-5' '5' '10' '15' '20' '25' '30' --multiprocessing --num_workers '32' --granulate 'variables' 'seasons' 'plevs' 'regions' --selectors 'sets' 'seasons' --reference_data_path '/global/cfs/cdirs/e3sm/acme_diags/obs_for_e3sm_diags/climatology/' --test_data_path '/global/cscratch1/sd/terai/E3SM_NGD-ATMPhys/Convection_diagnostic/PhaseII/SHOCplusZM/F20TR/climo_rgr/' --results_dir '/global/cfs/cdirs/e3sm/www/zhang40/tests'
```

Tracking down the error, it turned to be that a typo introduced from the PR https://github.com/E3SM-Project/e3sm_diags/pull/434 caused this issue.

All the cosp related results look okay after the fix:
https://portal.nersc.gov/cfs/e3sm/zhang40/tests/COSPv2_fix_lat_lon_MISR_2ndfix/viewer/

@zyuying would you please double check if i missed anything? Thank you.