### PR TITLE
Update integration test execution and paths from implicit to explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 tests/integration/integration_test_data
 tests/integration/integration_test_images
+tests/integration/all_sets_results/
 tests/integration/all_sets_results_test/
 tests/integration/image_check_failures/
 tests/v*_all_sets/

--- a/tests/integration/all_sets.cfg
+++ b/tests/integration/all_sets.cfg
@@ -175,7 +175,6 @@ end_yr = '2013'
 test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
 reference_data_path = 'tests/integration/integration_test_data'
-
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -196,7 +195,6 @@ ref_end_yr = '2013'
 test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
 reference_data_path = 'tests/integration/integration_test_data'
-
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -214,7 +212,6 @@ end_yr = '2013'
 test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
 reference_data_path = 'tests/integration/integration_test_data'
-
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -233,7 +230,6 @@ end_yr = '2013'
 test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
 reference_data_path = 'tests/integration/integration_test_data'
-
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -253,7 +249,6 @@ ref_end_yr = '2013'
 test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
 reference_data_path = 'tests/integration/integration_test_data'
-
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -270,7 +265,6 @@ end_yr = '2013'
 test_data_path = 'tests/integration/integration_test_data'
 test_file = 'U_201301_201312.nc'
 reference_data_path = 'tests/integration/integration_test_data'
-
 ref_file = 'U_201301_201312.nc'
 test_name = "system tests"
 variables = ["U"]

--- a/tests/integration/all_sets.cfg
+++ b/tests/integration/all_sets.cfg
@@ -9,12 +9,12 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
-reference_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 
 
@@ -30,12 +30,12 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1989-2005"
-reference_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 
 
@@ -51,12 +51,12 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1989-2005"
-reference_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 
 
@@ -73,12 +73,12 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
-reference_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 regions=["CONUS_RRM","global"]
 
@@ -98,12 +98,12 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
-reference_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 
 
@@ -119,12 +119,12 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "MISRCOSP"
 reference_name = "MISR COSP (2000-2009)"
-reference_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
 ref_file = "CLDMISR_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "CLD_MISR_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 
 
@@ -134,12 +134,12 @@ variables = ["TREFHT"]
 
 test_name = "system tests"
 short_test_name = "short_system tests"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "TREFHT_201201_201312.nc"
 start_yr = '2012'
 end_yr = '2013'
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 
 [enso_diags]
@@ -148,13 +148,14 @@ case_id = 'TREFHT-response-map'
 debug = True
 diff_colormap = "BrBG"
 regions = ["20S20N"]
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 seasons = ["ANN"]
 start_yr = '2012'
 end_yr = '2013'
-test_data_path = 'integration_test_data'
+test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -166,14 +167,15 @@ case_id = 'TREFHT-response-map-start-yrs'
 debug = True
 diff_colormap = "BrBG"
 regions = ["20S20N"]
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 seasons = ["ANN"]
 test_start_yr = '2012'
 ref_start_yr = '2012'
 end_yr = '2013'
-test_data_path = 'integration_test_data'
+test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -185,15 +187,16 @@ case_id = 'TREFHT-response-map-test-ref-yrs'
 debug = True
 diff_colormap = "BrBG"
 regions = ["20S20N"]
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 seasons = ["ANN"]
 test_start_yr = '2012'
 ref_start_yr = '2012'
 test_end_yr = '2013'
 ref_end_yr = '2013'
-test_data_path = 'integration_test_data'
+test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -204,13 +207,14 @@ sets = ["enso_diags"]
 plot_type = "scatter"
 case_id = "TREFHT-response-scatter"
 debug = True
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 seasons = ["ANN"]
 start_yr = '2012'
 end_yr = '2013'
-test_data_path = 'integration_test_data'
+test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -221,14 +225,15 @@ sets = ["enso_diags"]
 plot_type = "scatter"
 case_id = "TREFHT-response-scatter-start-yrs"
 debug = True
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 seasons = ["ANN"]
 test_start_yr = '2012'
 ref_start_yr = '2012'
 end_yr = '2013'
-test_data_path = 'integration_test_data'
+test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -239,15 +244,16 @@ sets = ["enso_diags"]
 plot_type = "scatter"
 case_id = "TREFHT-response-scatter-test-ref-yrs"
 debug = True
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 seasons = ["ANN"]
 test_start_yr = '2012'
 ref_start_yr = '2012'
 test_end_yr = '2013'
 ref_end_yr = '2013'
