### PR TITLE
Set regrid method to bilinear for a subset of variables with masks or missing data

### DIFF
--- a/e3sm_diags/driver/default_diags/lat_lon_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_model_vs_model.cfg
@@ -18,6 +18,7 @@ variables = ["SST"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-1, 0, 1, 3, 6, 9, 12, 15, 18, 20, 22, 24, 26, 28, 29]
 diff_levels = [-2.5, -2, -1.5, -1, -0.5, -0.1, 0.1, 0.5, 1, 1.5, 2.0, 2.5]
+regrid_method = "bilinear"
 
 
 [#]

--- a/e3sm_diags/driver/default_diags/lat_lon_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_model_vs_model.cfg
@@ -274,6 +274,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-20, -15, -10, -8, -5, -3, -1, 1, 3, 5, 8, 10, 15, 20]
 diff_levels = [-15, -10, -8, -6, -4, -2, -1, 1, 2, 4, 6, 8, 10, 15]
+regrid_method = "bilinear"
 
 
 [#]
@@ -298,6 +299,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-220,-180,-140,-100,-60,-20,-10,10,20, 60, 100, 140, 180, 220]
 diff_levels = [-80,-60,-40,-32,-24,-16,-8,-4, 4, 8,16,24,32,40,60,80]
+regrid_method = "bilinear"
 
 
 [#]
@@ -341,6 +343,7 @@ seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 plevs = [850.0]
 contour_levels = [240, 245, 250, 255, 260, 265, 270, 275, 280, 285, 290, 295]
 diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.25, 0.25, 0.5, 1, 2, 3, 4, 5]
