### PR TITLE
Update GH Actions workflows

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -151,7 +151,7 @@ jobs:
           # Only replace `main` docs with latest changes. Docs for tags should be untouched.
           rm -rf _build/html/main
           mkdir -p _build/html/main
-          cp -r ../docs/_build/html/main _build/html/main
+          cp -r ../docs/_build/html/ _build/html/main
 
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -97,7 +97,7 @@ jobs:
         run: bash tests/test.sh
 
   publish-docs:
-    # if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -97,7 +97,7 @@ jobs:
         run: bash tests/test.sh
 
   publish-docs:
-    if: ${{ github.event_name == 'push' }}
+    # if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -139,11 +139,21 @@ jobs:
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/e3sm_diags.git --branch gh-pages --single-branch gh-pages
 
-          # Only replace main docs with latest changes. Docs for tags should be untouched.
+          # Make sure we're in the gh-pages directory.
           cd gh-pages
-          rm -r _build/html/main
+
+          # Create `.nojekyll` (if it doesn't already exist) for proper GH Pages configuration.
+          touch .nojekyll
+
+          # Add `index.html` to point to the `main` branch automatically.
+          printf '<meta http-equiv="refresh" content="0; url=./_build/html/main/index.html" />' >> index.html
+
+          # Only replace main docs with latest changes. Docs for tags should be untouched.
+          rm -rf _build/html/main
+          mkdir -p _build/html/main
           cp -r ../docs/_build/html/main _build/html/main
 
+          # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -151,7 +151,7 @@ jobs:
           # Only replace `main` docs with latest changes. Docs for tags should be untouched.
           rm -rf _build/html/main
           mkdir -p _build/html/main
-          cp -r ../docs/_build/html/ _build/html/main
+          cp -r ../docs/_build/html/main _build/html
 
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -146,9 +146,9 @@ jobs:
           touch .nojekyll
 
           # Add `index.html` to point to the `main` branch automatically.
-          printf '<meta http-equiv="refresh" content="0; url=./_build/html/main/index.html" />' >> index.html
+          printf '<meta http-equiv="refresh" content="0; url=./_build/html/main/index.html" />' > index.html
 
-          # Only replace main docs with latest changes. Docs for tags should be untouched.
+          # Only replace `main` docs with latest changes. Docs for tags should be untouched.
           rm -rf _build/html/main
           mkdir -p _build/html/main
           cp -r ../docs/_build/html/main _build/html/main

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -59,7 +59,7 @@ jobs:
           # Only replace `main` docs with latest changes. Docs for tags should be untouched.
           rm -rf _build/html/main
           mkdir -p _build/html/main
-          cp -r ../docs/_build/html/ _build/html/main
+          cp -r ../docs/_build/html/main _build/html
 
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -54,9 +54,9 @@ jobs:
           touch .nojekyll
 
           # Add `index.html` to point to the `main` branch automatically.
-          printf '<meta http-equiv="refresh" content="0; url=./_build/html/main/index.html" />' >> index.html
+          printf '<meta http-equiv="refresh" content="0; url=./_build/html/main/index.html" />' > index.html
 
-          # Only replace main docs with latest changes. Docs for tags should be untouched.
+          # Only replace `main` docs with latest changes. Docs for tags should be untouched.
           rm -rf _build/html/main
           mkdir -p _build/html/main
           cp -r ../docs/_build/html/main _build/html/main

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -47,12 +47,21 @@ jobs:
           # gh-pages branch must already exist
           git clone https://github.com/E3SM-Project/e3sm_diags.git --branch gh-pages --single-branch gh-pages
 
+          # Make sure we're in the gh-pages directory.
           cd gh-pages
-          # Replace main docs to populate dropdown with latest tags
-          rm -r _build/html/main
-          # Only copy docs for main and current tag
-          cp -r -n ../docs/_build/html _build/
 
+          # Create `.nojekyll` (if it doesn't already exist) for proper GH Pages configuration.
+          touch .nojekyll
+
+          # Add `index.html` to point to the `main` branch automatically.
+          printf '<meta http-equiv="refresh" content="0; url=./_build/html/main/index.html" />' >> index.html
+
+          # Only replace main docs with latest changes. Docs for tags should be untouched.
+          rm -rf _build/html/main
+          mkdir -p _build/html/main
+          cp -r ../docs/_build/html/main _build/html/main
+
+          # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -59,7 +59,7 @@ jobs:
           # Only replace `main` docs with latest changes. Docs for tags should be untouched.
           rm -rf _build/html/main
           mkdir -p _build/html/main
