### PR TITLE
Add fix to improve and correct model_only implementation

### DIFF
--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -15,7 +15,7 @@ logger = custom_logger(__name__)
 
 
 def create_and_save_data_and_metrics(parameter, mv1_domain, mv2_domain):
-    if parameter.ref_name != "":
+    if not parameter.model_only:
         # Regrid towards the lower resolution of the two
         # variables for calculating the difference.
         mv1_reg, mv2_reg = utils.general.regrid_to_lower_res(
@@ -137,6 +137,7 @@ def run_diag(parameter):  # noqa: C901
                 land_frac = f("LANDFRAC")
                 ocean_frac = f("OCNFRAC")
 
+        parameter.model_only = False
         for var in variables:
             logger.info("Variable: {}".format(var))
             parameter.var_id = var
@@ -147,8 +148,8 @@ def run_diag(parameter):  # noqa: C901
             except (RuntimeError, IOError):
                 mv2 = mv1
                 logger.info("Can not process reference data, analyse test data only")
-                parameter.ref_name = ""
-                parameter.case_id = "Model_only"
+
+                parameter.model_only = True
 
             parameter.viewer_descr[var] = (
                 mv1.long_name

--- a/e3sm_diags/plot/cartopy/lat_lon_plot.py
+++ b/e3sm_diags/plot/cartopy/lat_lon_plot.py
@@ -260,7 +260,7 @@ def plot(reference, test, diff, metrics_dict, parameter):
         stats=(max1, mean1, min1),
     )
 
-    if parameter.ref_name != "":
+    if not parameter.model_only:
         min2 = metrics_dict["ref"]["min"]
         mean2 = metrics_dict["ref"]["mean"]
         max2 = metrics_dict["ref"]["max"]

--- a/e3sm_diags/viewer/lat_lon_viewer.py
+++ b/e3sm_diags/viewer/lat_lon_viewer.py
@@ -116,15 +116,22 @@ def _create_csv_from_dict(lat_lon_table_info, output_dir, season, test_name, run
             metrics = metrics_dic["metrics"]
             if run_type == "model_vs_model":
                 key = key.split()[0] + " " + key.split()[1]
+
+            if (
+                metrics["test_regrid"]["mean"] == 999.999
+                or metrics["ref_regrid"]["mean"] == 999.999
+            ):
+                mean_bias = 999.999
+            else:
+                mean_bias = (
+                    metrics["test_regrid"]["mean"] - metrics["ref_regrid"]["mean"]
+                )
             row = [
                 key,
                 metrics["unit"],
                 round(metrics["test_regrid"]["mean"], 3),
                 round(metrics["ref_regrid"]["mean"], 3),
-                round(
-                    metrics["test_regrid"]["mean"] - metrics["ref_regrid"]["mean"],
-                    3,
-                ),
+                round(mean_bias, 3),
                 round(metrics["test_regrid"]["std"], 3),
                 round(metrics["ref_regrid"]["std"], 3),
                 round(metrics["misc"]["rmse"], 3),


### PR DESCRIPTION
Close #597 
With the fix:
- Model-only run (i.e. missing seasons) will have the same ref name as those without obs seasons missing, thus showing on the same viewer line. 
- Theread_e3sm_diags_metrics routine for cmip6 comparison now would not fail on metrics json files with incomplete filename: i.e. "-season-region.json". 
- Bug fix in calculating mean bias in model-only case.