### PR TITLE
Support Model only analysis

### DIFF
--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -66,7 +66,7 @@ def create_and_save_data_and_metrics(parameter, mv1_domain, mv2_domain):
 def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     """Creates the mean, max, min, rmse, corr in a dictionary"""
     # For input None, metrics are instantiated to 999.999.
-    # Apply float() to make sure the elements in metrics_dict are Jason serializable, i.e. np.float64 type is JSON serializable, but not np.float32.
+    # Apply float() to make sure the elements in metrics_dict are JSON serializable, i.e. np.float64 type is JSON serializable, but not np.float32.
     missing_value = 999.999
     metrics_dict = {}
     metrics_dict["ref"] = {

--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -14,58 +14,20 @@ from e3sm_diags.plot import plot
 logger = custom_logger(__name__)
 
 
-def create_metrics_test_only(test):
+def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     """Creates the mean, max, min, rmse, corr in a dictionary"""
     missing_value = 999.999
     metrics_dict = {}
     metrics_dict["ref"] = {
-        "min": missing_value,
-        "max": missing_value,
-        "mean": missing_value,
+        "min": float(min_cdms(ref)) if ref is not None else missing_value,
+        "max": float(max_cdms(ref)) if ref is not None else missing_value,
+        "mean": float(mean(ref)) if ref is not None else missing_value,
     }
     metrics_dict["ref_regrid"] = {
-        "min": missing_value,
-        "max": missing_value,
-        "mean": missing_value,
-        "std": missing_value,
-    }
-    metrics_dict["test"] = {
-        "min": float(min_cdms(test)),
-        "max": float(max_cdms(test)),
-        "mean": float(mean(test)),
-        "std": float(std(test)),
-    }
-    metrics_dict["test_regrid"] = {
-        "min": float(min_cdms(test)),
-        "max": float(max_cdms(test)),
-        "mean": float(mean(test)),
-        "std": float(std(test)),
-    }
-    metrics_dict["diff"] = {
-        "min": missing_value,
-        "max": missing_value,
-        "mean": missing_value,
-    }
-    metrics_dict["misc"] = {
-        "rmse": missing_value,
-        "corr": missing_value,
-    }
-    return metrics_dict
-
-
-def create_metrics(ref, test, ref_regrid, test_regrid, diff):
-    """Creates the mean, max, min, rmse, corr in a dictionary"""
-    metrics_dict = {}
-    metrics_dict["ref"] = {
-        "min": float(min_cdms(ref)),
-        "max": float(max_cdms(ref)),
-        "mean": float(mean(ref)),
-    }
-    metrics_dict["ref_regrid"] = {
-        "min": float(min_cdms(ref_regrid)),
-        "max": float(max_cdms(ref_regrid)),
-        "mean": float(mean(ref_regrid)),
-        "std": float(std(ref_regrid)),
+        "min": float(min_cdms(ref_regrid)) if ref_regrid is not None else missing_value,
+        "max": float(max_cdms(ref_regrid)) if ref_regrid is not None else missing_value,
+        "mean": float(mean(ref_regrid)) if ref_regrid is not None else missing_value,
+        "std": float(std(ref_regrid)) if ref_regrid is not None else missing_value,
     }
     metrics_dict["test"] = {
         "min": float(min_cdms(test)),
@@ -79,13 +41,17 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
         "std": float(std(test_regrid)),
     }
     metrics_dict["diff"] = {
-        "min": float(min_cdms(diff)),
-        "max": float(max_cdms(diff)),
-        "mean": float(mean(diff)),
+        "min": float(min_cdms(diff)) if diff is not None else missing_value,
+        "max": float(max_cdms(diff)) if diff is not None else missing_value,
+        "mean": float(mean(diff)) if diff is not None else missing_value,
     }
     metrics_dict["misc"] = {
-        "rmse": float(rmse(test_regrid, ref_regrid)),
-        "corr": float(corr(test_regrid, ref_regrid)),
+        "rmse": float(rmse(test_regrid, ref_regrid))
+        if ref_regrid is not None
+        else missing_value,
+        "corr": float(corr(test_regrid, ref_regrid))
+        if ref_regrid is not None
+        else missing_value,
     }
     return metrics_dict
 
@@ -206,8 +172,11 @@ def run_diag(parameter):  # noqa: C901
                             )
                         else:
                             mv2_domain = None
+                            mv2_reg = None
                             diff = None
