### PR TITLE
CDAT Migration Phase 1 - Replace`CDPParameter`

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -29,5 +29,4 @@ dependencies:
   - scipy
   - pytest
   - pytest-cov
-
 prefix: /opt/miniconda3/envs/e3sm_diags_ci

--- a/e3sm_diags/driver/aerosol_aeronet_driver.py
+++ b/e3sm_diags/driver/aerosol_aeronet_driver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from typing import TYPE_CHECKING, Optional
 
@@ -7,13 +9,14 @@ from scipy import interpolate
 
 import e3sm_diags
 from e3sm_diags.driver import utils
+from e3sm_diags.logger import custom_logger
 from e3sm_diags.plot.cartopy import aerosol_aeronet_plot
 
 if TYPE_CHECKING:
-    from e3sm_diags.parameter.core_parameter import CoreParameter
     from cdms2.tvariable import TransientVariable
 
-from e3sm_diags.logger import custom_logger
+    from e3sm_diags.parameter.core_parameter import CoreParameter
+
 
 logger = custom_logger(__name__)
 
@@ -21,7 +24,7 @@ logger = custom_logger(__name__)
 # Years include 2006–2015 average climatology for observation according to Feng et al. 2022:doi:10.1002/essoar.10510950.1, and Golaz et al. 2022 E3SMv2 paper.
 
 
-def run_diag(parameter: "CoreParameter") -> "CoreParameter":
+def run_diag(parameter: CoreParameter) -> CoreParameter:
     """Runs the aerosol aeronet diagnostic.
 
     :param parameter: Parameters for the run
@@ -70,7 +73,7 @@ def run_diag(parameter: "CoreParameter") -> "CoreParameter":
 
 
 def interpolate_model_output_to_obs_sites(
-    var: Optional["TransientVariable"], var_id: str
+    var: Optional[TransientVariable], var_id: str
 ):
     """Interpolate model outputs (on regular lat lon grids) to observational sites
 

--- a/e3sm_diags/driver/aerosol_budget_driver.py
+++ b/e3sm_diags/driver/aerosol_budget_driver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import os
 from typing import TYPE_CHECKING  # , Optional
@@ -6,7 +8,6 @@ from e3sm_diags.driver import utils
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter
-#    from cdms2.tvariable import TransientVariable
 
 import cdutil
 import numpy
