### PR TITLE
update enviroment variable 

### DIFF
--- a/e3sm_diags/__init__.py
+++ b/e3sm_diags/__init__.py
@@ -21,4 +21,3 @@ os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
-

--- a/e3sm_diags/__init__.py
+++ b/e3sm_diags/__init__.py
@@ -20,3 +20,5 @@ os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 # Used by numpy, causes too many threads to spawn otherwise.
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+


### PR DESCRIPTION
Suggested by @tomvothecoder, to follow Dask best practice:
https://docs.dask.org/en/latest/array-best-practices.html#avoid-oversubscribing-threads
`OMP_NUM_THREADS` and `OPENBLAS_NUM_THREADS` were constrained, now adding `MKL_NUM_THREADS` for constraining thread number for Intel mkl.