-          cp -r ../docs/_build/html/main _build/html/main
+          cp -r ../docs/_build/html/ _build/html/main
 
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -165,5 +165,5 @@ texinfo_documents = [
 
 # -- Options sphinx-multiversion -------------------------------------------
 smv_tag_whitelist = r"^v\d+\.\d+.\d+$"  # Include tags like "tags/v2.5.0"
-smv_branch_whitelist = "master"
+smv_branch_whitelist = "main"
 smv_remote_whitelist = r"^(origin|upstream)$"  # Use branches from origin

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -30,7 +30,7 @@ This documentation is created using
 that makes it easy to create intelligent and beautiful documentation, written
 by Georg Brandl and licensed under the BSD license.
 
-The documentation is maintained in the ``master`` branch of the GitHub repository.
+The documentation is maintained in the ``main`` branch of the GitHub repository.
 You can include code and its corresponding documentation updates in a single pull request (PR).
 
 After merging a PR, GitHub Actions automates the documentation building process.
@@ -83,7 +83,7 @@ To begin editing:
 
       Docs version selector dropdown in the bottom left-hand corner
 
-7. Create a pull request from ``<your-fork>/e3sm_diags/branch-name`` to ``E3SM-Project/e3sm_diags/master``.
+7. Create a pull request from ``<your-fork>/e3sm_diags/branch-name`` to ``E3SM-Project/e3sm_diags/main``.
 
 Once this pull request is merged and GitHub Actions finishes building the docs, changes will be available on the
 `e3sm_diags documentation page <https://e3sm-project.github.io/e3sm_diags/>`_.

--- a/docs/source/dev_guide/project-standards.rst
+++ b/docs/source/dev_guide/project-standards.rst
@@ -16,19 +16,19 @@ The repository uses a fork-based Git workflow with tag releases.
 
 Guidelines
 ~~~~~~~~~~
-1. ``master`` must always be **deployable**
+1. ``main`` must always be **deployable**
 2. All changes are made through **support** branches on forks
-3. **Rebase** with ``master`` to avoid/resolve conflicts
+3. **Rebase** with ``main`` to avoid/resolve conflicts
 4. Make sure ``pre-commit`` checks pass when committing (enforced in CI/CD build)
 5. Open a pull-request (PR) early for discussion
 6. Once the CI/CD build passes and PR is approved, **squash and rebase** your
    commits
-7. Merge PR into ``master`` and **delete the branch**
+7. Merge PR into ``main`` and **delete the branch**
 
 Things to Avoid
 ~~~~~~~~~~~~~~~
 1. Don't merge in broken or commented out code
-2. Don't commit onto ``master`` directly
+2. Don't commit onto ``main`` directly
 3. Don't merge with conflicts (handle conflicts upon rebasing)
 
 Source: https://gist.github.com/jbenet/ee6c9ac48068889b0912
@@ -74,8 +74,8 @@ Run individual hook ::
 Squash and Rebase Commits
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Before you merge a support branch back into ``master``, the branch is typically
-squashed down to a single* buildable commit, and then rebased on top of the main repo's ``master`` branch.
+Before you merge a support branch back into ``main``, the branch is typically
+squashed down to a single* buildable commit, and then rebased on top of the main repo's ``main`` branch.
 
 \* *In some cases, it might be logical to have multiple squashed commits, as long as each commit passes the CI/CD build*
 
@@ -93,11 +93,11 @@ How to squash and rebase commits
 
 Assuming that you followed :ref:`"(b) Development Environment" <dev-env>`:
 
-1. Sync ``master`` with the main repo's ``master`` ::
+1. Sync ``main`` with the main repo's ``main`` ::
 
-    git checkout master
-    git rebase <upstream-origin>/master
-    git push -f <fork-origin> master
+    git checkout main
+    git rebase <upstream-origin>/main
+    git push -f <fork-origin> main
 
 2. Get the SHA of the commit OR number of commits to rebase to ::
 
@@ -111,10 +111,10 @@ Assuming that you followed :ref:`"(b) Development Environment" <dev-env>`:
 
     git rebase -i HEAD~[NUMBER OF COMMITS]
 
-4. Rebase branch onto ``master`` ::
+4. Rebase branch onto ``main`` ::
 
     git checkout <branch-name>
-    git rebase master
+    git rebase main
     git push -f <fork-origin> <branch-name>
 
 5. Make sure your squashed commit messages are refined
@@ -155,13 +155,13 @@ This project uses `GitHub Actions <https://github.com/E3SM-Project/e3sm_diags/ac
 
 1. CI/CD Build Workflow
 
-  This workflow is triggered by Git ``pull_request`` and ``push`` (merging PRs) events to the the main repo's ``master``.
+  This workflow is triggered by Git ``pull_request`` and ``push`` (merging PRs) events to the the main repo's ``main``.
 
   Jobs:
 
     1. Run ``pre-commit`` for formatting, linting, and type checking
     2. Run test suite in a conda environment
-    3. Publish latest `master` docs (only on `push`)
+    3. Publish latest `main` docs (only on `push`)
 
 2. CI/CD Release Workflow
 

--- a/docs/source/dev_guide/releasing-e3sm-diags.rst
+++ b/docs/source/dev_guide/releasing-e3sm-diags.rst
@@ -13,7 +13,7 @@ In this guide, we'll cover:
 Bumping the Version
 -------------------
 
-1. Checkout the latest ``master``.
+1. Checkout the latest ``main``.
 2. Checkout a branch with the name of the version.
 
     ::
@@ -56,11 +56,11 @@ Releasing on GitHub
 -------------------
 
 1. Draft a new release on the `releases page <https://github.com/E3SM-Project/e3sm_diags/releases>`_.
-2. Set `Tag version` to ``v<version>``, **including the "v"**. `@Target` should be ``master``.
+2. Set `Tag version` to ``v<version>``, **including the "v"**. `@Target` should be ``main``.
 3. Set `Release title` to ``v<version>``, **including the "v"**.
 4. Use `Describe this release` to summarize the changelog.
 
-   * You can scroll through `e3sm-diags commits <https://github.com/E3SM-Project/e3sm_diags/commits/master>`_ for a list of changes.
+   * You can scroll through `e3sm-diags commits <https://github.com/E3SM-Project/e3sm_diags/commits/main>`_ for a list of changes.
 
 5. If this version is a release candidate (``<version>`` appended with ``rc``), checkmark `This is a pre-release`.
 6. Click `Publish release`.

--- a/docs/source/dev_guide/testing.rst
+++ b/docs/source/dev_guide/testing.rst
@@ -43,7 +43,7 @@ After merging your pull request, edit ``README.md``.
 The version should be the version of E3SM Diags you ran ``./tests/test.sh`` with,
 the date should be the date you ran ``./tests/test.sh`` on,
 and the hash should be for the top commit shown by ``git log`` or on
-https://github.com/E3SM-Project/e3sm_diags/commits/master.
+https://github.com/E3SM-Project/e3sm_diags/commits/main.
 
 
 Automated tests
@@ -115,4 +115,4 @@ The version should be the version of E3SM Diags you ran
 ``python -m unittest tests/complete_run.py`` with,
 the date should be the date you ran ``python -m unittest tests/complete_run.py`` on,
 and the hash should be for the top commit shown by ``git log`` or on
-https://github.com/E3SM-Project/e3sm_diags/commits/master.
+https://github.com/E3SM-Project/e3sm_diags/commits/main.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -133,7 +133,7 @@ an SSL error unless you disable the SSL verification:
 
     ::
 
-        wget https://raw.githubusercontent.com/E3SM-Project/e3sm_diags/master/conda-env/prod.yml
+        wget https://raw.githubusercontent.com/E3SM-Project/e3sm_diags/main/conda-env/prod.yml
 
 
 3. Change ``prefix`` in that file to be your conda prefix. Typically, this will be ``~/miniconda3/envs/e3sm_diags_env``.
@@ -167,7 +167,7 @@ Instead, the developer will ``pip install .`` to build ``e3sm-diags`` with chang
 
 1. Follow :ref:`"Others/Local" <conda_environment_others>` section for installing conda.
 
-2. Clone your fork and keep it in sync with the main repo's ``master``
+2. Clone your fork and keep it in sync with the main repo's ``main``
 
     ::
 
@@ -183,7 +183,7 @@ Instead, the developer will ``pip install .`` to build ``e3sm-diags`` with chang
         # You should see your fork listed as `origin`
 
 
-   or if you already have a clone of your fork, rebase your fork on the main repo's ``master`` to keep it in sync:
+   or if you already have a clone of your fork, rebase your fork on the main repo's ``main`` to keep it in sync:
 
     ::
 
@@ -195,23 +195,23 @@ Instead, the developer will ``pip install .`` to build ``e3sm-diags`` with chang
         # Fetch all the branches of that remote into remote-tracking branches
         git fetch <upstream-origin>
 
-        # Make sure that you're on your master branch:
-        git checkout master
+        # Make sure that you're on your main branch:
+        git checkout main
 
-        # Rewrite your master branch so that any of your commits that
-        # aren't already in <upstream-origin>/master are replayed on top of that branch:
-        git rebase <upstream-origin>/master
+        # Rewrite your main branch so that any of your commits that
+        # aren't already in <upstream-origin>/main are replayed on top of that branch:
+        git rebase <upstream-origin>/main
 
-        # Push your master branch to your GitHub fork:
+        # Push your main branch to your GitHub fork:
         # Note that <fork-origin> should be `origin` if you cloned your fork as above.
-        git push -f <fork-origin> master
+        git push -f <fork-origin> main
 
 
-   Checkout a new branch from ``master``.
+   Checkout a new branch from ``main``.
 
     ::
 
-        git checkout -b <branch-name> master
+        git checkout -b <branch-name> main
 
 3. Remove any cached conda packages. This will ensure that you always get the latest packages.
 


### PR DESCRIPTION
* Update `publish-docs` CI step to automate file creation on `gh-pages`
* Fix a command that attempts to remove a non-existent directory, which causes the build step for publishing docs to fail
* Update build step to test for Python 3.10
* Update `master` references to `main` in docs