### PR TITLE
Fix segfault issue with newest shapely and esmpy

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -17,12 +17,14 @@ dependencies:
   - cdms2 3.1.5
   - cdutil 8.2.1
   - dask
+  - esmpy >=8.4.0
   - genutil 8.2.1
   - lxml
   - mache >=0.15.0
   - matplotlib-base
   - netcdf4
   - numpy >=1.23.0
+  - shapely >=2.0.0,<3.0.0
   - xarray >=2023.02.0
   # Testing
   # ==================

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -15,12 +15,14 @@ dependencies:
   - cdms2 3.1.5
   - cdutil 8.2.1
   - dask
+  - esmpy >=8.4.0
   - genutil 8.2.1
   - lxml
   - mache >=0.15.0
   - matplotlib-base
   - netcdf4
   - numpy >=1.23.0
+  - shapely >=2.0.0,<3.0.0
   - xarray >=2023.02.0
   # Testing
   # ==================

--- a/e3sm_diags/__init__.py
+++ b/e3sm_diags/__init__.py
@@ -1,6 +1,10 @@
 import os
 import sys
 
+# import shapely before esmpy to prevent a segfault related to multiprocessing
+import shapely  # isort: skip
+import esmpy  # isort: skip
+
 __version__ = "v2.9.0rc2"
 INSTALL_PATH = os.path.join(sys.prefix, "share/e3sm_diags/")
 


### PR DESCRIPTION
This merge fixes a segfault issue related to `shapely >=2.0.0` and `esmpy >=8.4.0`, likely caused by multiprocessing.  It appears that things work fine as long as `shapely` gets imported before `e3smpy`.

The proposed fix is simply to import `shapely`, then `esmpy` at the very start in  the `e3sm_diags` package.  This isn't a very elegant fix, so it will be worth exploring better options (perhaps including a bug report to ESMPy and/or shapely developers) in the future.  But we need this to work for us sooner than that is likely to work for us.

I also propose constraining `esmpy >=8.4.0` so we don't have to deal with the import name change from `ESMF` to `esmpy`.

I also propose to constrain `shapely >=2.0.0,<3.0.0`.  There were major changes from `shapely` 1.x to 2.x and other E3SM analysis tools like polaris, compass, MPAS-Analysis and geometric_features are all using shapely 2.x at this point.  `e3sm_diags` only depends on shapely indirectly (e.g. through cartopy) but for consistency in plots, it seems best to constrain shapely.  This may help to prevent issues upgrading E3SM-Unified in the future.

This is my proposed fix for https://github.com/E3SM-Project/zppy/pull/475