-test_data_path = 'integration_test_data'
+test_data_path = 'tests/integration/integration_test_data'
 test_file = 'TREFHT_201201_201312.nc'
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_file = 'TREFHT_201201_201312.nc'
 test_name = "system tests"
 variables = ["TREFHT"]
@@ -257,13 +263,14 @@ print_statements = True
 sets = ["qbo"]
 case_id = "qbo-test"
 debug = True
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 seasons = ["ANN"]
 start_yr = '2013'
 end_yr = '2013'
-test_data_path = 'integration_test_data'
+test_data_path = 'tests/integration/integration_test_data'
 test_file = 'U_201301_201312.nc'
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_file = 'U_201301_201312.nc'
 test_name = "system tests"
 variables = ["U"]
@@ -275,13 +282,14 @@ case_id = "RIVER_DISCHARGE_OVER_LAND_LIQ_GSIM"
 variables = ["RIVER_DISCHARGE_OVER_LAND_LIQ"]
 regions = ["global"]
 seasons = ["ANN"]
-reference_data_path = 'integration_test_data'
+reference_data_path = 'tests/integration/integration_test_data'
+
 ref_start_yr = '1986'
 ref_end_yr = '1988'
-test_data_path = 'integration_test_data/3yr_nc'
+test_data_path = 'tests/integration_test_data/3yr_nc'
 test_start_yr = '1959'
 test_end_yr = '1961'
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 test_name = "system tests"
 print_statements = True
 
@@ -296,12 +304,12 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "TRMM-3B43v-7_3hr"
 reference_name = "TRMM-3B43v-7"
-reference_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
 ref_file = "TRMM-3B43v-7_3hr_JJA_199806_201308_climo.nc"
-test_data_path = "integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_file = "20180215.DECKv1b_H1.ne30_oEC.edison.cam.h4_JJA_200006_200908_climo.nc"
 
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 debug = True
 
 
@@ -315,13 +323,13 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "armdiags"
 reference_name = "armdiags"
-reference_data_path = "integration_test_data"
-test_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_start_yr = '0001'
 test_end_yr = '0001'
 ref_start_yr = '0001'
 ref_end_yr = '0001'
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 
 [arm_diags2]
 sets = ["arm_diags"]
@@ -333,13 +341,13 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "armdiags"
 reference_name = "armdiags"
-reference_data_path = "integration_test_data"
-test_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_start_yr = '0001'
 test_end_yr = '0001'
 ref_start_yr = '0001'
 ref_end_yr = '0001'
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 
 [arm_diags3]
 sets = ["arm_diags"]
@@ -351,13 +359,13 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "armdiags"
 reference_name = "armdiags"
-reference_data_path = "integration_test_data"
-test_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_start_yr = '0001'
 test_end_yr = '0001'
 ref_start_yr = '0001'
 ref_end_yr = '0001'
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"
 
 [arm_diags4]
 sets = ["arm_diags"]
@@ -368,10 +376,10 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "armdiags"
 reference_name = "armdiags"
-reference_data_path = "integration_test_data"
-test_data_path = "integration_test_data"
+reference_data_path = "tests/integration/integration_test_data"
+test_data_path = "tests/integration/integration_test_data"
 test_start_yr = '0001'
 test_end_yr = '0001'
 ref_start_yr = '0001'
 ref_end_yr = '0001'
-results_dir = "all_sets_results_test"
+results_dir = "tests/integration/all_sets_results_test"

--- a/tests/integration/all_sets.cfg
+++ b/tests/integration/all_sets.cfg
@@ -283,10 +283,9 @@ variables = ["RIVER_DISCHARGE_OVER_LAND_LIQ"]
 regions = ["global"]
 seasons = ["ANN"]
 reference_data_path = 'tests/integration/integration_test_data'
-
 ref_start_yr = '1986'
 ref_end_yr = '1988'
-test_data_path = 'tests/integration_test_data/3yr_nc'
+test_data_path = 'tests/integration/integration_test_data/3yr_nc'
 test_start_yr = '1959'
 test_end_yr = '1961'
 results_dir = "tests/integration/all_sets_results_test"

--- a/tests/integration/all_sets_modified.cfg
+++ b/tests/integration/all_sets_modified.cfg
@@ -9,13 +9,15 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
-reference_data_path = "."
+reference_data_path = "tests/integration"
+
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "."
+test_data_path = "tests/integration"
+
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 debug = True
 
 
@@ -31,13 +33,15 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1989-2005"
-reference_data_path = "."
+reference_data_path = "tests/integration"
+
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "."
+test_data_path = "tests/integration"
+
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 debug = True
 plot_log_plevs = False
 plot_plevs = False
