### PR TITLE
Fix `numpy.int` --> `int`

### DIFF
--- a/analysis_data_preprocess/create_GPCP_climo.py
+++ b/analysis_data_preprocess/create_GPCP_climo.py
@@ -94,7 +94,7 @@ fisc=['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC','M
 fisc2=['01','02','03','04','05','06','07','08','09','10','11','12','MAM','JJA','SON','DJF','ANN']
 #fisc=['JAN']
 clim_edges=["-1-1","-2-1","-3-1","-4-1","-5-1","-6-1","-7-1","-8-1","-9-1","-10-1","-11-1","-12-1"]
-clim_edge_values=numpy.zeros((17,2),dtype=numpy.int)
+clim_edge_values=numpy.zeros((17,2),dtype=int)
 #JAN
 clim_edge_values[0,0]=0
 clim_edge_values[0,1]=1

--- a/analysis_data_preprocess/create_OAFLUX_climo.py
+++ b/analysis_data_preprocess/create_OAFLUX_climo.py
@@ -142,7 +142,7 @@ clim_edges = [
     "-11-1",
     "-12-1",
 ]
-clim_edge_values = numpy.zeros((17, 2), dtype=numpy.int)
+clim_edge_values = numpy.zeros((17, 2), dtype=int)
 # JAN
 clim_edge_values[0, 0] = 0
 clim_edge_values[0, 1] = 1

--- a/e3sm_diags/driver/utils/climo.py
+++ b/e3sm_diags/driver/utils/climo.py
@@ -73,7 +73,7 @@ def climo(var, season):
                 season_idx[cycle[n]][var_time_absolute[i].month - 1]
                 for i in range(len(var_time_absolute))
             ],
-            dtype=np.int,
+            dtype=int,
         ).nonzero()
         climo[n] = ma.average(v[idx], axis=0, weights=dt[idx])
 

--- a/e3sm_diags/driver/utils/diurnal_cycle.py
+++ b/e3sm_diags/driver/utils/diurnal_cycle.py
@@ -96,7 +96,7 @@ def composite_diurnal_cycle(var, season, fft=True):
                 season_idx[cycle[n]][var_time_absolute[i].month - 1]
                 for i in range(len(var_time_absolute))
             ],
-            dtype=numpy.int,
+            dtype=int,
         ).nonzero()
         var_diurnal[n,] = ma.average(  # noqa
             numpy.reshape(


### PR DESCRIPTION
The aliases `numpy.float` and `numpy.int` are not supported in the latest version of `numpy`.