@@ -89,7 +90,7 @@ SPECIES_NAMES = {
 MISSING_VALUE = 999.999
 
 
-def run_diag(parameter: "CoreParameter") -> "CoreParameter":
+def run_diag(parameter: CoreParameter) -> CoreParameter:
     """Runs the aerosol aeronet diagnostic.
 
     :param parameter: Parameters for the run

--- a/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
+++ b/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, List
 
@@ -19,10 +19,12 @@ if TYPE_CHECKING:
     from cdms2.axis import TransientAxis
     from cdms2.tvariable import TransientVariable
 
-    from e3sm_diags.parameter.core_parameter import CoreParameter
+    from e3sm_diags.parameter.annual_cycle_zonal_mean_parameter import (
+        ACzonalmeanParameter,
+    )
 
 
-def run_diag(parameter: "CoreParameter"):
+def run_diag(parameter: ACzonalmeanParameter) -> ACzonalmeanParameter:
     """Runs the annual cycle zonal mean diagnostic.
 
     :param parameter: Parameters for the run
@@ -128,7 +130,7 @@ def run_diag(parameter: "CoreParameter"):
     return parameter
 
 
-def _create_annual_cycle(dataset: Dataset, variable: str) -> "TransientVariable":
+def _create_annual_cycle(dataset: Dataset, variable: str) -> TransientVariable:
     """Creates the annual climatology cycle for a dataset variable.
 
     :param dataset: Dataset
@@ -144,7 +146,7 @@ def _create_annual_cycle(dataset: Dataset, variable: str) -> "TransientVariable"
     for index, month in enumerate(month_list):
         var = dataset.get_climo_variable(variable, month)
         if month == "01":
-            var_ann_cycle: "TransientVariable" = MV2.zeros([12] + list(var.shape))
+            var_ann_cycle: TransientVariable = MV2.zeros([12] + list(var.shape))
             var_ann_cycle.id = var.id
             var_ann_cycle.long_name = var.long_name
             var_ann_cycle.units = var.units

--- a/e3sm_diags/driver/area_mean_time_series_driver.py
+++ b/e3sm_diags/driver/area_mean_time_series_driver.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import collections
 import json
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 import cdutil
@@ -10,6 +13,12 @@ from e3sm_diags.driver import utils
 from e3sm_diags.logger import custom_logger
 from e3sm_diags.metrics import mean
 from e3sm_diags.plot.cartopy import area_mean_time_series_plot
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.area_mean_time_series_parameter import (
+        AreaMeanTimeSeriesParameter,
+    )
+
 
 logger = custom_logger(__name__)
 
@@ -24,7 +33,7 @@ def create_metrics(ref_domain):
     return {"mean": mean(ref_domain)}
 
 
-def run_diag(parameter):
+def run_diag(parameter: AreaMeanTimeSeriesParameter) -> AreaMeanTimeSeriesParameter:
     variables = parameter.variables
     regions = parameter.regions
     ref_names = parameter.ref_names

--- a/e3sm_diags/driver/arm_diags_driver.py
+++ b/e3sm_diags/driver/arm_diags_driver.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import collections
 import json
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 import numpy as np
@@ -10,6 +13,9 @@ import e3sm_diags.derivations.acme
 from e3sm_diags.driver import utils
 from e3sm_diags.logger import custom_logger
 from e3sm_diags.plot.cartopy import arm_diags_plot
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.arm_diags_parameter import ARMDiagsParameter
 
 logger = custom_logger(__name__)
 
@@ -50,7 +56,7 @@ def create_metrics(test, ref):
     }
 
 
-def run_diag_diurnal_cycle(parameter):
+def run_diag_diurnal_cycle(parameter: ARMDiagsParameter) -> ARMDiagsParameter:
     variables = parameter.variables
     regions = parameter.regions
     ref_name = parameter.ref_name
@@ -149,7 +155,7 @@ def run_diag_diurnal_cycle(parameter):
     return parameter
 
 
-def run_diag_diurnal_cycle_zt(parameter):
+def run_diag_diurnal_cycle_zt(parameter: ARMDiagsParameter) -> ARMDiagsParameter:
     variables = parameter.variables
     regions = parameter.regions
     ref_name = parameter.ref_name
@@ -259,7 +265,7 @@ def run_diag_diurnal_cycle_zt(parameter):
     return parameter
 
 
-def run_diag_annual_cycle(parameter):
+def run_diag_annual_cycle(parameter: ARMDiagsParameter) -> ARMDiagsParameter:
     variables = parameter.variables
     regions = parameter.regions
     ref_name = parameter.ref_name
@@ -360,7 +366,7 @@ def run_diag_annual_cycle(parameter):
     return parameter
 
 
-def run_diag_convection_onset(parameter):
+def run_diag_convection_onset(parameter: ARMDiagsParameter) -> ARMDiagsParameter:
     regions = parameter.regions
     ref_name = parameter.ref_name
     ref_path = parameter.reference_data_path
@@ -407,11 +413,11 @@ def run_diag_convection_onset(parameter):
     return parameter
 
 
-def run_diag_pdf_daily(parameter):
+def run_diag_pdf_daily(parameter: ARMDiagsParameter):
     logger.info("'run_diag_pdf_daily' is not yet implemented.")
 
 
-def run_diag(parameter):
+def run_diag(parameter: ARMDiagsParameter) -> ARMDiagsParameter:
 
     if parameter.diags_set == "annual_cycle":
         return run_diag_annual_cycle(parameter)

--- a/e3sm_diags/driver/cosp_histogram_driver.py
+++ b/e3sm_diags/driver/cosp_histogram_driver.py
@@ -1,6 +1,7 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 
@@ -9,6 +10,9 @@ from e3sm_diags.driver import utils
 from e3sm_diags.logger import custom_logger
 from e3sm_diags.metrics import corr, max_cdms, mean, min_cdms, rmse
 from e3sm_diags.plot import plot
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
 
 logger = custom_logger(__name__)
 
@@ -40,7 +44,7 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return metrics_dict
 
 
-def run_diag(parameter):
+def run_diag(parameter: CoreParameter) -> CoreParameter:
     variables = parameter.variables
     seasons = parameter.seasons
     ref_name = getattr(parameter, "ref_name", "")

--- a/e3sm_diags/driver/diurnal_cycle_driver.py
+++ b/e3sm_diags/driver/diurnal_cycle_driver.py
@@ -1,6 +1,7 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 
@@ -11,8 +12,11 @@ from e3sm_diags.plot import plot
 
 logger = custom_logger(__name__)
 
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
 
-def run_diag(parameter):
+
+def run_diag(parameter: DiurnalCycleParameter) -> DiurnalCycleParameter:
     variables = parameter.variables
     seasons = parameter.seasons
     ref_name = getattr(parameter, "ref_name", "")

--- a/e3sm_diags/driver/enso_diags_driver.py
+++ b/e3sm_diags/driver/enso_diags_driver.py
@@ -1,8 +1,9 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import json
 import math
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 import cdutil
@@ -15,6 +16,10 @@ from e3sm_diags.driver import utils
 from e3sm_diags.logger import custom_logger
 from e3sm_diags.metrics import corr, max_cdms, mean, min_cdms, rmse, std
 from e3sm_diags.plot.cartopy.enso_diags_plot import plot_map, plot_scatter
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+
 
 logger = custom_logger(__name__)
 
@@ -185,7 +190,7 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return metrics_dict
 
 
-def run_diag_map(parameter):
+def run_diag_map(parameter: EnsoDiagsParameter) -> EnsoDiagsParameter:
     variables = parameter.variables
     seasons = parameter.seasons
     regions = parameter.regions
@@ -378,7 +383,7 @@ def run_diag_map(parameter):
     return parameter
 
 
-def run_diag_scatter(parameter):
+def run_diag_scatter(parameter: EnsoDiagsParameter) -> EnsoDiagsParameter:
     variables = parameter.variables
     run_type = parameter.run_type
     # We will always use the same regions, so we don't do the following:
@@ -433,7 +438,7 @@ def run_diag_scatter(parameter):
     return parameter
 
 
-def run_diag(parameter):
+def run_diag(parameter: EnsoDiagsParameter) -> EnsoDiagsParameter:
     if parameter.plot_type == "map":
         return run_diag_map(parameter)
     elif parameter.plot_type == "scatter":

--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -1,7 +1,8 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import json
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 
@@ -12,6 +13,9 @@ from e3sm_diags.metrics import corr, mean, rmse, std
 from e3sm_diags.plot import plot
 
 logger = custom_logger(__name__)
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
 
 
 def create_and_save_data_and_metrics(parameter, mv1_domain, mv2_domain):
@@ -107,7 +111,7 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return metrics_dict
 
 
-def run_diag(parameter):  # noqa: C901
+def run_diag(parameter: CoreParameter) -> CoreParameter:  # noqa: C901
     variables = parameter.variables
     seasons = parameter.seasons
     ref_name = getattr(parameter, "ref_name", "")

--- a/e3sm_diags/driver/lat_lon_land_driver.py
+++ b/e3sm_diags/driver/lat_lon_land_driver.py
@@ -1,10 +1,16 @@
-from __future__ import print_function
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from e3sm_diags.driver.lat_lon_driver import (
     create_and_save_data_and_metrics as base_create_and_save_data_and_metrics,
 )
 from e3sm_diags.driver.lat_lon_driver import create_metrics as base_create_metrics
 from e3sm_diags.driver.lat_lon_driver import run_diag as base_run_diag
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
+    from e3sm_diags.parameter.lat_lon_land_parameter import LatLonLandParameter
 
 
 def create_and_save_data_and_metrics(parameter, test, ref):
@@ -16,5 +22,5 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return base_create_metrics(ref, test, ref_regrid, test_regrid, diff)
 
 
-def run_diag(parameter):
+def run_diag(parameter: LatLonLandParameter) -> CoreParameter:
     return base_run_diag(parameter)

--- a/e3sm_diags/driver/lat_lon_river_driver.py
+++ b/e3sm_diags/driver/lat_lon_river_driver.py
@@ -1,10 +1,16 @@
-from __future__ import print_function
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from e3sm_diags.driver.lat_lon_driver import (
     create_and_save_data_and_metrics as base_create_and_save_data_and_metrics,
 )
 from e3sm_diags.driver.lat_lon_driver import create_metrics as base_create_metrics
 from e3sm_diags.driver.lat_lon_driver import run_diag as base_run_diag
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
+    from e3sm_diags.parameter.lat_lon_river_parameter import LatLonRiverParameter
 
 
 def create_and_save_data_and_metrics(parameter, test, ref):
@@ -16,5 +22,5 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return base_create_metrics(ref, test, ref_regrid, test_regrid, diff)
 
 
-def run_diag(parameter):
+def run_diag(parameter: LatLonRiverParameter) -> CoreParameter:
     return base_run_diag(parameter)

--- a/e3sm_diags/driver/meridional_mean_2d_driver.py
+++ b/e3sm_diags/driver/meridional_mean_2d_driver.py
@@ -1,4 +1,6 @@
-from __future__ import print_function
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import cdms2
 import cdutil
@@ -12,6 +14,11 @@ from e3sm_diags.parameter.zonal_mean_2d_parameter import ZonalMean2dParameter
 from e3sm_diags.plot import plot
 
 logger = custom_logger(__name__)
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.meridional_mean_2d_parameter import (
+        MeridionalMean2dParameter,
+    )
 
 
 def create_metrics(ref, test, ref_regrid, test_regrid, diff):
@@ -66,7 +73,7 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return metrics_dict
 
 
-def run_diag(parameter):
+def run_diag(parameter: MeridionalMean2dParameter) -> MeridionalMean2dParameter:
     variables = parameter.variables
     seasons = parameter.seasons
     ref_name = getattr(parameter, "ref_name", "")

--- a/e3sm_diags/driver/polar_driver.py
+++ b/e3sm_diags/driver/polar_driver.py
@@ -1,6 +1,7 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 import MV2
@@ -12,6 +13,9 @@ from e3sm_diags.metrics import corr, max_cdms, mean, min_cdms, rmse
 from e3sm_diags.plot import plot
 
 logger = custom_logger(__name__)
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
 
 
 def create_metrics(ref, test, ref_regrid, test_regrid, diff):
@@ -41,7 +45,7 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return metrics_dict
 
 
-def run_diag(parameter):
+def run_diag(parameter: CoreParameter) -> CoreParameter:
     variables = parameter.variables
     seasons = parameter.seasons
     ref_name = getattr(parameter, "ref_name", "")

--- a/e3sm_diags/driver/qbo_driver.py
+++ b/e3sm_diags/driver/qbo_driver.py
@@ -1,7 +1,8 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import json
 import os
+from typing import TYPE_CHECKING
 
 import cdutil
 import numpy as np
@@ -13,6 +14,9 @@ from e3sm_diags.logger import custom_logger
 from e3sm_diags.plot.cartopy.qbo_plot import plot
 
 logger = custom_logger(__name__)
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.qbo_parameter import QboParameter
 
 
 def unify_plev(var):
@@ -154,7 +158,7 @@ def get_psd_from_deseason(xraw, period_new):
     return psd_x_new0, amplitude_new0
 
 
-def run_diag(parameter):
+def run_diag(parameter: QboParameter) -> QboParameter:
     variables = parameter.variables
     # The region will always be 5S5N
     region = "5S5N"

--- a/e3sm_diags/driver/streamflow_driver.py
+++ b/e3sm_diags/driver/streamflow_driver.py
@@ -1,7 +1,8 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import csv
 import os
+from typing import TYPE_CHECKING
 
 import cdms2
 import cdutil
@@ -17,6 +18,9 @@ from e3sm_diags.plot.cartopy.streamflow_plot import (
 )
 
 logger = custom_logger(__name__)
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
 
 
 def get_drainage_area_error(
@@ -89,7 +93,7 @@ def get_seasonality(monthly):
     return seasonality_index, peak_month
 
 
-def run_diag(parameter):
+def run_diag(parameter: StreamflowParameter) -> StreamflowParameter:
     # Assume `model` will always be a `nc` file.
     # Assume `obs` will always be a `mat` file.
     using_test_mat_file = False

--- a/e3sm_diags/driver/tc_analysis_driver.py
+++ b/e3sm_diags/driver/tc_analysis_driver.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import annotations
 
 import collections
 import os
@@ -14,8 +14,7 @@ from e3sm_diags.plot.cartopy import tc_analysis_plot
 
 if TYPE_CHECKING:
     from numpy.ma.core import MaskedArray
-
-    from e3sm_diags.parameter.core_parameter import CoreParameter
+    from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
 
 from e3sm_diags.logger import custom_logger
 
@@ -38,7 +37,7 @@ BASIN_DICT: Dict[str, BasinInfo] = {
 }
 
 
-def run_diag(parameter: "CoreParameter") -> "CoreParameter":
+def run_diag(parameter: TCAnalysisParameter) -> TCAnalysisParameter:
     """Runs the tropical cyclone analysis diagnostic.
 
     :param parameter: Parameters for the run

--- a/e3sm_diags/driver/utils/dataset.py
+++ b/e3sm_diags/driver/utils/dataset.py
@@ -281,7 +281,10 @@ class Dataset:
         path = self.parameters.reference_data_path
         data_name = self.parameters.ref_name
 
-        if hasattr(self.parameters, "ref_file"):
+        if (
+            hasattr(self.parameters, "ref_file")
+            and getattr(self.parameters, "ref_file") != ""
+        ):
             fnm = os.path.join(path, self.parameters.ref_file)
             if not os.path.exists(fnm):
                 raise IOError("File not found: {}".format(fnm))

--- a/e3sm_diags/driver/zonal_mean_2d_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_driver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 import cdms2
@@ -67,7 +65,9 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return metrics_dict
 
 
-def run_diag(parameter, default_plevs=ZonalMean2dParameter().plevs):
+def run_diag(
+    parameter: ZonalMean2dParameter, default_plevs=ZonalMean2dParameter().plevs
+) -> ZonalMean2dParameter:
     variables = parameter.variables
     seasons = parameter.seasons
     ref_name = getattr(parameter, "ref_name", "")

--- a/e3sm_diags/driver/zonal_mean_2d_stratosphere_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_stratosphere_driver.py
@@ -6,18 +6,19 @@ from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import (
     ZonalMean2dStratosphereParameter,
 )
 
-if TYPE_CHECKING:
-    from e3sm_diags.parameter.core_parameter import CoreParameter
-
 
 def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     """Creates the mean, max, min, rmse, corr in a dictionary"""
     return base_create_metrics(ref, test, ref_regrid, test_regrid, diff)
 
 
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.zonal_mean_2d_parameter import ZonalMean2dParameter
+
+
 def run_diag(
     parameter: ZonalMean2dStratosphereParameter,
-) -> CoreParameter:
+) -> ZonalMean2dParameter:
     return base_run_diag(
         parameter, default_plevs=ZonalMean2dStratosphereParameter().plevs
     )