@@ -55,13 +59,15 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1989-2005"
-reference_data_path = "."
+reference_data_path = "tests/integration"
+
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "."
+test_data_path = "tests/integration"
+
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 debug = True
 plot_log_plevs = False
 plot_plevs = False
@@ -80,13 +86,15 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
-reference_data_path = "."
+reference_data_path = "tests/integration"
+
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "."
+test_data_path = "tests/integration"
+
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 debug = True
 
 
@@ -104,13 +112,15 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
-reference_data_path = "."
+reference_data_path = "tests/integration"
+
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "."
+test_data_path = "tests/integration"
+
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 debug = True
 
 
@@ -126,13 +136,15 @@ test_name = "system tests"
 short_test_name = "short_system tests"
 ref_name = "MISRCOSP"
 reference_name = "MISR COSP (2000-2009)"
-reference_data_path = "."
+reference_data_path = "tests/integration"
+
 ref_file = "CLDMISR_ERA-Interim_ANN_198001_201401_climo.nc"
-test_data_path = "."
+test_data_path = "tests/integration"
+
 test_file = "CLD_MISR_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 debug = True
 
 
@@ -142,13 +154,14 @@ variables = ["TREFHT"]
 
 test_name = "system tests"
 short_test_name = "short_system tests"
-test_data_path = "."
+test_data_path = "tests/integration"
+
 test_file = "TREFHT_201201_201312.nc"
 start_yr = '2012'
 end_yr = '2013'
 
 backend = "mpl"
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 debug = True
 ref_names = []
 ref_timeseries_input = True
@@ -165,7 +178,7 @@ case_id = 'TREFHT-response'
 debug = True
 diff_colormap = "BrBG"
 regions = ["20S20N"]
-results_dir = "all_sets_results"
+results_dir = "tests/integration/all_sets_results"
 seasons = ["ANN"]
 start_yr = '2012'
 end_yr = '2013'

--- a/tests/integration/all_sets_modified.cfg
+++ b/tests/integration/all_sets_modified.cfg
@@ -10,10 +10,8 @@ short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
 reference_data_path = "tests/integration"
-
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
 test_data_path = "tests/integration"
-
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
@@ -34,10 +32,8 @@ short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1989-2005"
 reference_data_path = "tests/integration"
-
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
 test_data_path = "tests/integration"
-
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
@@ -60,10 +56,8 @@ short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1989-2005"
 reference_data_path = "tests/integration"
-
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
 test_data_path = "tests/integration"
-
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
@@ -87,10 +81,8 @@ short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
 reference_data_path = "tests/integration"
-
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
 test_data_path = "tests/integration"
-
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
@@ -113,10 +105,8 @@ short_test_name = "short_system tests"
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis 1979-2015"
 reference_data_path = "tests/integration"
-
 ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
 test_data_path = "tests/integration"
-
 test_file = "T_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
@@ -137,10 +127,8 @@ short_test_name = "short_system tests"
 ref_name = "MISRCOSP"
 reference_name = "MISR COSP (2000-2009)"
 reference_data_path = "tests/integration"
-
 ref_file = "CLDMISR_ERA-Interim_ANN_198001_201401_climo.nc"
 test_data_path = "tests/integration"
-
 test_file = "CLD_MISR_20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc"
 
 backend = "mpl"
@@ -155,7 +143,6 @@ variables = ["TREFHT"]
 test_name = "system tests"
 short_test_name = "short_system tests"
 test_data_path = "tests/integration"
-
 test_file = "TREFHT_201201_201312.nc"
 start_yr = '2012'
 end_yr = '2013'

--- a/tests/integration/config.py
+++ b/tests/integration/config.py
@@ -1,0 +1,8 @@
+# Paths and directories used in the integration test. Configurations in
+# `all_sets.cfg` and `all_sets_modified.cfg` should match these paths.
+TEST_ROOT_PATH = "tests/integration/"
+TEST_DATA_DIR = "integration_test_data"
+TEST_IMAGES_DIR = "integration_test_images"
+
+TEST_DATA_PATH = f"{TEST_ROOT_PATH}/{TEST_DATA_DIR}/"
+TEST_IMAGES_PATH = f"{TEST_ROOT_PATH}/{TEST_IMAGES_DIR}/"

