### PR TITLE
CDAT Migration Phase 1: Replace `cdp.cdp_run`

### DIFF
--- a/.vscode/e3sm_diags.code-workspace
+++ b/.vscode/e3sm_diags.code-workspace
@@ -35,14 +35,10 @@
     "python.linting.mypyArgs": ["--config=setup.cfg"],
     // Testing
     // ---------------------------
-    "python.testing.unittestEnabled": true,
-    "python.testing.unittestArgs": [
-      "-v",
-      "-s",
-      "./tests/e3sm_diags",
-      "-p",
-      "test_*.py"
-    ],
+    // NOTE: Debugger doesn't work if pytest-cov is enabled, so set "--no-cov"
+    // https://github.com/microsoft/vscode-python/issues/693
+    "python.testing.pytestArgs": ["--no-cov"],
+    "python.testing.pytestEnabled": true,
     // ===================
     // Extension settings
     // ===================

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -16,6 +16,7 @@ dependencies:
   - cdp
   - cdms2
   - cdutil
+  - dask
   - genutil
   - lxml
   - mache
@@ -23,6 +24,10 @@ dependencies:
   - netcdf4
   - numpy
   - xarray
-  # Required in test suite
+  # Testing
+  # ==================
   - scipy
+  - pytest
+  - pytest-cov
+
 prefix: /opt/miniconda3/envs/e3sm_diags_ci

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -14,6 +14,7 @@ dependencies:
   - cdp=1.7.0
   - cdms2=3.1.5
   - cdutil=8.2.1
+  - dask=2022.12.0
   - genutil=8.2.1
   - lxml=4.9.2
   - mache=1.9.0
@@ -32,6 +33,8 @@ dependencies:
   - isort=5.11.3
   - mypy=0.991
   - pre-commit=2.20.0
+  - pytest=7.2.0
+  - pytest-cov=4.0.0
   # Developer Tools
   # =================
   - tbump=6.9.0

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
-from __future__ import print_function
+# The above line is needed for `test_all_sets.test_all_sets_mpl`.
+# Otherwise, OSError: [Errno 8] Exec format error: 'e3sm_diags_driver.py'.
 
 import importlib
 import os
 import subprocess
 import sys
 import traceback
-from typing import Dict, Tuple
+from typing import Dict, List, Optional, Tuple
 
-import cdp.cdp_run
+import dask
 
 import e3sm_diags
 from e3sm_diags.logger import custom_logger
@@ -38,23 +39,6 @@ def get_default_diags_path(set_name, run_type, print_path=True):
             )
         )
     return pth
-
-
-def _collapse_results(parameters):
-    """
-    When using cdp_run, parameters is a list of lists: [[Parameters], ...].
-    Make this just a list: [Parameters, ...].
-    """
-    output_parameters = []
-
-    for p1 in parameters:
-        if isinstance(p1, list):
-            for p2 in p1:
-                output_parameters.append(p2)
-        else:
-            output_parameters.append(p1)
-
-    return output_parameters
 
 
 def _save_env_yml(results_dir):
@@ -256,29 +240,6 @@ def get_parameters(parser=CoreParser()):
     return parameters
 
 
-def run_diag(parameters):
-    """
-    For a single set of parameters, run the corresponding diags.
-    """
-    results = []
-    for set_name in parameters.sets:
-
-        parameters.current_set = set_name
-        mod_str = "e3sm_diags.driver.{}_driver".format(set_name)
-        try:
-            module = importlib.import_module(mod_str)
-            single_result = module.run_diag(parameters)
-            print("")
-            results.append(single_result)
-        except Exception:
-            logger.exception("Error in {}".format(mod_str), exc_info=True)
-            traceback.print_exc()
-            if parameters.debug:
-                sys.exit()
-
-    return results
-
-
 def create_parameter_dict(parameters):
     d: Dict[type, int] = dict()
     for parameter in parameters:
@@ -290,58 +251,207 @@ def create_parameter_dict(parameters):
     return d
 
 
