### PR TITLE
exclude auxiliary_tools in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "docs|node_modules|migrations|.git|.tox|examples|analysis_data_preprocess|conda/meta.yaml"
+exclude: "docs|node_modules|migrations|.git|.tox|examples|analysis_data_preprocess|auxiliary_tools|conda/meta.yaml"
 default_stages: [commit]
 fail_fast: true
 


### PR DESCRIPTION
Auxiliary_tools folder hosts user contributed e3sm diags use cases. This PR excludes this folder from pre-commit hooks