--- a/e3sm_diags/driver/zonal_mean_2d_stratosphere_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_stratosphere_driver.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from typing import TYPE_CHECKING
 
 from e3sm_diags.driver.zonal_mean_2d_driver import create_metrics as base_create_metrics
 from e3sm_diags.driver.zonal_mean_2d_driver import run_diag as base_run_diag
@@ -6,13 +6,18 @@ from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import (
     ZonalMean2dStratosphereParameter,
 )
 
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
+
 
 def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     """Creates the mean, max, min, rmse, corr in a dictionary"""
     return base_create_metrics(ref, test, ref_regrid, test_regrid, diff)
 
 
-def run_diag(parameter):
+def run_diag(
+    parameter: ZonalMean2dStratosphereParameter,
+) -> CoreParameter:
     return base_run_diag(
         parameter, default_plevs=ZonalMean2dStratosphereParameter().plevs
     )

--- a/e3sm_diags/driver/zonal_mean_2d_stratosphere_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_stratosphere_driver.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING
-
 from e3sm_diags.driver.zonal_mean_2d_driver import create_metrics as base_create_metrics
 from e3sm_diags.driver.zonal_mean_2d_driver import run_diag as base_run_diag
+from e3sm_diags.parameter.zonal_mean_2d_parameter import ZonalMean2dParameter
 from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import (
     ZonalMean2dStratosphereParameter,
 )