+def run_diag(parameter: CoreParameter) -> List[CoreParameter]:
+    """Run the corresponding diagnostics for a set of parameters.
+
+    Additional CoreParameter (or CoreParameter sub-class) objects are derived
+    from the CoreParameter `sets` attribute, hence this function returns a
+    list of CoreParameter objects.
+
+    This function loops over the specified diagnostic sets and runs the
+    diagnostic using the parameters.
+
+    Parameters
+    ----------
+    parameter : CoreParameter
+        The CoreParameter object to run diagnostics on.
+
+    Returns
+    -------
+    List[CoreParameter]
+        The list of CoreParameter objects with results from the diagnostic run.
+    """
+    results = []
+
+    for set_name in parameter.sets:
+        # FIXME: The parameter and driver for a diagnostic should be mapped
+        # together. If this is done, the `run_diag` function should be
+        # accessible by the parameter class without needing to perform a static
+        # string reference for the module name.
+        parameter.current_set = set_name
+        mod_str = "e3sm_diags.driver.{}_driver".format(set_name)
+
+        # Check if there is a matching driver module for the `set_name`.
+        try:
+            module = importlib.import_module(mod_str)
+        except ModuleNotFoundError as e:
+            logger.error(f"'Error with set name {set_name}'", exc_info=e)
+            continue
+
+        # If the module exists, call the driver module's `run_diag` function.
+        try:
+            single_result = module.run_diag(parameter)
+            results.append(single_result)
+        except Exception:
+            logger.exception(f"Error in {mod_str}", exc_info=True)
+
+            if parameter.debug:
+                sys.exit()
+
+    return results
+
+
+def _run_serially(parameters: List[CoreParameter]) -> List[CoreParameter]:
+    """Run diagnostics with the parameters serially.
+
+    Parameters
+    ----------
+    parameters : List[CoreParameter]
+        The list of CoreParameter objects to run diagnostics on.
+
+    Returns
+    -------
+    List[CoreParameter]
+        The list of CoreParameter objects with results from the diagnostic run.
+    """
+    results = []
+
+    for p in parameters:
+        results.append(run_diag(p))
+
+    # `results` becomes a list of lists of parameters so it needs to be
+    # collapsed a level.
+    collapsed_results = _collapse_results(results)
+
+    return collapsed_results
+
+
+def _run_with_dask_multiprocessing(
+    parameters: List[CoreParameter],
+    num_workers: Optional[int] = None,
+) -> List[CoreParameter]:
+    """Run diagnostics with the parameters in parallel using Dask.
+
+    This function passes ``run_diag`` to ``dask.bag.map``, which gets executed
+    in parallel with ``.compute``.
+
+    Parameters
+    ----------
+    parameters : List[CoreParameter]
+        The list of CoreParameter objects to run diagnostics on.
+    num_workers : Optional[int], optional
+        The number of workers for multiprocessing, by default None
+
+    Returns
+    -------
+    List[CoreParameter]
+        The list of CoreParameter objects with results from the diagnostic run.
+
+    Notes
+    -----
+    https://docs.dask.org/en/stable/generated/dask.bag.map.html
+    https://docs.dask.org/en/stable/generated/dask.dataframe.DataFrame.compute.html
+    """
+    bag = dask.bag.from_sequence(parameters)
+    config = {"scheduler": "processes", "context": "fork"}
+
+    with dask.config.set(config):
+        if num_workers is not None:
+            results = bag.map(run_diag).compute(num_workers=num_workers)
+        elif hasattr(parameters[0], "num_workers"):
+            results = bag.map(run_diag).compute(num_workers=parameters[0].num_workers)
+
+    # `results` becomes a list of lists of parameters so it needs to be
+    # collapsed a level.
+    collapsed_results = _collapse_results(results)
+
+    return collapsed_results
+
+
+def _collapse_results(parameters: List[List[CoreParameter]]) -> List[CoreParameter]:
+    """Collapses the results of diagnostic runs by one list level.
+
+    Parameters
+    ----------
+    parameters : List[List[CoreParameter]]
+        A list of lists of CoreParameter objects with results from the
+        diagnostic run.
+
+    Returns
+    -------
+    List[CoreParameter]
+        A list of CoreParameter objects with results from the diagnostic run.
+    """
+    output_parameters = []
+
+    for p1 in parameters:
+        if isinstance(p1, list):
+            for p2 in p1:
+                output_parameters.append(p2)
+        else:
+            output_parameters.append(p1)
+
+    return output_parameters
+
+
 def main(parameters=[]):
