### PR TITLE
fix typo in aerosol budget printout

### DIFF
--- a/auxiliary_tools/aerosol_budget.py
+++ b/auxiliary_tools/aerosol_budget.py
@@ -51,7 +51,7 @@ def generate_metrics_dic(data, aerosol, season):
     print(f'{aerosol} Lifetime (days): ',f'{burden_total/sink*365:.3f}')
     metrics_dict = {
     "Surface Emission (Tg/yr)": f'{srfemis:.3f}',
-    "Sink (Tg/s)": f'{sink:.3f}',
+    "Sink (Tg/yr)": f'{sink:.3f}',
     "Dry Deposition (Tg/yr)": f'{drydep:.3f}',
     "Wet Deposition (Tg/yr)": f'{wetdep:.3f}',
     "Burden (Tg)": f'{burden_total:.3f}',
@@ -98,7 +98,7 @@ for season in seasons:
         metrics_dict[aerosol] = generate_metrics_dic(test_data, aerosol, season)
         metrics_dict_ref[aerosol] = {
             "Surface Emission (Tg/yr)": f'{MISSING_VALUE:.3f}',
-            "Sink (Tg/s)": f'{MISSING_VALUE:.3f}',
+            "Sink (Tg/yr)": f'{MISSING_VALUE:.3f}',
             "Dry Deposition (Tg/yr)": f'{MISSING_VALUE:.3f}',
             "Wet Deposition (Tg/yr)": f'{MISSING_VALUE:.3f}',
             "Burden (Tg)": f'{MISSING_VALUE:.3f}',

--- a/e3sm_diags/driver/aerosol_budget_driver.py
+++ b/e3sm_diags/driver/aerosol_budget_driver.py
@@ -65,7 +65,7 @@ def generate_metrics_dic(data, aerosol, season):
     metrics_dict = {
         "Surface Emission (Tg/yr)": f"{srfemis:.3f}",
         "Elevated Emission (Tg/yr)": f"{elvemis:.3f}",
-        "Sink (Tg/s)": f"{sink:.3f}",
+        "Sink (Tg/yr)": f"{sink:.3f}",
         "Dry Deposition (Tg/yr)": f"{drydep:.3f}",
         "Wet Deposition (Tg/yr)": f"{wetdep:.3f}",
         "Burden (Tg)": f"{burden_total:.3f}",
@@ -133,7 +133,7 @@ def run_diag(parameter: CoreParameter) -> CoreParameter:
                 metrics_dict_ref[aerosol] = {
                     "Surface Emission (Tg/yr)": f"{MISSING_VALUE:.3f}",
                     "Elevated Emission (Tg/yr)": f"{MISSING_VALUE:.3f}",
-                    "Sink (Tg/s)": f"{MISSING_VALUE:.3f}",
+                    "Sink (Tg/yr)": f"{MISSING_VALUE:.3f}",
                     "Dry Deposition (Tg/yr)": f"{MISSING_VALUE:.3f}",
                     "Wet Deposition (Tg/yr)": f"{MISSING_VALUE:.3f}",
                     "Burden (Tg)": f"{MISSING_VALUE:.3f}",


### PR DESCRIPTION
Fixing a typo in the aerosol budget table. Sinks should have units of Tg/yr (as the rest). Marking as draft as I don't know if you accept PRs. Feel free to cherry pick or fix as you see fit.