### PR TITLE
Bump to 2.6.1rc1

### DIFF
--- a/conda/e3sm_diags_env.yml
+++ b/conda/e3sm_diags_env.yml
@@ -21,5 +21,5 @@ dependencies:
   - netcdf4=1.5.6
   # Additional
   # ==============
-  - e3sm_diags=2.6.0
+  - e3sm_diags=2.6.1rc1
 prefix: /opt/miniconda3/envs/e3sm_diags_env

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "e3sm_diags" %}
-{% set version = "2.6.0" %}
+{% set version = "2.6.1rc1" %}
 
 package:
     name: {{ name|lower }}

--- a/e3sm_diags/__init__.py
+++ b/e3sm_diags/__init__.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-__version__ = "v2.6.0"
+__version__ = "v2.6.1rc1"
 INSTALL_PATH = os.path.join(sys.prefix, "share/e3sm_diags/")
 
 # Disable MPI in cdms2, which is not currently supported by E3SM-unified

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ data_files = [
 
 setup(
     name="e3sm_diags",
-    version="2.6.0",
+    version="2.6.1rc1",
     author="Chengzhu (Jill) Zhang, Tom Vo, Ryan Forsyth, Chris Golaz and Zeshawn Shaheen",
     author_email="zhang40@llnl.gov",
     description="E3SM Diagnostics",

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/e3sm_diags"
 
 [version]
-current = "2.6.0"
+current = "2.6.1rc1"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
This PR bumps `e3sm_diags` from `2.6.0` to `2.6.1rc1`.