+    # Get the diagnostic run parameters
+    # ---------------------------------
     parser = CoreParser()
+
+    # If no parameters are passed, use the parser args as defaults. Otherwise,
+    # create the dictionary of expected parameters.
     if not parameters:
         parameters = get_parameters(parser)
     expected_parameters = create_parameter_dict(parameters)
-
-    # each case id (aka, variable) has a set of parameters specified.
-    # print out the parameters for each variable for trouble shootting
-    # for p in parameters:
-    #    attrs = vars(p)
-    #    print (', '.join("%s: %s" % item for item in attrs.items()))
 
     if not os.path.exists(parameters[0].results_dir):
         os.makedirs(parameters[0].results_dir, 0o755)
     if not parameters[0].no_viewer:  # Only save provenance for full runs.
         save_provenance(parameters[0].results_dir, parser)
 
+    # Perform the diagnostic run
+    # --------------------------
     if parameters[0].multiprocessing:
-        parameters = cdp.cdp_run.multiprocess(run_diag, parameters, context="fork")
-    elif parameters[0].distributed:
-        parameters = cdp.cdp_run.distribute(run_diag, parameters)
+        parameters_results = _run_with_dask_multiprocessing(parameters)
     else:
-        parameters = cdp.cdp_run.serial(run_diag, parameters)
+        parameters_results = _run_serially(parameters)
 
-    parameters = _collapse_results(parameters)
-
-    if not parameters:
+    # Generate the viewer outputs using results
+    # -----------------------------------------
+    if not parameters_results:
         logger.warning(
             "There was not a single valid diagnostics run, no viewer created."
         )
     else:
-        # If you get `AttributeError: 'NoneType' object has no attribute 'no_viewer'` on this line
-        # then `run_diag` likely returns `None`.
-
-        if parameters[0].no_viewer:
+        # If you get `AttributeError: 'NoneType' object has no attribute
+        # `'no_viewer'` on this line then `run_diag` likely returns `None`.
+        if parameters_results[0].no_viewer:
             logger.info("Viewer not created because the no_viewer parameter is True.")
         else:
-            path = os.path.join(parameters[0].results_dir, "viewer")
+            path = os.path.join(parameters_results[0].results_dir, "viewer")
             if not os.path.exists(path):
                 os.makedirs(path)
 
-            index_path = create_viewer(path, parameters)
+            index_path = create_viewer(path, parameters_results)
             logger.info("Viewer HTML generated at {}".format(index_path))
 
-    actual_parameters = create_parameter_dict(parameters)
-    if parameters[0].fail_on_incomplete and (actual_parameters != expected_parameters):
+    # Validate actual and expected parameters are aligned
+    # ---------------------------------------------------
+    actual_parameters = create_parameter_dict(parameters_results)
+    if parameters_results[0].fail_on_incomplete and (
+        actual_parameters != expected_parameters
+    ):
         d: Dict[type, Tuple[int, int]] = dict()
+
         # Loop through all expected parameter types.
         for t in expected_parameters.keys():
             d[t] = (actual_parameters[t], expected_parameters[t])
