### PR TITLE
Fix `FileNotFoundError` for log file

### DIFF
--- a/e3sm_diags/logger.py
+++ b/e3sm_diags/logger.py
@@ -59,7 +59,7 @@ def custom_logger(name: str, propagate: bool = True) -> logging.Logger:
     >>> logger.critical("")
     """
     log_format = "%(asctime)s [%(levelname)s]: %(filename)s(%(funcName)s:%(lineno)s) >> %(message)s"
-    log_filemode = "a"
+    log_filemode = "w"
 
     # Setup
     logging.basicConfig(


### PR DESCRIPTION
- Closes #601 
- Add `force=True` in `logging.basicConfig` under `setup_custom_logger()` to clear root handlers and avoid sharing file references in between runs
- Update `move_log_to_prov_dir()`
- Add module level instantiation of `logger` in `logger.py` to avoid repeating logger outputs in `move_log_to_prov_dir()`