### PR TITLE
Use total (interstitial and cloud-borne) aerosols directly from 2D burdens

### DIFF
--- a/e3sm_diags/driver/aerosol_budget_driver.py
+++ b/e3sm_diags/driver/aerosol_budget_driver.py
@@ -28,19 +28,34 @@ def global_integral(var, area_m2):
 
 def calc_column_integral(data, aerosol, season):
     """Calculate column integrated mass"""
-    mass = data.get_climo_variable(f"Mass_{aerosol}", season)
-    hyai, hybi, ps = data.get_extra_variables_only(
-        f"Mass_{aerosol}", season, extra_vars=["hyai", "hybi", "PS"]
-    )
 
-    p0 = 100000.0  # Pa
-    ps = ps  # Pa
-    pressure_levs = cdutil.vertical.reconstructPressureFromHybrid(ps, hyai, hybi, p0)
+    # take aerosol and change it to the appropriate string
+    # ncl -> SEASALT, dst -> DUST, rest1 -> REST1
+    # only needed if ABURDEN terms are available
+    if aerosol == "ncl":
+        aerosol_name = "SEASALT"
+    elif aerosol == "dst":
+        aerosol_name = "DUST"
+    else:
+        aerosol_name = aerosol.upper()
+    try:
+        # if ABURDEN terms are available, use them
+        burden = data.get_climo_variable(f"ABURDEN{aerosol_name}", season)
+    except RuntimeError:
+        # if not, use the Mass_ terms and integrate over the column
+        mass = data.get_climo_variable(f'Mass_{aerosol}', season)
+        hyai, hybi, ps = data.get_extra_variables_only(
+            f'Mass_{aerosol}', season, extra_vars=["hyai", "hybi", "PS"]
+        )
 
-    # (72,lat,lon)
-    delta_p = numpy.diff(pressure_levs, axis=0)
-    mass_3d = mass * delta_p / 9.8  # mass density * mass air   kg/m2
-    burden = numpy.nansum(mass_3d, axis=0)  # kg/m2
+        p0 = 100000.0  # Pa
+        ps = ps   # Pa
+        pressure_levs = cdutil.vertical.reconstructPressureFromHybrid(ps, hyai, hybi, p0)
+
+        #(72,lat,lon)
+        delta_p = numpy.diff(pressure_levs,axis = 0)
+        mass_3d = mass*delta_p/9.8 #mass density * mass air   kg/m2
+        burden = numpy.nansum(mass_3d,axis = 0)   #kg/m2
     return burden
 
 

--- a/e3sm_diags/driver/aerosol_budget_driver.py
+++ b/e3sm_diags/driver/aerosol_budget_driver.py
@@ -43,19 +43,21 @@ def calc_column_integral(data, aerosol, season):
         burden = data.get_climo_variable(f"ABURDEN{aerosol_name}", season)
     except RuntimeError:
         # if not, use the Mass_ terms and integrate over the column
-        mass = data.get_climo_variable(f'Mass_{aerosol}', season)
+        mass = data.get_climo_variable(f"Mass_{aerosol}", season)
         hyai, hybi, ps = data.get_extra_variables_only(
-            f'Mass_{aerosol}', season, extra_vars=["hyai", "hybi", "PS"]
+            f"Mass_{aerosol}", season, extra_vars=["hyai", "hybi", "PS"]
         )
 
         p0 = 100000.0  # Pa
-        ps = ps   # Pa
-        pressure_levs = cdutil.vertical.reconstructPressureFromHybrid(ps, hyai, hybi, p0)
+        ps = ps  # Pa
+        pressure_levs = cdutil.vertical.reconstructPressureFromHybrid(
+            ps, hyai, hybi, p0
+        )
 
-        #(72,lat,lon)
-        delta_p = numpy.diff(pressure_levs,axis = 0)
-        mass_3d = mass*delta_p/9.8 #mass density * mass air   kg/m2
-        burden = numpy.nansum(mass_3d,axis = 0)   #kg/m2
+        # (72,lat,lon)
+        delta_p = numpy.diff(pressure_levs, axis=0)
+        mass_3d = mass * delta_p / 9.8  # mass density * mass air   kg/m2
+        burden = numpy.nansum(mass_3d, axis=0)  # kg/m2
     return burden
 
 


### PR DESCRIPTION
Fix #681 

- follow https://github.com/E3SM-Project/E3SM/pull/5774
- instead of doing an offline column integration, we now default to using online calculated burdens


TODO:
- [x] double check for the misc items (deposition, etc.) to ensure they still work (we may need two different dicts to accommodate for different naming conventions)
- [x] test both PRs to v3atm/e3sm and this PR on a production 15-month simulation and post results here