-                            metrics_dict = create_metrics_test_only(mv1)
+                            metrics_dict = create_metrics(
+                                mv2_domain, mv1, mv2_reg, mv1, diff
+                            )
 
                             # Saving the metrics as a json.
                         metrics_dict["unit"] = mv1.units
@@ -274,10 +243,12 @@ def run_diag(parameter):  # noqa: C901
                             mv2_domain, mv1_domain, mv2_reg, mv1_reg, diff
                         )
                     else:
-                        mv1_domain = mv1
                         mv2_domain = None
+                        mv2_reg = None
                         diff = None
-                        metrics_dict = create_metrics_test_only(mv1)
+                        metrics_dict = create_metrics(
+                            mv2_domain, mv1, mv2_reg, mv1, diff
+                        )
 
                     # Saving the metrics as a json.
                     metrics_dict["unit"] = mv1.units

--- a/e3sm_diags/driver/lat_lon_land_driver.py
+++ b/e3sm_diags/driver/lat_lon_land_driver.py
@@ -1,7 +1,14 @@
 from __future__ import print_function
 
+from e3sm_diags.driver.lat_lon_driver import (
+    create_and_save_data_and_metrics as base_create_and_save_data_and_metrics,
+)
 from e3sm_diags.driver.lat_lon_driver import create_metrics as base_create_metrics
 from e3sm_diags.driver.lat_lon_driver import run_diag as base_run_diag
+
+
+def create_and_save_data_and_metrics(parameter, test, ref):
+    return base_create_and_save_data_and_metrics(parameter, test, ref)
 
 
 def create_metrics(ref, test, ref_regrid, test_regrid, diff):

--- a/e3sm_diags/driver/utils/general.py
+++ b/e3sm_diags/driver/utils/general.py
@@ -346,8 +346,8 @@ def save_ncfiles(set_num, test, ref, diff, parameter):
 
         with cdms2.open(test_pth, cdms_arg) as file_test:
             file_test.write(test)
-        
-        if parameter.ref_name != '':
+
+        if parameter.ref_name != "":
             # Save reference file
             if ref.id.startswith("variable_"):
                 ref.id = parameter.var_id

--- a/e3sm_diags/driver/utils/general.py
+++ b/e3sm_diags/driver/utils/general.py
@@ -346,21 +346,22 @@ def save_ncfiles(set_num, test, ref, diff, parameter):
 
         with cdms2.open(test_pth, cdms_arg) as file_test:
             file_test.write(test)
+        
+        if parameter.ref_name != '':
+            # Save reference file
+            if ref.id.startswith("variable_"):
+                ref.id = parameter.var_id
+            ref_pth = os.path.join(pth, parameter.output_file + "_ref.nc")
+            with cdms2.open(ref_pth, cdms_arg) as file_ref:
+                file_ref.write(ref)
 
-        # Save reference file
-        if ref.id.startswith("variable_"):
-            ref.id = parameter.var_id
-        ref_pth = os.path.join(pth, parameter.output_file + "_ref.nc")
-        with cdms2.open(ref_pth, cdms_arg) as file_ref:
-            file_ref.write(ref)
-
-        # Save difference file
-        if diff is not None:
-            if diff.id.startswith("variable_"):
-                diff.id = parameter.var_id + "_diff"
-            diff_pth = os.path.join(pth, parameter.output_file + "_diff.nc")
-            with cdms2.open(diff_pth, cdms_arg) as file_diff:
-                file_diff.write(diff)
+            # Save difference file
+            if diff is not None:
+                if diff.id.startswith("variable_"):
+                    diff.id = parameter.var_id + "_diff"
+                diff_pth = os.path.join(pth, parameter.output_file + "_diff.nc")
+                with cdms2.open(diff_pth, cdms_arg) as file_diff:
+                    file_diff.write(diff)
 
 
 def get_output_dir(set_num, parameter):

--- a/e3sm_diags/plot/cartopy/lat_lon_plot.py
+++ b/e3sm_diags/plot/cartopy/lat_lon_plot.py
@@ -256,7 +256,7 @@ def plot(reference, test, diff, metrics_dict, parameter):
         stats=(max1, mean1, min1),
     )
 
-    if parameter.ref_name !="":
+    if parameter.ref_name != "":
         min2 = metrics_dict["ref"]["min"]
         mean2 = metrics_dict["ref"]["mean"]
         max2 = metrics_dict["ref"]["max"]