-        message = "Not all parameters completed successfully. Check output above for errors/exceptions. The following dictionary maps parameter types to their actual and expected numbers: {}".format(
-            d
+
+        message = (
+            "Not all parameters completed successfully. Check output above for "
+            "errors/exceptions. The following dictionary maps parameter types to their "
+            f"actual and expected numbers: {d}"
         )
         raise Exception(message)
 

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -78,7 +78,6 @@ class CoreParameter(cdp.cdp_parameter.CDPParameter):
         self.diff_units = ""
 
         self.multiprocessing = False
-        self.distributed = False
         self.num_workers = 4
 
         self.no_viewer = False

--- a/e3sm_diags/parser/core_parser.py
+++ b/e3sm_diags/parser/core_parser.py
@@ -460,15 +460,6 @@ class CoreParser(cdp.cdp_parser.CDPParser):
         )
 
         self.add_argument(
-            "--distributed",
-            dest="distributed",
-            help="Run the diags distributedly.",
-            action="store_const",
-            const=True,
-            required=False,
-        )
-
-        self.add_argument(
             "--save_netcdf",
             dest="save_netcdf",
             help="Save the NetCDF files.",

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,9 @@ ignore_errors = True
 
 [mypy-model_data_preprocess.*]
 ignore_errors = True
+
+[tool:pytest]
+junit_family=xunit2
+addopts = --cov=e3sm_diags --cov-report term --cov-report html:tests_coverage_reports/htmlcov --cov-report xml:tests_coverage_reports/coverage.xml -s --ignore=tests/integration
+python_files = tests.py test_*.py
+testpaths = tests/e3sm_diags

--- a/tests/e3sm_diags/test_e3sm_diags_driver.py
+++ b/tests/e3sm_diags/test_e3sm_diags_driver.py
@@ -1,10 +1,6 @@
 import pytest
 
-from e3sm_diags.e3sm_diags_driver import (
-    _run_serially,
-    _run_with_dask_multiprocessing,
-    run_diag,
-)
+from e3sm_diags.e3sm_diags_driver import _run_serially, _run_with_dask, run_diag
 from e3sm_diags.logger import custom_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
@@ -62,14 +58,11 @@ class TestRunDiag:
         # tests validates the results.
         assert results == expected
 
-    @pytest.mark.parametrize("num_workers", [(None), (1)])
-    def test_run_diag_with_dask_multiprocessing_returns_parameters_with_results(
-        self, num_workers
-    ):
+    def test_run_diag_with_dask_returns_parameters_with_results(self):
         parameter = CoreParameter()
         parameter.sets = ["lat_lon"]
 
-        results = _run_with_dask_multiprocessing([parameter], num_workers)
+        results = _run_with_dask([parameter])
 
         expected_parameter = CoreParameter()
         expected_parameter.sets = ["lat_lon"]
@@ -83,3 +76,13 @@ class TestRunDiag:
         # parameter objects, not the results themselves. There are integration
         # tests validates the results.
         assert results[0].__dict__ == expected[0].__dict__
+
+    def test_run_diag_with_dask_raises_error_if_num_workers_attr_not_set(
+        self,
+    ):
+        parameter = CoreParameter()
+        parameter.sets = ["lat_lon"]
+        del parameter.num_workers
+
+        with pytest.raises(ValueError):
+            _run_with_dask([parameter])

--- a/tests/e3sm_diags/test_e3sm_diags_driver.py
+++ b/tests/e3sm_diags/test_e3sm_diags_driver.py
@@ -1,0 +1,85 @@
+import pytest
+
+from e3sm_diags.e3sm_diags_driver import (
+    _run_serially,
+    _run_with_dask_multiprocessing,
+    run_diag,
+)
+from e3sm_diags.logger import custom_logger
+from e3sm_diags.parameter.core_parameter import CoreParameter
+
+logger = custom_logger("e3sm_diags.e3sm_diags_driver", propagate=True)
+
+
+class TestRunDiag:
+    def test_returns_parameter_with_results(self):
+        parameter = CoreParameter()
+        parameter.sets = ["lat_lon"]
+
+        results = run_diag(parameter)
+        expected = [parameter]
+
+        # NOTE: We are only testing that the function returns a list of
+        # parameter objects, not the results themselves. There are integration
+        # tests validates the results.
+        assert results == expected
+
+    def test_logs_error_if_driver_module_for_set_not_found(self, caplog):
+        parameter = CoreParameter()
+        parameter.sets = ["invalid_set"]
+
+        run_diag(parameter)
+
+        assert (
+            "ModuleNotFoundError: No module named 'e3sm_diags.driver.invalid_set_driver'"
+            in caplog.text
+        )
+
+    @pytest.mark.xfail
+    def test_logs_exception_if_driver_run_diag_function_fails(self, caplog):
+        # TODO: Need to implement this test by raising an exception through
+        # the driver's `run_diag` function
+        parameter = CoreParameter()
+        parameter.sets = ["lat_lon"]
+
+        # Make this attribute an invalid value to test exception is thrown.
+        parameter.seasons = None  # type: ignore
+
+        # NOTE: Comment out temporarily to avoid polluting the test output log.
+        # run_diag(parameter)
+
+        assert "TypeError: 'NoneType' object is not iterable" in caplog.text
+
+    def test_run_diag_serially_returns_parameters_with_results(self):
+        parameter = CoreParameter()
+        parameter.sets = ["lat_lon"]
+
+        results = _run_serially([parameter])
+        expected = [parameter]
+
+        # NOTE: We are only testing that the function returns a list of
+        # parameter objects, not the results themselves. There are integration
+        # tests validates the results.
+        assert results == expected
+
+    @pytest.mark.parametrize("num_workers", [(None), (1)])
+    def test_run_diag_with_dask_multiprocessing_returns_parameters_with_results(
+        self, num_workers
+    ):
+        parameter = CoreParameter()
+        parameter.sets = ["lat_lon"]
+
+        results = _run_with_dask_multiprocessing([parameter], num_workers)
+
+        expected_parameter = CoreParameter()
+        expected_parameter.sets = ["lat_lon"]
+        expected_parameter.current_set = "lat_lon"
+        expected_parameter.test_name_yrs = ""
+        expected_parameter.ref_name_yrs = ""
+        expected_parameter.model_only = False
+        expected = [expected_parameter]
+
+        # NOTE: We are only testing that the function returns a list of
+        # parameter objects, not the results themselves. There are integration
+        # tests validates the results.
+        assert results[0].__dict__ == expected[0].__dict__

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,7 +4,7 @@ set -e # Fail if any line fails
 
 printf "1. Run unit tests\n"
 printf "==============================================\n"
-python -m unittest tests/e3sm_diags/*/test_*.py
+pytest tests/e3sm_diags/
 
 printf "\n2. Copy over test data and images from the web\n"
 printf "==============================================\n"
@@ -17,18 +17,4 @@ python -m tests.integration.download_data
 
 printf "\n3. Run integration tests\n"
 printf "==============================================\n"
-# Integration tests must be called individually. `e3sm_diags` uses `cdp_parser.get_parameters()`, which incorrectly picks up `python -m unittest` cmd args.
-# This results in `cdp_parser.get_parameters()` raising `error: unrecognized arguments <UNITTEST ARGS>`.
-# Running tests using these commands do not work:
-#  - `python -m unittest tests/integration/test_*.py`
-#  - `python -m unittest discover -s tests/integration --pattern "test_*.py"`
-# Related lines of code : https://github.com/CDAT/cdp/blob/2917603097112f7db52be0bf7a2e766e14cc2e16/cdp/cdp_parser.py#L498
-command='python -m unittest tests/integration/'
-declare -a files=("test_all_sets" "test_dataset" "test_diags" "test_run")
-for file in "${files[@]}"
-    do
-        file="${file}.py"
-        printf "\n${file}\n"
-        printf "~~~~~~~~~~~~~~~~~~~~\n"
-        eval "${command}${file}"
-done
+pytest tests/integration/


### PR DESCRIPTION
Closes #426 

This PR removes the `cdp.cdp_run` dependency, which mainly just involved porting code over from this module and doing some refactoring.

Summary of Changes:
- Port `serial` and `multiprocess` from `cdp.cdp_run`
  - Refactor function arguments to remove unnecessary code
- Remove logic for distributed because it never actually worked (experimental code)
- Add `dask` as a dependency in the conda env yml files

TODO:
- [x] Write unit tests for `_run_serially()`
- [x] Write unit tests for `_run_with_dask_multiprocessing`