@@ -10,10 +9,6 @@ from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import (
 def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     """Creates the mean, max, min, rmse, corr in a dictionary"""
     return base_create_metrics(ref, test, ref_regrid, test_regrid, diff)
-
-
-if TYPE_CHECKING:
-    from e3sm_diags.parameter.zonal_mean_2d_parameter import ZonalMean2dParameter
 
 
 def run_diag(

--- a/e3sm_diags/driver/zonal_mean_xy_driver.py
+++ b/e3sm_diags/driver/zonal_mean_xy_driver.py
@@ -1,4 +1,6 @@
-from __future__ import print_function
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import cdms2
 import cdutil
@@ -11,6 +13,9 @@ from e3sm_diags.metrics import corr, max_cdms, mean, min_cdms, rmse
 from e3sm_diags.plot import plot
 
 logger = custom_logger(__name__)
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
 
 
 def regrid_to_lower_res_1d(mv1, mv2):
@@ -90,7 +95,7 @@ def create_metrics(ref, test, ref_regrid, test_regrid, diff):
     return metrics_dict
 
 
-def run_diag(parameter):
+def run_diag(parameter: CoreParameter) -> CoreParameter:
     variables = parameter.variables
     seasons = parameter.seasons
     ref_name = getattr(parameter, "ref_name", "")

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -351,7 +351,7 @@ def _run_with_dask(parameters: List[CoreParameter]) -> List[CoreParameter]:
     https://docs.dask.org/en/stable/generated/dask.dataframe.DataFrame.compute.html
     """
     bag = dask.bag.from_sequence(parameters)
-    config = {"scheduler": "processes", "context": "fork"}
+    config = {"scheduler": "processes", "multiprocessing.context": "fork"}
 
     num_workers = getattr(parameters[0], "num_workers", None)
     if num_workers is None:

--- a/e3sm_diags/parameter/annual_cycle_zonal_mean_parameter.py
+++ b/e3sm_diags/parameter/annual_cycle_zonal_mean_parameter.py
@@ -4,4 +4,6 @@ from .core_parameter import CoreParameter
 class ACzonalmeanParameter(CoreParameter):
     def __init__(self):
         super(ACzonalmeanParameter, self).__init__()
+        # Override existing attributes
+        # =============================
         self.granulate.remove("seasons")

--- a/e3sm_diags/parameter/annual_cycle_zonal_mean_parameter.py
+++ b/e3sm_diags/parameter/annual_cycle_zonal_mean_parameter.py
@@ -4,5 +4,4 @@ from .core_parameter import CoreParameter
 class ACzonalmeanParameter(CoreParameter):
     def __init__(self):
         super(ACzonalmeanParameter, self).__init__()
-        # A list of the reference names to run the diags on.
         self.granulate.remove("seasons")

--- a/e3sm_diags/parameter/area_mean_time_series_parameter.py
+++ b/e3sm_diags/parameter/area_mean_time_series_parameter.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from e3sm_diags.logger import custom_logger
 
 from .core_parameter import CoreParameter
@@ -8,22 +10,28 @@ logger = custom_logger(__name__)
 class AreaMeanTimeSeriesParameter(CoreParameter):
     def __init__(self):
         super(AreaMeanTimeSeriesParameter, self).__init__()
-        # A list of the reference names to run the diags on.
+        # Override existing attributes
+        # ============================
         self.ref_names = []
         self.ref_timeseries_input = True
         self.test_timeseries_input = True
-        # Granulating with regions doesn't make sense,
-        # because we have multiple regions for each plot.
-        # So keep all of the default values except regions.
-        # self.seasons = ['ANN']
+
+        # Granulating with regions doesn't make sense, because we have multiple
+        # regions for each plot. So keep all of the default values except
+        # regions.
         self.granulate.remove("regions")
         self.granulate.remove("seasons")
+
+        # Custom attributes
+        # =================
+        self.start_yr: Optional[str] = None
+        self.end_yr: Optional[str] = None
 
     def check_values(self):
         if not self.ref_names:
             msg = "You have no value for ref_names. Calculate test data only"
             logger.info(msg)
 
-        if not (hasattr(self, "start_yr") and hasattr(self, "end_yr")):
+        if self.start_yr is None and self.end_yr is None:
             msg = "You need to define both the 'start_yr' and 'end_yr' parameter."
             raise RuntimeError(msg)

--- a/e3sm_diags/parameter/arm_diags_parameter.py
+++ b/e3sm_diags/parameter/arm_diags_parameter.py
@@ -1,16 +1,27 @@
+from typing import Optional
+
 from .core_parameter import CoreParameter
 
 
 class ARMDiagsParameter(CoreParameter):
     def __init__(self):
         super(ARMDiagsParameter, self).__init__()
-        # A list of the reference names to run the diags on.
+        # Override existing attributes
+        # =============================
         self.granulate.remove("seasons")
         self.test_timeseries_input = True
         self.ref_timeseries_input = True
 
+        # Custom attributes
+        # =============================
+        self.test_start_yr: Optional[str] = None
+        self.test_end_yr: Optional[str] = None
+        self.ref_start_yr: Optional[str] = None
+        self.ref_end_yr: Optional[str] = None
 
-#    def check_values(self):
-#        if not self.ref_names:
-#            msg = 'You must have a value for ref_names.'
-#            raise RuntimeError(msg)
+        # "Options include: annual_cycle", "diurnal_cycle", "diurnal_cycle_zt",
+        # "pdf_daily", "convection_onset"
+        self.diags_set: Optional[str] = None
+
+        self.var_name: Optional[str] = None
+        self.var_units: Optional[str] = None

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -1,18 +1,59 @@
-from __future__ import print_function
+import copy
+from typing import Dict, List, Optional
 
-import cdp.cdp_parameter
 
-
-class CoreParameter(cdp.cdp_parameter.CDPParameter):
+class CoreParameter:
     def __init__(self):
-        self.case_id = ""
-        # The user must define these, so don't give any defaults.
-        # self.reference_data_path = ''
-        # self.test_data_path = ''
-        self.ref_timeseries_input = False
-        self.test_timeseries_input = False
+        # File I/O
+        # ------------------------
+        # FIXME: (REQUIRED) attributes should be set through `__init__` since
+        # they are required, but they are currently set after initializing the
+        # CoreParameter object (e.g., param.results_dir = "dir"). The default
+        # values are set to "", and `self.check_values()` will validate that
+        # it is not "" since they must be set by the user.
 
-        self.sets = [
+        # (REQUIRED) Path to the reference (obs) data. If there are multiple
+        # datasets in the path, use ref_name parameter to specify which dataset
+        # should be used.
+        self.reference_data_path: str = ""
+
+        # (REQUIRED) Path to the test (model) data.
+        self.test_data_path: str = ""
+
+        # (REQUIRED) The name of the folder where all runs will be stored.
+        self.results_dir: str = ""
+
+        # The name of the folder where the results (plots and nc files) will be
+        # stored for a single run
+        self.case_id = ""
+
+        # Set to True to not generate a Viewer for the result.
+        self.no_viewer: bool = False
+
+        # If True, stops running all of the diagnostics on the first failure.
+        # If False (the default), all errors are caught and ignored. If there
+        # was an error and a plot could not be created, there’s a ‘—’ for that
+        # set of parameters in the viewer.
+        self.debug: bool = False
+
+        # Time series data
+        # ------------------------
+        # Set to True if the ref data is in timeseries format. Default False. If
+        # True, both ref_start_yr and ref_end_yr must also be set.
+        self.ref_timeseries_input: bool = False
+
+        # Set to True if the test data is in timeseries format. Default False.
+        # If True, both test_start_yr and # test_end_yr must also be set.
+        self.test_timeseries_input: bool = False
+
+        # Diagnostic run settings
+        # ------------------------
+        # The supported run type for the diagnostics. Possible options are:
+        # 'model_vs_obs' (by default), 'model_vs_model', or 'obs_vs_obs'.
+        self.run_type: str = "model_vs_obs"
+
+        # A list of the sets to be run. Default is all sets
+        self.sets: List[str] = [
             "zonal_mean_xy",
             "zonal_mean_2d",
             "zonal_mean_2d_stratosphere",
@@ -33,67 +74,127 @@ class CoreParameter(cdp.cdp_parameter.CDPParameter):
             "aerosol_aeronet",
             "aerosol_budget",
         ]
-        self.dataset = ""
-        self.run_type = "model_vs_obs"
-        self.variables = []
-        self.seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-        self.regions = ["global"]
-        self.regrid_tool = "esmf"
-        self.regrid_method = "conservative"
-        self.plevs = []
-        self.plot_log_plevs = False
-        self.plot_plevs = False
 
-        # Plotting related.
-        self.main_title = ""
-        self.backend = "mpl"
-        self.save_netcdf = False
-        self.output_format = ["png"]
-        self.output_format_subplot = []
-        self.canvas_size_w = 1212
-        self.canvas_size_h = 1628
-        self.figsize = [8.5, 11.0]
-        self.dpi = 150
-        self.arrows = True
-        self.logo = False
+        # The current set that is being ran when looping over sets in
+        # `e3sm_diags_driver.run_diag()`.
+        self.current_set: str = ""
 
-        self.contour_levels = []
-        self.test_name = ""
-        self.short_test_name = ""
-        self.test_title = ""
-        self.test_colormap = "cet_rainbow.rgb"
-        self.test_units = ""
+        self.variables: List[str] = []
+        self.seasons: List[str] = ["ANN", "DJF", "MAM", "JJA", "SON"]
+        self.regions: List[str] = ["global"]
 
-        self.ref_name = ""
-        self.reference_name = ""
-        self.short_ref_name = ""
-        self.reference_title = ""
-        self.reference_colormap = "cet_rainbow.rgb"
-        self.reference_units = ""
+        self.regrid_tool: str = "esmf"
+        self.regrid_method: str = "conservative"
 
-        self.diff_name = ""
-        self.diff_title = "Model - Observation"
-        self.diff_colormap = "diverging_bwr.rgb"
-        self.diff_levels = []
-        self.diff_units = ""
+        self.plevs: List[float] = []
+        self.plot_log_plevs: bool = False
+        self.plot_plevs: bool = False
 
-        self.multiprocessing = False
-        self.num_workers = 4
+        self.multiprocessing: bool = False
+        self.num_workers: int = 4
 
-        self.no_viewer = False
-        self.debug = False
+        # Diagnostic plot settings
+        # ------------------------
+        self.main_title: str = ""
+        self.backend: str = "mpl"
+        self.save_netcdf: bool = False
 
-        self.granulate = ["variables", "seasons", "plevs", "regions"]
-        self.selectors = ["sets", "seasons"]
-        self.viewer_descr = {}
-        self.fail_on_incomplete = False
+        # Plot format settings
+        self.output_file: str = ""
+        self.output_format: List[str] = ["png"]
+        self.output_format_subplot: List[str] = []
+        self.canvas_size_w: int = 1212
+        self.canvas_size_h: int = 1628
+        self.figsize: List[float] = [8.5, 11.0]
+        self.dpi: int = 150
+        self.arrows: bool = True
+        self.logo: bool = False
+        self.contour_levels: List[str] = []
+
+        # Test plot settings
+        self.test_name: str = ""
+        self.test_name_yrs: str = ""
+        self.short_test_name: str = ""
+        self.test_title: str = ""
+        self.test_colormap: str = "cet_rainbow.rgb"
+        self.test_units: str = ""
+
+        # Reference plot settings
+        self.ref_name: str = ""
+        self.ref_name_yrs: str = ""
+        self.reference_name: str = ""
+        self.short_ref_name: str = ""
+        self.reference_title: str = ""
+        self.reference_colormap: str = "cet_rainbow.rgb"
+        self.reference_units: str = ""
+
+        # The reference file name based on the season and other parameters, for
+        # climo files only.
+        # FIXME: This attribute is only set in `dataset.get_ref_filename_climo()`.
+        self.ref_file: Optional[str] = None
+
+        # Variable ID is used as the reference file ID in `general.save_ncfiles()`
+        self.var_id: str = ""
+
+        # Variable region, used in polar plots.
+        self.var_region: str = ""
+
+        # Difference plot settings
+        self.diff_name: str = ""
+        self.diff_title: str = "Model - Observation"
+        self.diff_colormap: str = "diverging_bwr.rgb"
+        self.diff_levels: List[str] = []
+        self.diff_units: str = ""
+
+        # Other settings
+        # ------------------------
+        # TODO: Need documentation on these attributes here and
+        # here: https://e3sm-project.github.io/e3sm_diags/_build/html/main/available-parameters.html
+        self.dataset: str = ""
+        self.granulate: List[str] = ["variables", "seasons", "plevs", "regions"]
+        self.selectors: List[str] = ["sets", "seasons"]
+        self.viewer_descr: Dict[str, str] = {}
+        self.fail_on_incomplete: bool = False
+
+        # List of user derived variables, set in `dataset.Dataset`.
+        self.derived_variables: Dict[str, object] = {}
+
+        # FIXME: This attribute is only used in `lat_lon_driver.py`
+        self.model_only: bool = False
+
+    def __add__(self, other):
+        """Copies attributes from the other CoreParameter object to this one.
+
+        This method overrides existing attributes if they are already set
+        using the new values from the other object.
+
+        It is based on cdp.cdp_parameter.CDPParameter.__add__().
+
+        Parameters
+        ----------
+        other : CoreParameter
+            The other CoreParameter (or sub-class) object.
+
+        Returns
+        -------
+        CoreParameter
+            A new instance of CoreParameter with new attributes.
+        """
+        new_obj = copy.deepcopy(self)
+        new_attrs = other.__dict__
+
+        for attr, value in new_attrs.items():
+            setattr(new_obj, attr, value)
+
+        return new_obj
 
     def check_values(self):
-        # must_have_params = ['reference_data_path', 'test_data_path', 'results_dir']
-        must_have_params = ["test_data_path", "results_dir"]
-
+        # The default values for these attributes are set to "" in `__init__`.
+        # FIXME: The user should pass these values into the object
+        # initialization rather than having to check they are set here.
+        must_have_params = ["reference_data_path", "test_data_path", "results_dir"]
         for param in must_have_params:
-            if not hasattr(self, param):
+            if getattr(self, param) == "":
                 msg = "You need to specify {p} in the parameters file or via the command line using --{p}".format(
                     p=param
                 )

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 
 class CoreParameter:
@@ -130,8 +130,7 @@ class CoreParameter:
 
         # The reference file name based on the season and other parameters, for
         # climo files only.
-        # FIXME: This attribute is only set in `dataset.get_ref_filename_climo()`.
-        self.ref_file: Optional[str] = None
+        self.ref_file: str = ""
 
         # Variable ID is used as the reference file ID in `general.save_ncfiles()`
         self.var_id: str = ""

--- a/e3sm_diags/parameter/diurnal_cycle_parameter.py
+++ b/e3sm_diags/parameter/diurnal_cycle_parameter.py
@@ -4,8 +4,8 @@ from .core_parameter import CoreParameter
 class DiurnalCycleParameter(CoreParameter):
     def __init__(self):
         super(DiurnalCycleParameter, self).__init__()
+        # Custom attributes
+        # =============================
+        self.normalize_amp_int = 0
         self.print_statements = False
         self.normalize_test_amp = False
-        self.ref_timeseries_input = False
-        self.test_timeseries_input = False
-        self.normalize_amp_int = 0

--- a/e3sm_diags/parameter/enso_diags_parameter.py
+++ b/e3sm_diags/parameter/enso_diags_parameter.py
@@ -4,12 +4,17 @@ from .time_series_parameter import TimeSeriesParameter
 class EnsoDiagsParameter(TimeSeriesParameter):
     def __init__(self):
         super(EnsoDiagsParameter, self).__init__()
+        # Override existing attributes
+        # =============================
         self.granulate.remove("seasons")
+        self.ref_timeseries_input = True
+        self.test_timeseries_input = True
+
+        # Custom attributes
+        # =============================
         self.nino_region = "NINO34"
         self.plot_type = "map"
         self.print_statements = False
-        self.ref_timeseries_input = True
-        self.test_timeseries_input = True
 
     def check_values(self):
         super(EnsoDiagsParameter, self).check_values()

--- a/e3sm_diags/parameter/meridional_mean_2d_parameter.py
+++ b/e3sm_diags/parameter/meridional_mean_2d_parameter.py
@@ -8,6 +8,8 @@ from .core_parameter import CoreParameter
 class MeridionalMean2dParameter(CoreParameter):
     def __init__(self):
         super(MeridionalMean2dParameter, self).__init__()
+        # Override existing attributes
+        # =============================
         self.plevs = numpy.logspace(2.0, 3.0, num=17).tolist()
         self.plot_log_plevs = False
         self.plot_plevs = False

--- a/e3sm_diags/parameter/qbo_parameter.py
+++ b/e3sm_diags/parameter/qbo_parameter.py
@@ -1,10 +1,19 @@
+from typing import Optional
+
 from .time_series_parameter import TimeSeriesParameter
 
 
 class QboParameter(TimeSeriesParameter):
     def __init__(self):
         super(QboParameter, self).__init__()
+        # Override existing attributes
+        # =============================
         self.print_statements = False
         self.ref_timeseries_input = True
         self.test_timeseries_input = True
         self.granulate.remove("seasons")
+
+        # Custom attributes
+        # -----------------
+        self.ref_yrs: Optional[str] = None
+        self.test_yrs: Optional[str] = None

--- a/e3sm_diags/parameter/streamflow_parameter.py
+++ b/e3sm_diags/parameter/streamflow_parameter.py
@@ -4,6 +4,14 @@ from .time_series_parameter import TimeSeriesParameter
 class StreamflowParameter(TimeSeriesParameter):
     def __init__(self):
         super(StreamflowParameter, self).__init__()
+        # Override existing attributes
+        # =============================
+        self.ref_timeseries_input = True
+        self.test_timeseries_input = True
+        self.granulate.remove("seasons")
+
+        # Custom attributes
+        # =============================
         self.gauges_path = None
         self.main_title_seasonality_map = "Seasonality Map"
         self.main_title_annual_map = "Mean Annual Streamflow Map"
@@ -13,6 +21,3 @@ class StreamflowParameter(TimeSeriesParameter):
         self.output_file_annual_map = "annual_map"
         self.output_file_annual_scatter = "annual_scatter"
         self.print_statements = False
-        self.ref_timeseries_input = True
-        self.test_timeseries_input = True
-        self.granulate.remove("seasons")

--- a/e3sm_diags/parameter/tc_analysis_parameter.py
+++ b/e3sm_diags/parameter/tc_analysis_parameter.py
@@ -4,13 +4,19 @@ from .core_parameter import CoreParameter
 class TCAnalysisParameter(CoreParameter):
     def __init__(self):
         super(TCAnalysisParameter, self).__init__()
-        # A list of the reference names to run the diags on.
+        # Override existing attributes
+        # ============================
         self.granulate.remove("seasons")
-        self.test_timeseries_input = True
-        self.ref_timeseries_input = True
+        self.test_timeseries_input: bool = True
+        self.ref_timeseries_input: bool = True
 
+        # Custom attributes
+        # =================
+        self.ref_title: str = ""
 
-#    def check_values(self):
-#        if not self.ref_names:
-#            msg = 'You must have a value for ref_names.'
-#            raise RuntimeError(msg)
+        # TODO: There should be some validation checks because these attributes
+        # are used in `tc_analysis_driver.run_diag` when `self.run_type == "model_vs_model"`
+        self.ref_start_yr: str = ""
+        self.ref_end_yr: str = ""
+        self.test_start_yr: str = ""
+        self.test_end_yr: str = ""

--- a/e3sm_diags/parameter/time_series_parameter.py
+++ b/e3sm_diags/parameter/time_series_parameter.py
@@ -7,6 +7,9 @@ class TimeSeriesParameter(CoreParameter):
 
     def check_values(self):
         # Do not call super -- we want to overwrite check_values from CoreParameter
+        # TODO: These conditionals seem overly complex for mapping whether
+        # attributes are set. There is probably a better way to implement this.
+        # TODO: Write tests to cover this function.
         test_ref_start_yr_both_set = hasattr(self, "test_start_yr") and hasattr(
             self, "ref_start_yr"
         )

--- a/e3sm_diags/parameter/zonal_mean_2d_parameter.py
+++ b/e3sm_diags/parameter/zonal_mean_2d_parameter.py
@@ -9,36 +9,9 @@ class ZonalMean2dParameter(CoreParameter):
     def __init__(self):
         super(ZonalMean2dParameter, self).__init__()
         self.plevs = numpy.linspace(50, 1000, 20).tolist()
-        # self.plevs = numpy.logspace(2.0, 3.0, num=17).tolist()
-        # self.plevs = [
-        #    30.0,
-        #    50.0,
-        #    75.0,
-        #    100.0,
-        #    150.0,
-        #    200.0,
-        #    250.0,
-        #    300.0,
-        #    350.0,
-        #    400.0,
-        #    450.0,
-        #    500.0,
-        #    550.0,
-        #    600.0,
-        #    650.0,
-        #    700.0,
-        #    750.0,
-        #    800.0,
-        #    850.0,
-        #    875.0,
-        #    900.0,
-        #    925.0,
-        #    950.0,
-        #    975.0,
-        #    1000.0,
-        # ]
         self.plot_log_plevs = False
         self.plot_plevs = False
+
         # Granulating plevs causes duplicate plots in this case.
         # So keep all of the default values except plevs.
         self.granulate.remove("plevs")

--- a/e3sm_diags/parameter/zonal_mean_2d_parameter.py
+++ b/e3sm_diags/parameter/zonal_mean_2d_parameter.py
@@ -8,10 +8,11 @@ from .core_parameter import CoreParameter
 class ZonalMean2dParameter(CoreParameter):
     def __init__(self):
         super(ZonalMean2dParameter, self).__init__()
+        # Override existing attributes
+        # =============================
         self.plevs = numpy.linspace(50, 1000, 20).tolist()
         self.plot_log_plevs = False
         self.plot_plevs = False
-
         # Granulating plevs causes duplicate plots in this case.
         # So keep all of the default values except plevs.
         self.granulate.remove("plevs")

--- a/e3sm_diags/parameter/zonal_mean_2d_stratosphere_parameter.py
+++ b/e3sm_diags/parameter/zonal_mean_2d_stratosphere_parameter.py
@@ -6,5 +6,7 @@ from e3sm_diags.parameter.zonal_mean_2d_parameter import ZonalMean2dParameter
 class ZonalMean2dStratosphereParameter(ZonalMean2dParameter):
     def __init__(self):
         super(ZonalMean2dStratosphereParameter, self).__init__()
+        # Override existing attributes
+        # =============================
         self.plevs = numpy.logspace(0, 2.0, num=10).tolist()
         self.plot_log_plevs = True

--- a/tests/e3sm_diags/test_parameters.py
+++ b/tests/e3sm_diags/test_parameters.py
@@ -1,0 +1,249 @@
+import numpy as np
+import pytest
+
+from e3sm_diags.parameter.annual_cycle_zonal_mean_parameter import ACzonalmeanParameter
+from e3sm_diags.parameter.area_mean_time_series_parameter import (
+    AreaMeanTimeSeriesParameter,
+)
+from e3sm_diags.parameter.arm_diags_parameter import ARMDiagsParameter
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+from e3sm_diags.parameter.lat_lon_land_parameter import LatLonLandParameter
+from e3sm_diags.parameter.lat_lon_river_parameter import LatLonRiverParameter
+from e3sm_diags.parameter.meridional_mean_2d_parameter import MeridionalMean2dParameter
+from e3sm_diags.parameter.qbo_parameter import QboParameter
+from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.parameter.time_series_parameter import TimeSeriesParameter
+from e3sm_diags.parameter.zonal_mean_2d_parameter import ZonalMean2dParameter
+from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import (
+    ZonalMean2dStratosphereParameter,
+)
+
+
+class TestCoreParameter:
+    def test__init__(self):
+        CoreParameter()
+
+    def test__add__copies_attributes_from_other_object(self):
+        param1 = CoreParameter()
+        param2 = CoreParameter()
+
+        # Add custom attributes to the second object
+        param2.test_start_yr = 2000  # type: ignore
+        param2.test_end_yr = 2001  # type: ignore
+
+        new_param = param2 + param1
+
+        assert new_param.test_start_yr == 2000
+        assert new_param.test_end_yr == 2001
+
+    def test_check_values_does_not_raise_error_if_required_args_are_set(self):
+        param = CoreParameter()
+        param.reference_data_path = "path"
+        param.test_data_path = "path"
+        param.results_dir = "path"
+
+        param.check_values()
+
+    def test_check_values_raises_error_if_required_args_are_not_set(self):
+        param = CoreParameter()
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_raises_error_if_ref_timeseries_input_and_no_ref_start_and_end_year_set(
+        self,
+    ):
+        param = CoreParameter()
+        param.reference_data_path = "path"
+        param.test_data_path = "path"
+        param.results_dir = "path"
+
+        param.ref_timeseries_input = True
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_raises_error_if_test_timeseries_input_and_no_test_start_and_end_year_set(
+        self,
+    ):
+        param = CoreParameter()
+        param.reference_data_path = "path"
+        param.test_data_path = "path"
+        param.results_dir = "path"
+
+        param.test_timeseries_input = True
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+
+def test_ac_zonal_mean_parameter():
+    param = ACzonalmeanParameter()
+
+    assert "seasons" not in param.granulate
+
+
+def test_area_mean_time_series_parameter(caplog):
+    param = AreaMeanTimeSeriesParameter()
+
+    assert "regions" not in param.granulate
+    assert "seasons" not in param.granulate
+
+    # Raises error if no start year or end year set.
+    with pytest.raises(RuntimeError):
+        param.check_values()
+
+    assert "You have no value for ref_names. Calculate test data only" in caplog.text
+
+
+def test_arms_diags_parameter():
+    param = ARMDiagsParameter()
+
+    assert "seasons" not in param.granulate
+
+
+def test_diurnal_cycle_parameter():
+    DiurnalCycleParameter()
+
+
+def test_enso_diags_parameter():
+    param1 = EnsoDiagsParameter()
+
+    assert "seasons" not in param1.granulate
+
+    # Raises error if nino region is not valid.
+    param1.nino_region = "INVALID_NINO"
+    with pytest.raises(RuntimeError):
+        param1.check_values()
+
+    param2 = EnsoDiagsParameter()
+
+    # Raises error invalid plot type
+    param2.plot_type = "invalid_plot_Type"
+    with pytest.raises(RuntimeError):
+        param2.check_values()
+
+
+def test_lat_lon_land_parameter():
+    LatLonLandParameter()
+
+
+def test_lat_lon_river_parameter():
+    LatLonRiverParameter()
+
+
+class TestMeridionalMean2dParameter:
+    def test__init__(self):
+        param = MeridionalMean2dParameter()
+
+        assert "plevs" not in param.granulate
+        np.testing.assert_allclose(param.plevs, np.logspace(2.0, 3.0, num=17))
+
+    def test_check_values_raises_error_if_plevs_is_not_a_list(self):
+        param = MeridionalMean2dParameter()
+        param.plevs = "not_an_array"  # type: ignore
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_raises_error_if_plevs_are_not_monotonically_increasing_or_decreasing(
+        self,
+    ):
+        param = MeridionalMean2dParameter()
+        param.plevs = [1, 0, 2]
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_raises_error_if_less_than_2_plevs_are_set(self):
+        param = MeridionalMean2dParameter()
+        param.plevs = [1]
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_forces_monotonically_increasing_list(self):
+        param = MeridionalMean2dParameter()
+        param.plevs = [3, 2, 1]
+
+        param.check_values()
+
+        assert param.plevs == [1, 2, 3]
+
+
+def test_qbo_parameter():
+    param = QboParameter()
+
+    assert "seasons" not in param.granulate
+
+
+def test_streamflow_parameter():
+    param = StreamflowParameter()
+
+    assert "seasons" not in param.granulate
+
+
+def test_tc_analysis_parameter():
+    param = TCAnalysisParameter()
+
+    assert "seasons" not in param.granulate
+
+
+class TestTimeSeriesParameter:
+    def test__init__(self):
+        TimeSeriesParameter()
+
+    @pytest.mark.xfail
+    def test_check_values_raises_error_if_start_year_set_with_no_end_year(self):
+        assert 0
+
+    @pytest.mark.xfail
+    def test_check_values_raises_error_if_end_year_set_with_no_start_year(self):
+        assert 0
+
+
+class TestZonalMean2dParameter:
+    def test__init__(self):
+        param = ZonalMean2dParameter()
+
+        assert "plevs" not in param.granulate
+        np.testing.assert_allclose(param.plevs, np.linspace(50, 1000, 20))
+
+    def test_check_values_raises_error_if_plevs_is_not_a_list(self):
+        param = ZonalMean2dParameter()
+        param.plevs = "not_an_array"  # type: ignore
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_raises_error_if_plevs_are_not_monotonically_increasing_or_decreasing(
+        self,
+    ):
+        param = ZonalMean2dParameter()
+        param.plevs = [1, 0, 2]
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_raises_error_if_less_than_2_plevs_are_set(self):
+        param = ZonalMean2dParameter()
+        param.plevs = [1]
+
+        with pytest.raises(RuntimeError):
+            param.check_values()
+
+    def test_check_values_forces_monotonically_increasing_list(self):
+        param = ZonalMean2dParameter()
+        param.plevs = [3, 2, 1]
+
+        param.check_values()
+
+        assert param.plevs == [1, 2, 3]
+
+
+def test_zonal_mean_2d_stratosphere_parameter():
+    param = ZonalMean2dStratosphereParameter()
+    np.testing.assert_allclose(param.plevs, np.logspace(0, 2.0, num=10))


### PR DESCRIPTION
Closes #633 

This PR removes `CDPParameter` as a dependency from the `CoreParameter` class and its sub-classes. This was a fairly non-invasive process. I tried to avoid refactoring too much code in this PR to avoid unwanted side-effects that would require more debugging (#639 is for refactoring).

The parameter classes are used the same way to configure `e3sm_diags`, which means there are no public API changes in this PR that warrant a major release.

## Steps

### 1. Refactor `CoreParameter`
- [x] Remove `CoreParser` subclassing `CDPParameter` 
  -  `CDPParameter` is just a Python class that stores parameters as object attributes.
  - As a result, removing this dependency was straightforward and painless.
- [x] Port `__add_()` method from `CDPParameter`
  - This was the only method from `CDPParameter` that was being called in `e3sm_diags`.
  - I refactored the implementation so the logic is now simpler.

### 2. Refactor `CoreParameter` Inheritance
- [x] Understand how `CoreParameter` class is sub-classed and extended
  - Each child parameter subclass (e.g. `ZonalMean2dParameter`) either does nothing except sub-class, modifies or updates attributes, adds new attributes, or has unique `check_values()`
  - `SETS_TO_PARAMETER` defined in `parameter/__init__.py` maps the string name of "set" to the parameter class
- [x] Figure out an extensible way of inheriting from `CoreParameter` for each diagnostic set

**UPDATE: I decided to keep the current design pattern to minimize side-effects. Opened up a new issue to address refactoring here #639.**

### 3. Testing and cleanup
- [x] Add unit tests for each parameter class 
  - The only method that I did not test was `TimeSeriesParameter.check_values()` because the conditional statements are a bit too complex for me to sit down and understand for this PR. I added a TODO statement to revisit this later.
- [x] Test locally with `run_e3sm_diags.py` script
- [x] Integration tests still pass