@@ -291,7 +291,6 @@ def plot(reference, test, diff, metrics_dict, parameter):
             stats=(max3, mean3, min3, r, c),
         )
 
-
     # Save figure
     for f in parameter.output_format:
         f = f.lower().split(".")[-1]
@@ -307,8 +306,6 @@ def plot(reference, test, diff, metrics_dict, parameter):
         panels = [panel[0]]
     else:
         panels = panel
-    
- 
 
     for f in parameter.output_format_subplot:
         fnm = os.path.join(

--- a/e3sm_diags/plot/cartopy/lat_lon_plot.py
+++ b/e3sm_diags/plot/cartopy/lat_lon_plot.py
@@ -236,6 +236,9 @@ def plot(reference, test, diff, metrics_dict, parameter):
     fig = plt.figure(figsize=parameter.figsize, dpi=parameter.dpi)
     proj = ccrs.PlateCarree()
 
+    # Figure title
+    fig.suptitle(parameter.main_title, x=0.5, y=0.96, fontsize=18)
+
     # First two panels
     min1 = metrics_dict["test"]["min"]
     mean1 = metrics_dict["test"]["mean"]
@@ -253,41 +256,41 @@ def plot(reference, test, diff, metrics_dict, parameter):
         stats=(max1, mean1, min1),
     )
 
-    min2 = metrics_dict["ref"]["min"]
-    mean2 = metrics_dict["ref"]["mean"]
-    max2 = metrics_dict["ref"]["max"]
-    plot_panel(
-        1,
-        fig,
-        proj,
-        reference,
-        parameter.contour_levels,
-        parameter.reference_colormap,
-        (parameter.ref_name_yrs, parameter.reference_title, reference.units),
-        parameter,
-        stats=(max2, mean2, min2),
-    )
+    if parameter.ref_name !="":
+        min2 = metrics_dict["ref"]["min"]
+        mean2 = metrics_dict["ref"]["mean"]
+        max2 = metrics_dict["ref"]["max"]
 
-    # Third panel
-    min3 = metrics_dict["diff"]["min"]
-    mean3 = metrics_dict["diff"]["mean"]
-    max3 = metrics_dict["diff"]["max"]
-    r = metrics_dict["misc"]["rmse"]
-    c = metrics_dict["misc"]["corr"]
-    plot_panel(
-        2,
-        fig,
-        proj,
-        diff,
-        parameter.diff_levels,
-        parameter.diff_colormap,
-        (None, parameter.diff_title, test.units),
-        parameter,
-        stats=(max3, mean3, min3, r, c),
-    )
+        plot_panel(
+            1,
+            fig,
+            proj,
+            reference,
+            parameter.contour_levels,
+            parameter.reference_colormap,
+            (parameter.ref_name_yrs, parameter.reference_title, reference.units),
+            parameter,
+            stats=(max2, mean2, min2),
+        )
 
-    # Figure title
-    fig.suptitle(parameter.main_title, x=0.5, y=0.96, fontsize=18)
+        # Third panel
+        min3 = metrics_dict["diff"]["min"]
+        mean3 = metrics_dict["diff"]["mean"]
+        max3 = metrics_dict["diff"]["max"]
+        r = metrics_dict["misc"]["rmse"]
+        c = metrics_dict["misc"]["corr"]
+        plot_panel(
+            2,
+            fig,
+            proj,
+            diff,
+            parameter.diff_levels,
+            parameter.diff_colormap,
+            (None, parameter.diff_title, test.units),
+            parameter,
+            stats=(max3, mean3, min3, r, c),
+        )
+
 
     # Save figure
     for f in parameter.output_format:
@@ -297,14 +300,16 @@ def plot(reference, test, diff, metrics_dict, parameter):
             parameter.output_file + "." + f,
         )
         plt.savefig(fnm)
-        # Get the filename that the user has passed in and display that.
-        fnm = os.path.join(
-            get_output_dir(parameter.current_set, parameter),
-            parameter.output_file + "." + f,
-        )
         logger.info(f"Plot saved in: {fnm}")
 
     # Save individual subplots
+    if parameter.ref_name == "":
+        panels = [panel[0]]
+    else:
+        panels = panel
+    
+ 
+
     for f in parameter.output_format_subplot:
         fnm = os.path.join(
             get_output_dir(parameter.current_set, parameter),
@@ -312,7 +317,7 @@ def plot(reference, test, diff, metrics_dict, parameter):
         )
         page = fig.get_size_inches()
         i = 0
