### PR TITLE
Allow setting INSTALL_PATH using an env var

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -251,9 +251,17 @@ Instead, the developer will ``pip install .`` to build ``e3sm-diags`` with chang
 
         pip install .
 
-8. Check that tests pass: ``./tests/test.sh``. This takes about 4 minutes.
+8. If you need to make more than one edit, or have an "editable" installation (option ``-e``), use:
 
-9. Commit changes and make sure ``pre-commit`` checks pass
+    - Tip: it is possible to customize the ``INSTALL_PATH`` location with an env variable 
+
+    ::
+
+        E3SM_DIAGS_INSTALL_PATH=/some/path/ pip install . -e
+
+9. Check that tests pass: ``./tests/test.sh``. This takes about 4 minutes.
+
+10. Commit changes and make sure ``pre-commit`` checks pass
     ::
 
         git commit -m "..."

--- a/e3sm_diags/__init__.py
+++ b/e3sm_diags/__init__.py
@@ -2,7 +2,13 @@ import os
 import sys
 
 __version__ = "v2.9.0rc1"
-INSTALL_PATH = os.path.join(sys.prefix, "share/e3sm_diags/")
+if os.getenv("E3SM_DIAGS_INSTALL_PATH", default=None):
+    # Note pre-commit is right suspicious if default is left to None below
+    # I set it to a string to avoid typing problems (i.e., avoid None type)
+    # This is okay because we will never use the default because of if above
+    INSTALL_PATH = os.getenv("E3SM_DIAGS_INSTALL_PATH", default="share/e3sm_diags/")
+else:
+    INSTALL_PATH = os.path.join(sys.prefix, "share/e3sm_diags/")
 
 # Disable MPI in cdms2, which is not currently supported by E3SM-unified
 os.environ["CDMS_NO_MPI"] = "True"

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ mp_partition_files = get_all_files_in_dir(
 rgb_files = get_all_files_in_dir("e3sm_diags/plot/colormaps", "*.rgb")
 control_runs_files = get_all_files_in_dir("e3sm_diags/driver/control_runs", "*")
 
-INSTALL_PATH = "share/e3sm_diags/"
+INSTALL_PATH = os.getenv("E3SM_DIAGS_INSTALL_PATH", default="share/e3sm_diags/")
 
 data_files = [
     (os.path.join(INSTALL_PATH, "zonal_mean_xy"), zonal_mean_xy_files),


### PR DESCRIPTION
This PR doesn't change any behavior; it only optionally adds a capability to allow setting INSTALL_PATH via env variable either at installation time or at runtime. 

The goal of this PR is twofold:

1. Allow setting INSTALL_PATH using an env variable
2. Point out the editable (`-e`) installation option for easier development

Currently, INSTALL_PATH works well for a conda env or an actual installation, but not editable installation. There's probably a much better way to organize the logic, but I opened the issue a while ago and never acted on it, so I decided to finally act on it. I will have this PR in draft mode for a bit first to get feedback from team members. I will also conduct my own tests locally to ensure it works well (I will update the text description with more information before marking it ready for review).

Fix #684