+regrid_method = "bilinear"
 
 
 [#]
@@ -617,7 +620,17 @@ diff_levels = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, -0.02, 0.02, 0.05, 0.1, 0.2,
 sets = ["lat_lon"]
 case_id = "model_vs_model"
 variables = ["TREFHT"]
-regions = ["global", "land"]
+regions = ["land"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+regrid_method = "bilinear"
+
+[#]
+sets = ["lat_lon"]
+case_id = "model_vs_model"
+variables = ["TREFHT"]
+regions = ["global"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
@@ -626,7 +639,7 @@ diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
 sets = ["lat_lon"]
 case_id = "model_vs_model"
 variables = ["TREFMNAV"]
-regions = ["global", "land"]
+regions = ["global"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
@@ -635,7 +648,7 @@ diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
 sets = ["lat_lon"]
 case_id = "model_vs_model"
 variables = ["TREFMXAV"]
-regions = ["global", "land"]
+regions = ["global"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
@@ -644,10 +657,40 @@ diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
 sets = ["lat_lon"]
 case_id = "model_vs_model"
 variables = ["TREF_range"]
-regions = ["land","global"]
+regions = ["global"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [2, 4, 6, 8, 10, 12, 14, 16,18]
 diff_levels = [ -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8]
+
+[#]
+sets = ["lat_lon"]
+case_id = "model_vs_model"
+variables = ["TREFMNAV"]
+regions = ["land"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"
+
+[#]
+sets = ["lat_lon"]
+case_id = "model_vs_model"
+variables = ["TREFMXAV"]
+regions = ["land"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"
+
+[#]
+sets = ["lat_lon"]
+case_id = "model_vs_model"
+variables = ["TREF_range"]
+regions = ["land"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [2, 4, 6, 8, 10, 12, 14, 16,18]
+diff_levels = [ -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8]
+regrid_method = "bilinear"
 
 [#]
 sets = ["lat_lon"]
@@ -660,6 +703,7 @@ reference_colormap = "Purples"
 diff_colormap = "RdBu"
 contour_levels = [0., 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5]
 diff_levels = [-0.1, -0.08, -0.06, -0.05, -0.04, -0.02, -0.01,  0.01, 0.02, 0.04, 0.05, 0.06, 0.08, 0.1]
+regrid_method = "bilinear"
 
 [#]
 sets = ["lat_lon"]

--- a/e3sm_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
@@ -38,6 +38,8 @@ reference_name = "CRU Global Monthly Mean T Land"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 5, 10, 15]
+regrid_method = "bilinear"
+
 
 
 [#]

--- a/e3sm_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_model_vs_obs.cfg
@@ -49,6 +49,7 @@ reference_name = "HadISST"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-1, 0, 1, 3, 6, 9, 12, 15, 18, 20, 22, 24, 26, 28, 29]
 diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+regrid_method = "bilinear"
 
 
 [#]
@@ -60,6 +61,7 @@ reference_name = "HadISST (Climatology)"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-1, 0, 1, 3, 6, 9, 12, 15, 18, 20, 22, 24, 26, 28, 29]
 diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+regrid_method = "bilinear"
 
 
 [#]
@@ -71,6 +73,7 @@ reference_name = "HadISST (Pre-Indust)"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-1, 0, 1, 3, 6, 9, 12, 15, 18, 20, 22, 24, 26, 28, 29]
 diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+regrid_method = "bilinear"
 
 
 [#]
@@ -82,6 +85,7 @@ reference_name = "HadISST (Present Day)"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-1, 0, 1, 3, 6, 9, 12, 15, 18, 20, 22, 24, 26, 28, 29]
 diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+regrid_method = "bilinear"
 
 [#]
 sets = ["lat_lon"]
@@ -575,6 +579,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-20, -15, -10, -8, -5, -3, -1, 1, 3, 5, 8, 10, 15, 20]
 diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+regrid_method = "bilinear"
 
 
 [#]
@@ -656,6 +661,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-220,-180,-140,-100,-60,-20,-10,10,20, 60, 100, 140, 180, 220]
 diff_levels = [-80,-60,-40,-32,-24,-16,-8,-4, 4, 8,16,24,32,40,60,80]
+regrid_method = "bilinear"
 
 
 [#]
@@ -668,6 +674,7 @@ seasons = ["ANN"]
 plevs = [850.0]
 contour_levels = [240, 245, 250, 255, 260, 265, 270, 275, 280, 285, 290, 295]
 diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+regrid_method = "bilinear"
 
 
 [#]
@@ -680,6 +687,7 @@ seasons = ["DJF", "MAM", "JJA", "SON"]
 plevs = [850.0]
 contour_levels = [230, 240, 250, 260, 270, 280, 290, 300]
 diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+regrid_method = "bilinear"
 
 
 [#]
@@ -719,6 +727,7 @@ reference_colormap = "Purples"
 diff_colormap = "RdBu"
 contour_levels = [0., 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5]
 diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
+regrid_method = "bilinear"
 
 [#]
 sets = ["lat_lon"]
@@ -823,6 +832,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-20, -15, -10, -8, -5, -3, -1, 1, 3, 5, 8, 10, 15, 20]
 diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+regrid_method = "bilinear"
 
 
 [#]
@@ -904,6 +914,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-220,-180,-140,-100,-60,-20,-10,10,20, 60, 100, 140, 180, 220]
 diff_levels = [-80,-60,-40,-32,-24,-16,-8,-4, 4, 8,16,24,32,40,60,80]
+regrid_method = "bilinear"
 
 
 [#]
@@ -916,6 +927,7 @@ seasons = ["ANN"]
 plevs = [850.0]
 contour_levels = [240, 245, 250, 255, 260, 265, 270, 275, 280, 285, 290, 295]
 diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+regrid_method = "bilinear"
 
 
 [#]
@@ -928,6 +940,7 @@ seasons = ["DJF", "MAM", "JJA", "SON"]
 plevs = [850.0]
 contour_levels = [230, 240, 250, 260, 270, 280, 290, 300]
 diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+regrid_method = "bilinear"
 
 
 [#]
@@ -967,6 +980,7 @@ reference_colormap = "Purples"
 diff_colormap = "RdBu"
 contour_levels = [0., 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5]
 diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
+regrid_method = "bilinear"
 
 [#]
 sets = ["lat_lon"]
@@ -1071,6 +1085,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-20, -15, -10, -8, -5, -3, -1, 1, 3, 5, 8, 10, 15, 20]
 diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+regrid_method = "bilinear"
 
 
 [#]
@@ -1153,6 +1168,7 @@ test_colormap = "PiYG_r"
 reference_colormap = "PiYG_r"
 contour_levels = [-220,-180,-140,-100,-60,-20,-10, 10,20, 60, 100, 140, 180, 220]
 diff_levels = [-80,-60,-40,-32,-24,-16,-8,-4, 4,8,16,24,32,40,60,80]
+regrid_method = "bilinear"
 
 
 [#]
@@ -1165,6 +1181,7 @@ seasons = ["ANN"]
 plevs = [850.0]
 contour_levels = [240, 245, 250, 255, 260, 265, 270, 275, 280, 285, 290, 295]
 diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+regrid_method = "bilinear"
 
 
 [#]
@@ -1177,6 +1194,7 @@ seasons = ["DJF", "MAM", "JJA", "SON"]
 plevs = [850.0]
 contour_levels = [230, 240, 250, 260, 270, 280, 290, 300]
 diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+regrid_method = "bilinear"
 
 
 [#]
@@ -1216,6 +1234,7 @@ reference_colormap = "Purples"
 diff_colormap = "RdBu"
 contour_levels = [0., 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5]
 diff_levels = [-0.13, -0.11, -0.09, -0.07, -0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.07, 0.09, 0.11, 0.13]
+regrid_method = "bilinear"
 
 
 [#]
@@ -1496,6 +1515,7 @@ reference_colormap = "Blues"
 diff_colormap = "RdBu"
 contour_levels = [10, 25, 50, 75, 100, 125, 150, 175, 200,225, 250]
 diff_levels = [-80, -60, -50, -40,-30, -20, -10, 10, 20,30, 40,50, 60, 80]
+regrid_method = "bilinear"
 
 [#]
 sets = ["lat_lon"]
@@ -1511,12 +1531,11 @@ diff_colormap = "BrBG_r"
 contour_levels = [0., 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2]
 diff_levels = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, -0.02, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
 
-
 [#]
 sets = ["lat_lon"]
 case_id = "ERA-Interim"
 variables = ["TREFHT"]
-regions = ["land", "global"]
+regions = ["global"]
 ref_name = "ERA-Interim"
 reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
@@ -1525,35 +1544,111 @@ diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
 
 [#]
 sets = ["lat_lon"]
-case_id = "ERA5"
+case_id = "ERA-Interim"
 variables = ["TREFHT"]
-regions = ["land", "global"]
-ref_name = "ERA5"
-reference_name = "ERA5 Reanalysis"
+regions = ["land"]
+ref_name = "ERA-Interim"
+reference_name = "ERA-Interim Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
-diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 5, 10, 15]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"
 
 [#]
 sets = ["lat_lon"]
-case_id = "MERRA2"
+case_id = "ERA5"
 variables = ["TREFHT"]
-regions = ["land", "global"]
-ref_name = "MERRA2"
-reference_name = "MERRA2 Reanalysis"
-regions = ["land","global"]
+regions = ["global"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
 
 [#]
 sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["TREFHT"]
+regions = ["land"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"
+
+[#]
+sets = ["lat_lon"]
 case_id = "MERRA2"
-variables = ["TREFMNAV"]
-regions = ["land", "global"]
+variables = ["TREFHT"]
+regions = ["global"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
-regions = ["land","global"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "MERRA2"
+variables = ["TREFHT"]
+regions = ["land"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"
+
+[#]
+sets = ["lat_lon"]
+case_id = "MERRA2"
+variables = ["TREFMNAV"]
+regions = ["land"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+regions = ["global"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"
+
+
+[#]
+sets = ["lat_lon"]
+case_id = "MERRA2"
+variables = ["TREFMXAV"]
+regions = ["land"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+regions = ["global"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"
+
+[#]
+sets = ["lat_lon"]
+case_id = "MERRA2"
+variables = ["TREF_range"]
+regions = ["land"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+regions = ["global"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [2, 4, 6, 8, 10, 12, 14, 16,18]
+diff_levels = [ -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8]
+regrid_method = "bilinear"
+
+[#]
+sets = ["lat_lon"]
+case_id = "MERRA2"
+variables = ["TREFMNAV"]
+regions = ["global"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+regions = ["global"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
@@ -1563,10 +1658,10 @@ diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
 sets = ["lat_lon"]
 case_id = "MERRA2"
 variables = ["TREFMXAV"]
-regions = ["land", "global"]
+regions = ["global"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
-regions = ["land","global"]
+regions = ["global"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
 diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
@@ -1575,10 +1670,10 @@ diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
 sets = ["lat_lon"]
 case_id = "MERRA2"
 variables = ["TREF_range"]
-regions = ["land", "global"]
+regions = ["global"]
 ref_name = "MERRA2"
 reference_name = "MERRA2 Reanalysis"
-regions = ["land","global"]
+regions = ["global"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 contour_levels = [2, 4, 6, 8, 10, 12, 14, 16,18]
 diff_levels = [ -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8]


### PR DESCRIPTION
This PR is to temporarily address a long-standing issue reported in #175  #411 #560  , where errors around edges of land/sea mask or missing data. The root cause is the treatment of masking in conservative method of cdms2.
For now, I have set variables with masks/missing data to use billinear regridding. TREFHT with ocean mask, TAUXY with land mask, T at 850mb, etc. 
To run with a sample simulation, the errors are gone. 
[conserv method](https://portal.nersc.gov/project/e3sm/zhang40/tests/e3sm_diags_regrid_consv/viewer/) vs [bilinear method](https://portal.nersc.gov/project/e3sm/zhang40/tests/e3sm_diags_regrid_bilinear/viewer/) comparing impacted variables.  
here gives ANN metrics difference, as a reference: https://www.diffchecker.com/iNS5B5gz 

We will replace the cdms2 regridding with xcdat/xesmf tool in the coming a few months. 