-        for p in panel:
+        for p in panels:
             # Extent of subplot
             subpage = np.array(p).reshape(2, 2)
             subpage[1, :] = subpage[0, :] + subpage[1, :]

--- a/e3sm_diags/viewer/default_viewer.py
+++ b/e3sm_diags/viewer/default_viewer.py
@@ -184,7 +184,6 @@ def create_viewer(root_dir, parameters):
         table_tuple = lat_lon_viewer.generate_lat_lon_metrics_table(
             LAT_LON_TABLE_INFO, SEASONS, viewer, root_dir, parameters
         )
-
         return [(name, url), table_tuple]
 
     return (name, url)

--- a/e3sm_diags/viewer/lat_lon_viewer.py
+++ b/e3sm_diags/viewer/lat_lon_viewer.py
@@ -66,11 +66,13 @@ def generate_lat_lon_metrics_table(
 
         lat_lon_table_info[season]["html_path"] = html_path
 
-    url = _create_lat_lon_table_index(lat_lon_table_info, seasons, viewer, root_dir)
+    url = _create_lat_lon_table_index(
+        lat_lon_table_info, seasons, viewer, root_dir, table_name
+    )
     utils.add_header(root_dir, os.path.join(root_dir, url), parameters)
-    _edit_table_html(lat_lon_table_info, seasons, root_dir)
+    _edit_table_html(lat_lon_table_info, seasons, root_dir, table_name)
 
-    return "Table", url
+    return f"Table{table_name}", url
 
 
 def _create_csv_from_dict(lat_lon_table_info, output_dir, season, test_name, run_type):
@@ -161,12 +163,14 @@ def _cvs_to_html(csv_path, season, test_name, ref_name):
     return html_path
 
 
-def _create_lat_lon_table_index(lat_lon_table_info, seasons, viewer, root_dir):
+def _create_lat_lon_table_index(
+    lat_lon_table_info, seasons, viewer, root_dir, table_name
+):
     """
     Create an index in the viewer that links the
     individual htmls for the lat-lon table.
     """
-    viewer.add_page("Table", seasons)
+    viewer.add_page(f"Table{table_name}", seasons)
     viewer.add_group("Summary Table")
     viewer.add_row("All variables")
 
@@ -432,7 +436,7 @@ def _create_taylor_index(seasons, viewer, root_dir, season_to_png):
     return url
 
 
-def _edit_table_html(lat_lon_table_info, seasons, root_dir):
+def _edit_table_html(lat_lon_table_info, seasons, root_dir, table_name):
     """
     After the viewer is created, edit the table html to
     insert the custom htmls.
@@ -486,5 +490,5 @@ def _edit_table_html(lat_lon_table_info, seasons, root_dir):
             _add_html_to_col(
                 s,
                 lat_lon_table_info[s]["html_path"],
-                os.path.join(root_dir, "table", "index.html"),
+                os.path.join(root_dir, f"table{table_name}", "index.html"),
             )


### PR DESCRIPTION
This PR is to address #536 
Enable plotting and generating metrics tables when reference data is not present. 
For instances:
1. Following single command line, would plot the precipitation lat-lon plot without including a reference data:
e3sm_diags lat_lon --no_viewer --sets 'lat_lon' --variables 'PRECT' --seasons 'ANN'  --test_name '20160520.A_WCYCL1850.ne30_oEC.edison.alpha6_01' --test_colormap 'WhiteBlueGreenYellowRed.rgb' --test_data_path '/Users/zhang40/Documents/ACME_simulations/' --reference_data_path '/Users/zhang40/Documents/ACME_simulations/obs_for_e3sm_diags/climatology' --results_dir '/Users/zhang40/Downloads/lat_lon_model_vs_none' --output_format_subplot 'pdf'

2. Users can use following .cfg file to create diags with a combination of variables, with or without an observation dataset.
[example output](https://portal.nersc.gov/cfs/e3sm/zhang40/tests/lat_lon_test_model_only/viewer/)
```
[Diags]
sets = ['lat_lon']
case_id = "model_only"
variables = ["AODVIS"]
seasons = ["ANN"]
regions = ["global"]

[Diags2]
sets = ['lat_lon']
case_id = "model_only"
variables = ["PRECL"]
seasons = ["ANN"]
regions = ["global"]

[Diags3]
sets = ['lat_lon']
case_id = "GPCP_v2.3"
ref_name = "GPCP_v2.3"
variables = ["PRECT"]
seasons = ["ANN"]
regions = ["global"]