--- a/tests/integration/download_data.py
+++ b/tests/integration/download_data.py
@@ -2,6 +2,8 @@ import os
 import re
 import urllib.request
 
+from tests.integration.config import TEST_DATA_DIR, TEST_IMAGES_DIR, TEST_ROOT_PATH
+
 
 # https://stackoverflow.com/questions/49113616/how-to-download-file-using-python
 def retrieve_file(url, file_path):
@@ -15,6 +17,7 @@ def retrieve_file(url, file_path):
 
 
 def download_files(url_prefix, url_suffix, directory_prefix=None):
+    print(f"Downloading {url_suffix}")
     print("url_prefix={}".format(url_prefix))
     print("url_suffix={}".format(url_suffix))
     print("(local) directory_prefix={}".format(directory_prefix))
@@ -67,17 +70,17 @@ def download_files(url_prefix, url_suffix, directory_prefix=None):
 
 
 def download():
-    print("Downloading integration_test_data")
     download_files(
         "https://web.lcrc.anl.gov/public/e3sm/e3sm_diags_test_data/integration",
-        "integration_test_data",
+        TEST_DATA_DIR,
+        directory_prefix=TEST_ROOT_PATH,
     )
-    print("Downloading integration_test_images")
     download_files(
         "https://web.lcrc.anl.gov/public/e3sm/e3sm_diags_test_data/integration/expected",
-        "integration_test_images",
+        TEST_IMAGES_DIR,
+        directory_prefix=TEST_ROOT_PATH,
     )
-    print("Downloaded integration_test_data and integration_test_images")
+    print(f"Downloaded {TEST_DATA_DIR} and {TEST_ROOT_PATH}")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_all_sets.py
+++ b/tests/integration/test_all_sets.py
@@ -3,6 +3,7 @@ import re
 import shutil
 import unittest
 
+from tests.integration.config import TEST_DATA_DIR
 from tests.integration.utils import run_command_and_get_stderr
 
 
@@ -28,7 +29,7 @@ class TestAllSets(unittest.TestCase):
 
     def run_test(self, backend):
         pth = os.path.dirname(__file__)
-        test_pth = os.path.join(pth, "integration_test_data")
+        test_pth = os.path.join(pth, TEST_DATA_DIR)
         cfg_pth = os.path.join(pth, "all_sets_modified.cfg")
         cfg_pth = os.path.abspath(cfg_pth)
 

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -6,10 +6,7 @@ import cdms2
 from e3sm_diags.derivations import acme as acme_derivations
 from e3sm_diags.driver.utils.dataset import Dataset
 from e3sm_diags.parameter.core_parameter import CoreParameter
-
-
-def get_abs_file_path(relative_path):
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), relative_path)
+from tests.integration.config import TEST_DATA_PATH
 
 
 class TestDataset(unittest.TestCase):
@@ -17,9 +14,7 @@ class TestDataset(unittest.TestCase):
         self.parameter = CoreParameter()
 
     def test_convert_units(self):
-        with cdms2.open(
-            get_abs_file_path("integration_test_data/precc.nc")
-        ) as precc_file:
+        with cdms2.open(f"{TEST_DATA_PATH}/precc.nc") as precc_file:
             var = precc_file("PRECC")
 
         new_var = acme_derivations.convert_units(var, "mm/day")
@@ -81,7 +76,7 @@ class TestDataset(unittest.TestCase):
         # We pass in the path to a file, so the input directory
         # to the tests doesn't need to be like how it is for when e3sm_diags
         # is ran wit a bunch of diags.
-        self.parameter.reference_data_path = "./integration_test_data"
+        self.parameter.reference_data_path = TEST_DATA_PATH
         self.parameter.ref_file = "ta_ERA-Interim_ANN_198001_201401_climo.nc"
         data = Dataset(self.parameter, ref=True)
         self.assertEqual(data.get_attr_from_climo("Conventions", "ANN"), "CF-1.0")

--- a/tests/integration/test_diags.py
+++ b/tests/integration/test_diags.py
@@ -6,6 +6,7 @@ import unittest
 
 from PIL import Image, ImageChops, ImageDraw
 
+from tests.integration.config import TEST_IMAGES_PATH, TEST_ROOT_PATH
 from tests.integration.utils import run_command_and_get_stderr
 
 # Run these tetsts on Cori by doing the following:
@@ -134,7 +135,9 @@ def compare_images(
 class TestAllSets(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        command = "python all_sets.py -d all_sets.cfg"
+        command = (
+            f"python {TEST_ROOT_PATH}/all_sets.py -d {TEST_ROOT_PATH}/all_sets.cfg"
+        )
         stderr = run_command_and_get_stderr(command)
         # FIXME: "Type[TestAllSets]" has no attribute "results_dir"
         TestAllSets.results_dir = get_results_dir(stderr)  # type: ignore
@@ -170,7 +173,7 @@ class TestAllSets(unittest.TestCase):
 
         image_name = os.path.split(png_path)[-1]
         path_to_actual_png = full_png_path
-        path_to_expected_png = "integration_test_images/{}".format(png_path)
+        path_to_expected_png = f"{TEST_IMAGES_PATH}/{png_path}"
 
         if "CHECK_IMAGES" in os.environ:
             # Set `export CHECK_IMAGES=True` to do a pixel-by-pixel image comparison check.
@@ -334,8 +337,10 @@ class TestAllSets(unittest.TestCase):
 
     # Test the image count
     def test_image_count(self):
-        actual_num_images, actual_images = count_images("all_sets_results_test")
-        expected_num_images, expected_images = count_images("integration_test_images")
+        actual_num_images, actual_images = count_images(
+            f"{TEST_ROOT_PATH}/all_sets_results_test"
+        )
+        expected_num_images, expected_images = count_images(TEST_IMAGES_PATH)
         self.assertEqual(actual_images, expected_images)
         self.assertEqual(actual_num_images, expected_num_images)
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -14,4 +14,4 @@ python -m tests.integration.download_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/expected/integration_test_images integration_test_images
 
 # 3. Run integration tests
-python -m unittest discover -s tests/integration
+python -m unittest tests/integration/test_*.py

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -29,6 +29,6 @@ for file in "${files[@]}";
     do
         file="${file}.py"
         printf "\n${file}\n"
-        printf "~~~~~~~~~~~~~~~~~~~~"
+        printf "~~~~~~~~~~~~~~~~~~~~\n"
         eval "${command}${file}";
 done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -25,10 +25,10 @@ printf "==============================================\n"
 # Related lines of code : https://github.com/CDAT/cdp/blob/2917603097112f7db52be0bf7a2e766e14cc2e16/cdp/cdp_parser.py#L498
 command='python -m unittest tests/integration/'
 declare -a files=("test_all_sets" "test_dataset" "test_diags" "test_run")
-for file in "${files[@]}";
+for file in "${files[@]}"
     do
         file="${file}.py"
         printf "\n${file}\n"
         printf "~~~~~~~~~~~~~~~~~~~~\n"
-        eval "${command}${file}";
+        eval "${command}${file}"
 done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -14,4 +14,4 @@ python -m tests.integration.download_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/expected/integration_test_images integration_test_images
 
 # 3. Run integration tests
-python -m unittest discover --start-directory "tests/integration"
+python -m unittest discover --start-directory tests/integration

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -6,7 +6,6 @@ set -e # Fail if any line fails
 python -m unittest tests/e3sm_diags/*/test_*.py
 
 # 2. Copy over test data and images from the web. [Takes about four minutes]
-# `-m mod` : run library module as a script. This allows for absolute imports within the directory (e.g., utilities from tests.integration.utils)
 python -m tests.integration.download_data
 
 # To use `scp`, run the following two lines instead. Be sure to change <username>. [Takes about two minutes]
@@ -14,4 +13,13 @@ python -m tests.integration.download_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/expected/integration_test_images integration_test_images
 
 # 3. Run integration tests
-python -m unittest tests/integration/test_*.py
+# Integration tests must be called individually. `e3sm_diags` uses `cdp_parser.get_parameters()`, which incorrectly picks up `python -m unittest` cmd args.
+# This results in `cdp_parser.get_parameters()` raising `error: unrecognized arguments <UNITTEST ARGS>`.
+# Running tests using these commands do not work:
+#  - `python -m unittest tests/integration/test_*.py`
+#  - `python -m unittest discover -s tests/integration --pattern "test_*.py"`
+# Related lines of code : https://github.com/CDAT/cdp/blob/2917603097112f7db52be0bf7a2e766e14cc2e16/cdp/cdp_parser.py#L498
+python -m unittest tests/integration/test_all_sets.py
+python -m unittest tests/integration/test_dataset.py
+python -m unittest tests/integration/test_diags.py
+python -m unittest tests/integration/test_run.py

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -14,4 +14,4 @@ python -m tests.integration.download_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/expected/integration_test_images integration_test_images
 
 # 3. Run integration tests
-python -m unittest discover --start-directory tests/integration
+python -m unittest discover -s tests/integration

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -6,9 +6,7 @@ set -e # Fail if any line fails
 python -m unittest tests/e3sm_diags/*/test_*.py
 
 # 2. Copy over test data and images from the web. [Takes about four minutes]
-# `-m` executes the the module as a stand-alone within a package, allowing for absolute imports
-# of other modules within the tests directory.
-# https://stackoverflow.com/a/3617928
+# `-m mod` : run library module as a script. This allows for absolute imports within the directory (e.g., utilities from tests.integration.utils)
 python -m tests.integration.download_data
 
 # To use `scp`, run the following two lines instead. Be sure to change <username>. [Takes about two minutes]
@@ -16,4 +14,4 @@ python -m tests.integration.download_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/expected/integration_test_images integration_test_images
 
 # 3. Run integration tests
-python -m unittest discover -s "tests/integration"
+python -m unittest discover --start-directory "tests/integration"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,15 +5,15 @@ set -e # Fail if any line fails
 # 1. Run unit tests
 python -m unittest tests/e3sm_diags/*/test_*.py
 
-# 2. Enter tests directory
-cd tests
-
-# 3. Copy over test data and images from the web. [Takes about four minutes]
-cd integration && python download_data.py && cd ..
+# 2. Copy over test data and images from the web. [Takes about four minutes]
+# `-m` executes the the module as a stand-alone within a package, allowing for absolute imports
+# of other modules within the tests directory.
+# https://stackoverflow.com/a/3617928
+python -m tests.integration.download_data
 
 # To use `scp`, run the following two lines instead. Be sure to change <username>. [Takes about two minutes]
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/integration_test_data integration_test_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/expected/integration_test_images integration_test_images
 
-# 4. Run integration tests
-cd integration && python -m unittest && cd ..
+# 3. Run integration tests
+python -m unittest discover -s "tests/integration"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,24 +2,33 @@
 
 set -e # Fail if any line fails
 
-# 1. Run unit tests
+printf "1. Run unit tests\n"
+printf "==============================================\n"
 python -m unittest tests/e3sm_diags/*/test_*.py
 
-# 2. Copy over test data and images from the web. [Takes about four minutes]
+printf "\n2. Copy over test data and images from the web\n"
+printf "==============================================\n"
+# Takes about four minutes
 python -m tests.integration.download_data
 
 # To use `scp`, run the following two lines instead. Be sure to change <username>. [Takes about two minutes]
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/integration_test_data integration_test_data
 #scp -r <username>@blues.lcrc.anl.gov:/lcrc/group/e3sm/public_html/e3sm_diags_test_data/integration/expected/integration_test_images integration_test_images
 
-# 3. Run integration tests
+printf "\n3. Run integration tests\n"
+printf "==============================================\n"
 # Integration tests must be called individually. `e3sm_diags` uses `cdp_parser.get_parameters()`, which incorrectly picks up `python -m unittest` cmd args.
 # This results in `cdp_parser.get_parameters()` raising `error: unrecognized arguments <UNITTEST ARGS>`.
 # Running tests using these commands do not work:
 #  - `python -m unittest tests/integration/test_*.py`
 #  - `python -m unittest discover -s tests/integration --pattern "test_*.py"`
 # Related lines of code : https://github.com/CDAT/cdp/blob/2917603097112f7db52be0bf7a2e766e14cc2e16/cdp/cdp_parser.py#L498
-python -m unittest tests/integration/test_all_sets.py
-python -m unittest tests/integration/test_dataset.py
-python -m unittest tests/integration/test_diags.py
-python -m unittest tests/integration/test_run.py
+command='python -m unittest tests/integration/'
+declare -a files=("test_all_sets" "test_dataset" "test_diags" "test_run")
+for file in "${files[@]}";
+    do
+        file="${file}.py"
+        printf "\n${file}\n"
+        printf "~~~~~~~~~~~~~~~~~~~~"
+        eval "${command}${file}";
+done


### PR DESCRIPTION
This PR updates the commands in `test.sh` so that they are called explicitly, rather than using `cd tests` beforehand.

It also adds static string variables defining the paths and directories used in the integration test files to reduce repeated code.

- Closes #545 
- Extension of PR #544 