<details><summary>RESULTS</summary>
<p>

The table below shows the calculated burdens based on `Mass_` (current behavior), based on `ABURDEN_` (proposed behavior), and based on `BURDEN_` (by ignoring the cloud-borne portion).

<google-sheets-html-origin style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-size-adjust: auto; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">

merra2.PD | Mass_ | ABURDEN_ | BURDEN_
-- | -- | -- | --
  |   |   |  
Black Carbon |   |   |  
Surface Emission (Tg/yr) | 7.597 | 7.597 | 7.597
Elevated Emission (Tg/yr) | 1.751 | 1.751 | 1.751
Sink (Tg/yr) | 9.379 | 9.379 | 9.379
Dry Deposition (Tg/yr) | 3.566 | 3.566 | 3.566
Wet Deposition (Tg/yr) | 5.813 | 5.813 | 5.813
Burden (Tg) | 0.214 | 0.213 | 0.211
Lifetime (Days) | 8.33 | 8.288 | 8.217
  |   |   |  
Dust |   |   |  
Surface Emission (Tg/yr) | 2848.05 | 2848.05 | 2848.05
Elevated Emission (Tg/yr) | 0 | 0 | 0
Sink (Tg/yr) | 2858.861 | 2858.861 | 2858.861
Dry Deposition (Tg/yr) | 2011.018 | 2011.018 | 2011.018
Wet Deposition (Tg/yr) | 847.843 | 847.843 | 847.843
Burden (Tg) | 24.252 | 24.077 | 23.881
Lifetime (Days) | 3.096 | 3.074 | 3.049
  |   |   |  
Marine Organic Matter |   |   |  
Surface Emission (Tg/yr) | 13.013 | 13.013 | 13.013
Elevated Emission (Tg/yr) | 0 | 0 | 0
Sink (Tg/yr) | 13.114 | 13.114 | 13.114
Dry Deposition (Tg/yr) | 3.238 | 3.238 | 3.238
Wet Deposition (Tg/yr) | 9.875 | 9.875 | 9.875
Burden (Tg) | 0.074 | 0.073 | 0.069
Lifetime (Days) | 2.062 | 2.045 | 1.922
  |   |   |  
Sea Salt |   |   |  
Surface Emission (Tg/yr) | 1956.414 | 1956.414 | 1956.414
Elevated Emission (Tg/yr) | 0 | 0 | 0
Sink (Tg/yr) | 1971.292 | 1971.292 | 1971.292
Dry Deposition (Tg/yr) | 923.677 | 923.677 | 923.677
Wet Deposition (Tg/yr) | 1047.615 | 1047.615 | 1047.615
Burden (Tg) | 5.233 | 5.185 | 4.889
Lifetime (Days) | 0.969 | 0.96 | 0.905
  |   |   |  
Primary Organic Matter |   |   |  
Surface Emission (Tg/yr) | 25.848 | 25.848 | 25.848
Elevated Emission (Tg/yr) | 21.272 | 21.272 | 21.272
Sink (Tg/yr) | 47.103 | 47.103 | 47.103
Dry Deposition (Tg/yr) | 15.941 | 15.941 | 15.941
Wet Deposition (Tg/yr) | 31.162 | 31.162 | 31.162
Burden (Tg) | 1.072 | 1.066 | 1.056
Lifetime (Days) | 8.309 | 8.259 | 8.181
  |   |   |  
Sulfate |   |   |  
Surface Emission (Tg/yr) | 0.987 | 0.987 | 0.987
Elevated Emission (Tg/yr) | 5.499 | 5.499 | 5.499
Sink (Tg/yr) | 93.674 | 93.674 | 93.674
Dry Deposition (Tg/yr) | 21.929 | 21.929 | 21.929
Wet Deposition (Tg/yr) | 71.746 | 71.746 | 71.746
Burden (Tg) | 2.046 | 2.031 | 2.001
Lifetime (Days) | 7.973 | 7.915 | 7.796
  |   |   |  
Secondary Organic Aerosol |   |   |  
Surface Emission (Tg/yr) | 0 | 0 | 0
Elevated Emission (Tg/yr) | 0 | 0 | 0
Sink (Tg/yr) | 117.558 | 117.558 | 117.558
Dry Deposition (Tg/yr) | 21.511 | 21.511 | 21.511
Wet Deposition (Tg/yr) | 96.048 | 96.048 | 96.048
Burden (Tg) | 3.022 | 3.002 | 2.969
Lifetime (Days) | 9.383 | 9.32 | 9.219

</google-sheets-html-origin>

</p>
</details> 