### PR TITLE
Add ERA5 in lat-lon

### DIFF
--- a/e3sm_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
@@ -720,6 +720,253 @@ diff_colormap = "RdBu"
 contour_levels = [0., 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5]
 diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
 
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["LHFLX"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0,5, 15, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300]
+diff_levels = [-150, -120, -90, -60, -30, -20, -10, -5, 5, 10, 20, 30, 60, 90, 120, 150]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["SHFLX"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-100, -75, -50, -25, -10, 0, 10, 25, 50, 75, 100, 125, 150]
+diff_levels = [-100, -80, -60, -40, -20, -10, -5, 5, 10, 20, 40, 60, 80, 100]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["PSL"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [955, 965, 975,980, 985, 990, 995, 1000, 1005, 1010, 1015, 1020, 1025, 1035]
+diff_levels = [ -16, -12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12, 16]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["FSNS"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["FLNS"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [0, 20, 40, 60, 80, 100, 120, 140, 160]
+diff_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["NET_FLUX_SRF"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-200, -160, -120, -80, -40, 0, 40, 80, 120, 160, 200]
+diff_levels = [-75, -50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50, 75]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["PRECT"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["TMQ"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
+diff_levels = [-12, -9, -6, -4, -3, -2, -1, 1, 2, 3, 4, 6, 9, 12]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["U"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+plevs = [850.0]
+test_colormap = "PiYG_r"
+reference_colormap = "PiYG_r"
+contour_levels = [-20, -15, -10, -8, -5, -3, -1, 1, 3, 5, 8, 10, 15, 20]
+diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["U"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN"]
+plevs = [200.0]
+test_colormap = "PiYG_r"
+reference_colormap = "PiYG_r"
+contour_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+diff_levels = [-15, -10, -8, -6, -4, -2, -1, 1, 2, 4, 6, 8, 10, 15]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["U"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["DJF", "MAM", "JJA", "SON"]
+plevs = [200.0]
+test_colormap = "PiYG_r"
+reference_colormap = "PiYG_r"
+contour_levels = [-75, -50, -30, -20, -10, -5, 5, 10, 20, 30, 50, 75]
+diff_levels = [-15, -10, -8, -6, -4, -2, 2, 4, 6, 8, 10, 15]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["Z3"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+plevs = [500.0]
+contour_levels = [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58]
+diff_levels = [-1.8, -1.4, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.4, 1.8]
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["OMEGA"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["DJF", "MAM", "JJA", "SON", "ANN"]
+plevs = [200.0]
+test_colormap = "PiYG_r"
+reference_colormap = "PiYG_r"
+contour_levels = [-35,-30,-25,-20,-15,-10,-5,5,10,15,20,25,30,35]
+diff_levels = [-20,-15,-10,-8,-6,-4,-2,2,4,6,8,10,15,20]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["OMEGA"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["DJF", "MAM", "JJA", "SON", "ANN"]
+plevs = [500.0]
+test_colormap = "PiYG_r"
+reference_colormap = "PiYG_r"
+contour_levels = [-110,-90,-70,-50,-30,-10,10,30,50,70,90,110]
+diff_levels = [-40,-30,-20,-16,-12,-8,-4,4,8,12,16,20,30,40]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["OMEGA"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["DJF", "MAM", "JJA", "SON", "ANN"]
+plevs = [850.0]
+test_colormap = "PiYG_r"
+reference_colormap = "PiYG_r"
+contour_levels = [-220,-180,-140,-100,-60,-20,-10,10,20, 60, 100, 140, 180, 220]
+diff_levels = [-80,-60,-40,-32,-24,-16,-8,-4, 4, 8,16,24,32,40,60,80]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["T"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN"]
+plevs = [850.0]
+contour_levels = [240, 245, 250, 255, 260, 265, 270, 275, 280, 285, 290, 295]
+diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["T"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["DJF", "MAM", "JJA", "SON"]
+plevs = [850.0]
+contour_levels = [230, 240, 250, 260, 270, 280, 290, 300]
+diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["T"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN"]
+plevs = [200.0]
+contour_levels = [210, 212, 214, 216, 218, 220, 222, 224, 226]
+diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["T"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["DJF", "MAM", "JJA", "SON"]
+plevs = [200.0]
+contour_levels = [200, 205, 210, 215, 220, 225, 230, 235, 240]
+diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["TAUXY"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+regions = ["ocean"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+test_colormap = "Purples"
+reference_colormap = "Purples"
+diff_colormap = "RdBu"
+contour_levels = [0., 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5]
+diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
 
 [#]
 sets = ["lat_lon"]
@@ -1276,6 +1523,16 @@ seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 5, 10, 15]
 
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["TREFHT"]
+regions = ["land", "global"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 5, 10, 15]
 
 [#]
 sets = ["lat_lon"]


### PR DESCRIPTION
This PR is to add ERA5 in addition to ERA-Interim. ERA-Interim is a global atmospheric reanalysis that is available from 1 January 1979 to 31 August 2019. It has been superseded by the ERA5 reanalysis. This updated ERA5 dataset has years ranging from 1979 to 2019, with 0.25 deg resolution. 
The datasets already available on all E3SM supported machines
