### PR TITLE
Add Q to zonal_mean_2d plots

### DIFF
--- a/e3sm_diags/derivations/acme.py
+++ b/e3sm_diags/derivations/acme.py
@@ -1295,7 +1295,7 @@ derived_variables = {
             ),
         ]
     ),
-    "SHUM": OrderedDict(
+    "Q": OrderedDict(
         [
             (
                 ("hus",),

--- a/e3sm_diags/driver/default_diags/zonal_mean_2d_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/zonal_mean_2d_model_vs_model.cfg
@@ -27,6 +27,14 @@ diff_levels = [-20,-15,-10,-7.5,-5.0,-2.5,-1.0,1.0,2.5,5.0,7.5,10,15,20]
 [#]
 sets = ["zonal_mean_2d"]
 case_id = "model_vs_model"
+variables = ["Q"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0.2, 0.5, 1, 2.5, 5, 7.5, 10, 12.5, 15]
+diff_levels = [-1.5, -1, -0.5, -0.2, -0.1,-0.05,-0.01, 0.01,0.05, 0.1, 0.2, 0.5, 1, 1.5]
+
+[#]
+sets = ["zonal_mean_2d"]
+case_id = "model_vs_model"
 variables = ["OMEGA"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 test_colormap = "PiYG_r"

--- a/e3sm_diags/driver/default_diags/zonal_mean_2d_model_vs_obs.cfg
+++ b/e3sm_diags/driver/default_diags/zonal_mean_2d_model_vs_obs.cfg
@@ -28,7 +28,7 @@ ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [5,10,15,20,25,30,40,50,60,70,75,80,85,90,95]
-diff_levels = [-50,-40,-30,-20,-15,-10,-5,5,10,15,20,30,40,50]
+diff_levels = [-40,-30,-20,-15,-10,-5,-2.5,2.5,5,10,15,20,30,40]
 
 [#]
 sets = ["zonal_mean_2d"]
@@ -37,6 +37,8 @@ variables = ["Q"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0.2, 0.5, 1, 2.5, 5, 7.5, 10, 12.5, 15]
+diff_levels = [-1.5, -1, -0.5, -0.2, -0.1,-0.05,-0.01, 0.01,0.05, 0.1, 0.2, 0.5, 1, 1.5]
 
 [#]
 sets = ["zonal_mean_2d"]
@@ -92,7 +94,7 @@ ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [5,10,15,20,25,30,40,50,60,70,75,80,85,90,95]
-diff_levels = [-50,-40,-30,-20,-15,-10,-5,5,10,15,20,30,40,50]
+diff_levels = [-40,-30,-20,-15,-10,-5,-2.5,2.5,5,10,15,20,30,40]
 
 [#]
 sets = ["zonal_mean_2d"]
@@ -101,3 +103,5 @@ variables = ["Q"]
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0.2, 0.5, 1, 2.5, 5, 7.5, 10, 12.5, 15]
+diff_levels = [-1.5, -1, -0.5, -0.2, -0.1, -0.05,-0.01, 0.01,0.05, 0.1, 0.2, 0.5, 1, 1.5]

--- a/e3sm_diags/driver/default_diags/zonal_mean_2d_model_vs_obs.cfg
+++ b/e3sm_diags/driver/default_diags/zonal_mean_2d_model_vs_obs.cfg
@@ -33,6 +33,14 @@ diff_levels = [-50,-40,-30,-20,-15,-10,-5,5,10,15,20,30,40,50]
 [#]
 sets = ["zonal_mean_2d"]
 case_id = "MERRA2"
+variables = ["Q"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+
+[#]
+sets = ["zonal_mean_2d"]
+case_id = "MERRA2"
 variables = ["OMEGA"]
 ref_name = "MERRA2"
 reference_name = "MERRA2"
@@ -85,3 +93,11 @@ reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [5,10,15,20,25,30,40,50,60,70,75,80,85,90,95]
 diff_levels = [-50,-40,-30,-20,-15,-10,-5,5,10,15,20,30,40,50]
+
+[#]
+sets = ["zonal_mean_2d"]
+case_id = "ERA-Interim"
+variables = ["Q"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]

--- a/e3sm_diags/driver/default_diags/zonal_mean_2d_stratosphere_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/zonal_mean_2d_stratosphere_model_vs_model.cfg
@@ -21,8 +21,16 @@ sets = ["zonal_mean_2d_stratosphere"]
 case_id = "model_vs_model"
 variables = ["RELHUM"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-contour_levels = [5,10,15,20,25,30,40,50,60,70,75,80,85]
-diff_levels = [-10,-7.5,-5.0,-2.5,-1.0,1.0,2.5,5.0,7.5,10]
+contour_levels = [0.5,1,2,5,10,15,20,25,30,40,50,70]
+diff_levels = [-15,-10,-5,-2,-1,-0.5, 0.5, 1,2,5,10,15]
+
+[#]
+sets = ["zonal_mean_2d_stratosphere"]
+case_id = "model_vs_model"
+variables = ["Q"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0.6,0.8, 1, 1.2, 1.6, 2, 2.5, 3, 3.5, 4]
+diff_levels = [-3, -2,-1.5,-1,-0.5,-0.1,0.1,0.5,1,1.5,2,3]
 
 [#]
 sets = ["zonal_mean_2d_stratosphere"]

--- a/e3sm_diags/driver/default_diags/zonal_mean_2d_stratosphere_model_vs_obs.cfg
+++ b/e3sm_diags/driver/default_diags/zonal_mean_2d_stratosphere_model_vs_obs.cfg
@@ -33,6 +33,16 @@ diff_levels = [-15,-10,-5,-2,-1,1,2,5,10,15]
 [#]
 sets = ["zonal_mean_2d_stratosphere"]
 case_id = "MERRA2"
+variables = ["Q"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 3, 4]
+diff_levels = [-2,-1.5,-1,-0.5,-0.1,0.1,0.5,1,1.5,2]
+
+[#]
+sets = ["zonal_mean_2d_stratosphere"]
+case_id = "MERRA2"
 variables = ["OMEGA"]
 ref_name = "MERRA2"
 reference_name = "MERRA2"
@@ -85,3 +95,13 @@ reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [5,10,15,20,25,30,40,50,60,70,80]
 diff_levels = [-15,-10,-5,-2,-1,1,2,5,10,15]
+
+[#]
+sets = ["zonal_mean_2d_stratosphere"]
+case_id = "ERA-Interim"
+variables = ["Q"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 3, 4]
+diff_levels = [-2,-1.5,-1,-0.5,-0.1,0.1,0.5,1,1.5,2]

--- a/e3sm_diags/driver/default_diags/zonal_mean_2d_stratosphere_model_vs_obs.cfg
+++ b/e3sm_diags/driver/default_diags/zonal_mean_2d_stratosphere_model_vs_obs.cfg
@@ -27,8 +27,8 @@ variables = ["RELHUM"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-contour_levels = [5,10,15,20,25,30,40,50,60,70,80]
-diff_levels = [-15,-10,-5,-2,-1,1,2,5,10,15]
+contour_levels = [0.5,1,2,5,10,15,20,25,30,40,50,70]
+diff_levels = [-15,-10,-5,-2,-1,-0.5, 0.5, 1,2,5,10,15]
 
 [#]
 sets = ["zonal_mean_2d_stratosphere"]
@@ -37,8 +37,8 @@ variables = ["Q"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-contour_levels = [0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 3, 4]
-diff_levels = [-2,-1.5,-1,-0.5,-0.1,0.1,0.5,1,1.5,2]
+contour_levels = [0.6,0.8, 1, 1.2, 1.6, 2, 2.5, 3, 3.5, 4]
+diff_levels = [-3, -2,-1.5,-1,-0.5,-0.1,0.1,0.5,1,1.5,2,3]
 
 [#]
 sets = ["zonal_mean_2d_stratosphere"]
@@ -93,8 +93,8 @@ variables = ["RELHUM"]
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-contour_levels = [5,10,15,20,25,30,40,50,60,70,80]
-diff_levels = [-15,-10,-5,-2,-1,1,2,5,10,15]
+contour_levels = [0.5,1,2,5,10,15,20,25,30,40,50,70]
+diff_levels = [-15,-10,-5,-2,-1,-0.5, 0.5, 1,2,5,10,15]
 
 [#]
 sets = ["zonal_mean_2d_stratosphere"]
@@ -103,5 +103,5 @@ variables = ["Q"]
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-contour_levels = [0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 3, 4]
-diff_levels = [-2,-1.5,-1,-0.5,-0.1,0.1,0.5,1,1.5,2]
+contour_levels = [0.6,0.8, 1, 1.2, 1.6, 2, 2.5, 3, 3.5, 4]
+diff_levels = [-3, -2,-1.5,-1,-0.5,-0.1,0.1,0.5,1,1.5,2,3]

--- a/e3sm_diags/driver/zonal_mean_2d_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_driver.py
@@ -158,6 +158,19 @@ def run_diag(parameter, default_plevs=ZonalMean2dParameter().plevs):
                 mv2_p = utils.general.convert_to_pressure_levels(
                     mv2, plevs, ref_data, var, season
                 )
+
+                # Note this is a special case to handle small values of stratosphere specific humidity.
+                # The general derived variable process converts specific humidity to units [g/kg]
+                # Following converts from g/kg to ppm
+
+                if (
+                    parameter.current_set == "zonal_mean_2d_stratosphere"
+                    and parameter.var_id == "Q"
+                ):
+                    mv1_p = mv1_p * 1000.0
+                    mv1_p.units = "ppm"
+                    mv2_p = mv2_p * 1000.0
+                    mv2_p.units = "ppm"
                 # Regrid towards the lower resolution of the two
                 # variables for calculating the difference.
                 mv1_p_reg, mv2_p_reg = utils.general.regrid_to_lower_res(
@@ -166,6 +179,7 @@ def run_diag(parameter, default_plevs=ZonalMean2dParameter().plevs):
                     parameter.regrid_tool,
                     parameter.regrid_method,
                 )
+
                 diff_p = mv1_p_reg - mv2_p_reg
                 diff = cdutil.averager(diff_p, axis="x")
 

--- a/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
+++ b/e3sm_diags/plot/cartopy/zonal_mean_2d_plot.py
@@ -152,8 +152,8 @@ def plot_panel(n, fig, proj, var, clevels, cmap, title, parameters, stats=None):
         fontdict=plotSideTitle,
     )
 
-    # if Max is smaller than 0.01, use scientific notation
-    if stats[0] < 0.01:
+    # if positive Max is smaller than 0.01, use scientific notation
+    if stats[0] < 0.01 and stats[0] > 0:
         stats_fmt = "%.e\n%.e\n%.e"
     else:
         stats_fmt = "%.2f\n%.2f\n%.2f"

--- a/e3sm_diags/plot/cartopy/zonal_mean_2d_stratosphere_plot.py
+++ b/e3sm_diags/plot/cartopy/zonal_mean_2d_stratosphere_plot.py
@@ -4,4 +4,5 @@ from e3sm_diags.plot.cartopy.zonal_mean_2d_plot import plot as base_plot
 
 
 def plot(reference, test, diff, metrics_dict, parameter):
+
     return base_plot(reference, test, diff, metrics_dict, parameter)

--- a/examples/run_v2_6_0_all_sets_E3SM_machines.py
+++ b/examples/run_v2_6_0_all_sets_E3SM_machines.py
@@ -11,6 +11,8 @@ from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
 from e3sm_diags.parameter.qbo_parameter import QboParameter
 from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
 from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import ZonalMean2dStratosphereParameter
+
 from e3sm_diags.run import runner
 
 
@@ -187,6 +189,7 @@ def run_all_sets(html_prefix, d):
     tc_param.ref_end_yr = "2018"
 
     ac_param = ACzonalmeanParameter()
+    zm_param = ZonalMean2dStratosphereParameter()
 
     runner.sets_to_run = [
         "lat_lon",
@@ -208,6 +211,7 @@ def run_all_sets(html_prefix, d):
     runner.run_diags(
         [
             param,
+            zm_param,
             ac_param,
             enso_param,
             qbo_param,


### PR DESCRIPTION
Add Q to both regular zonal_mean_2d and zonal_mean_2d_stratosphere: 
Example plots show here:
https://compy-dtn.pnl.gov/zhan429/zonal_mean2d/v2_6_0_all_sets_compute/viewer/

Refined both RELHUM, Q contour levels and added to model_vs_model .cfg