### PR TITLE
[Refactor]: Update `e3sm_diags_driver.run_diags` as `CoreParameter` method

### DIFF
--- a/.vscode/e3sm_diags.code-workspace
+++ b/.vscode/e3sm_diags.code-workspace
@@ -8,6 +8,9 @@
       "path": ".."
     }
   ],
+  // ===========================
+  // VS Code Workspace Settings.
+  // ===========================
   "settings": {
     // ===================
     // Editor settings
@@ -22,17 +25,14 @@
       "editor.rulers": [80, 88, 120],
       "editor.wordWrap": "wordWrapColumn",
       "editor.wordWrapColumn": 120,
-      "editor.defaultFormatter": "ms-python.python"
+      "editor.defaultFormatter": "ms-python.black-formatter"
     },
     // Code Formatting and Linting
     // ---------------------------
-    "python.formatting.provider": "black",
-    "python.linting.flake8Enabled": true,
-    "python.linting.flake8Args": ["--config=setup.cfg"],
+    "flake8.args": ["--config=setup.cfg"],
     // Type checking
     // ---------------------------
-    "python.linting.mypyEnabled": true,
-    "python.linting.mypyArgs": ["--config=setup.cfg"],
+    "mypy-type-checker.args": ["--config=pyproject.toml"],
     // Testing
     // ---------------------------
     // NOTE: Debugger doesn't work if pytest-cov is enabled, so set "--no-cov"
@@ -49,5 +49,24 @@
       "editor.wordWrap": "wordWrapColumn",
       "editor.wordWrapColumn": 120
     }
+  },
+  // =====================================
+  // VS Code Python Debugger Configuration
+  // =====================================
+  "launch": {
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Python: Current File",
+        "type": "python",
+        "request": "launch",
+        "program": "${file}",
+        "console": "integratedTerminal",
+        "justMyCode": true,
+        "env": {
+          "PYTHONPATH": "${workspaceFolder}"
+        }
+      }
+    ]
   }
 }

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -262,14 +262,16 @@ def _run_serially(parameters: List[CoreParameter]) -> List[CoreParameter]:
     List[CoreParameter]
         The list of CoreParameter objects with results from the diagnostic run.
     """
-    results: List[CoreParameter] = []
+    # A nested list of lists, where a sub-list represents the results of
+    # the sets related to the CoreParameter object.
+    nested_results: List[List[CoreParameter]] = []
 
     for parameter in parameters:
-        results.append(parameter._run_diag())  # type: ignore
+        nested_results.append(parameter._run_diag())
 
     # `results` becomes a list of lists of parameters so it needs to be
     # collapsed a level.
-    collapsed_results = _collapse_results(results)  # type: ignore
+    collapsed_results = _collapse_results(nested_results)
 
     return collapsed_results
 

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # The above line is needed for `test_all_sets.test_all_sets_mpl`.
 # Otherwise, OSError: [Errno 8] Exec format error: 'e3sm_diags_driver.py'.
-
-import importlib
 import os
 import subprocess
 import sys
@@ -251,56 +249,6 @@ def create_parameter_dict(parameters):
     return d
 
 
-def run_diag(parameter: CoreParameter) -> List[CoreParameter]:
-    """Run the corresponding diagnostics for a set of parameters.
-
-    Additional CoreParameter (or CoreParameter sub-class) objects are derived
-    from the CoreParameter `sets` attribute, hence this function returns a
-    list of CoreParameter objects.
-
-    This function loops over the specified diagnostic sets and runs the
-    diagnostic using the parameters.
-
-    Parameters
-    ----------
-    parameter : CoreParameter
-        The CoreParameter object to run diagnostics on.
-
-    Returns
-    -------
-    List[CoreParameter]
-        The list of CoreParameter objects with results from the diagnostic run.
-    """
-    results = []
-
-    for set_name in parameter.sets:
-        # FIXME: The parameter and driver for a diagnostic should be mapped
-        # together. If this is done, the `run_diag` function should be
-        # accessible by the parameter class without needing to perform a static
-        # string reference for the module name.
-        parameter.current_set = set_name
-        mod_str = "e3sm_diags.driver.{}_driver".format(set_name)
-
-        # Check if there is a matching driver module for the `set_name`.
-        try:
-            module = importlib.import_module(mod_str)
-        except ModuleNotFoundError as e:
-            logger.error(f"'Error with set name {set_name}'", exc_info=e)
-            continue
-
-        # If the module exists, call the driver module's `run_diag` function.
-        try:
-            single_result = module.run_diag(parameter)
-            results.append(single_result)
-        except Exception:
-            logger.exception(f"Error in {mod_str}", exc_info=True)
-
-            if parameter.debug:
-                sys.exit()
-
-    return results
-
-
 def _run_serially(parameters: List[CoreParameter]) -> List[CoreParameter]:
     """Run diagnostics with the parameters serially.
 
@@ -314,14 +262,14 @@ def _run_serially(parameters: List[CoreParameter]) -> List[CoreParameter]:
     List[CoreParameter]
         The list of CoreParameter objects with results from the diagnostic run.
     """
-    results = []
+    results: List[CoreParameter] = []
 
-    for p in parameters:
-        results.append(run_diag(p))
+    for parameter in parameters:
+        results.append(parameter._run_diag())  # type: ignore
 
     # `results` becomes a list of lists of parameters so it needs to be
     # collapsed a level.
-    collapsed_results = _collapse_results(results)
+    collapsed_results = _collapse_results(results)  # type: ignore
 
     return collapsed_results
 
@@ -362,7 +310,7 @@ def _run_with_dask(parameters: List[CoreParameter]) -> List[CoreParameter]:
         )
 
     with dask.config.set(config):
-        results = bag.map(run_diag).compute(num_workers=num_workers)
+        results = bag.map(CoreParameter._run_diag).compute(num_workers=num_workers)
 
     # `results` becomes a list of lists of parameters so it needs to be
     # collapsed a level.

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -241,7 +241,7 @@ class CoreParameter:
         for set_name in self.sets:
             self.current_set = set_name
             # FIXME: This is a shortcut to importing `run_diag`, but can break
-            # easily because the module driver must match the module name.
+            # easily because the module driver include the set name (static reference).
             # Instead, the import should be done more progammatically via
             # direct Python import.
             mod_str = "e3sm_diags.driver.{}_driver".format(set_name)

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -1,19 +1,14 @@
 import copy
 import importlib
 import sys
-from typing import Dict, Generic, List, TypeVar
+from typing import Any, Dict, List
 
 from e3sm_diags.logger import custom_logger
 
 logger = custom_logger(__name__)
 
-T = TypeVar("T")
 
-
-class CoreParameter(Generic[T]):
-    # A type annotation for `self`.
-    _Self = TypeVar("_Self", bound="CoreParameter[T]")  # noqa: F821
-
+class CoreParameter:
     def __init__(self):
         # File I/O
         # ------------------------
@@ -225,7 +220,7 @@ class CoreParameter(Generic[T]):
             msg = "You need to define both the 'test_start_yr' and 'test_end_yr' parameter."
             raise RuntimeError(msg)
 
-    def _run_diag(self) -> List[_Self]:
+    def _run_diag(self) -> List[Any]:
         """Run the corresponding diagnostics for a set of parameters.
 
         Additional CoreParameter (or CoreParameter sub-class) objects are derived
@@ -237,8 +232,9 @@ class CoreParameter(Generic[T]):
 
         Returns
         -------
-        List[_Self]
+        List[Any]
             The list of CoreParameter objects with results from the diagnostic run.
+            NOTE: `Self` type is not yet supported by mypy.
         """
         results = []
 

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -241,7 +241,7 @@ class CoreParameter:
         for set_name in self.sets:
             self.current_set = set_name
             # FIXME: This is a shortcut to importing `run_diag`, but can break
-            # easily because the module driver include the set name (static reference).
+            # easily because the module driver is statically imported via string.
             # Instead, the import should be done more progammatically via
             # direct Python import.
             mod_str = "e3sm_diags.driver.{}_driver".format(set_name)

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -221,7 +221,7 @@ class CoreParameter:
             raise RuntimeError(msg)
 
     def _run_diag(self) -> List[Any]:
-        """Run the corresponding diagnostics for a set of parameters.
+        """Run the diagnostics for each set in the parameter.
 
         Additional CoreParameter (or CoreParameter sub-class) objects are derived
         from the CoreParameter `sets` attribute, hence this function returns a

--- a/tests/e3sm_diags/test_e3sm_diags_driver.py
+++ b/tests/e3sm_diags/test_e3sm_diags_driver.py
@@ -1,6 +1,6 @@
 import pytest
 
-from e3sm_diags.e3sm_diags_driver import _run_serially, _run_with_dask, run_diag
+from e3sm_diags.e3sm_diags_driver import _run_serially, _run_with_dask
 from e3sm_diags.logger import custom_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
@@ -8,44 +8,6 @@ logger = custom_logger("e3sm_diags.e3sm_diags_driver", propagate=True)
 
 
 class TestRunDiag:
-    def test_returns_parameter_with_results(self):
-        parameter = CoreParameter()
-        parameter.sets = ["lat_lon"]
-
-        results = run_diag(parameter)
-        expected = [parameter]
-
-        # NOTE: We are only testing that the function returns a list of
-        # parameter objects, not the results themselves. There are integration
-        # tests validates the results.
-        assert results == expected
-
-    def test_logs_error_if_driver_module_for_set_not_found(self, caplog):
-        parameter = CoreParameter()
-        parameter.sets = ["invalid_set"]
-
-        run_diag(parameter)
-
-        assert (
-            "ModuleNotFoundError: No module named 'e3sm_diags.driver.invalid_set_driver'"
-            in caplog.text
-        )
-
-    @pytest.mark.xfail
-    def test_logs_exception_if_driver_run_diag_function_fails(self, caplog):
-        # TODO: Need to implement this test by raising an exception through
-        # the driver's `run_diag` function
-        parameter = CoreParameter()
-        parameter.sets = ["lat_lon"]
-
-        # Make this attribute an invalid value to test exception is thrown.
-        parameter.seasons = None  # type: ignore
-
-        # NOTE: Comment out temporarily to avoid polluting the test output log.
-        # run_diag(parameter)
-
-        assert "TypeError: 'NoneType' object is not iterable" in caplog.text
-
     def test_run_diag_serially_returns_parameters_with_results(self):
         parameter = CoreParameter()
         parameter.sets = ["lat_lon"]

--- a/tests/e3sm_diags/test_parameters.py
+++ b/tests/e3sm_diags/test_parameters.py
@@ -79,6 +79,44 @@ class TestCoreParameter:
         with pytest.raises(RuntimeError):
             param.check_values()
 
+    def test_returns_parameter_with_results(self):
+        parameter = CoreParameter()
+        parameter.sets = ["lat_lon"]
+
+        results = parameter._run_diag()
+        expected = [parameter]
+
+        # NOTE: We are only testing that the function returns a list of
+        # parameter objects, not the results themselves. There are integration
+        # tests validates the results.
+        assert results == expected
+
+    def test_logs_error_if_driver_module_for_set_not_found(self, caplog):
+        parameter = CoreParameter()
+        parameter.sets = ["invalid_set"]
+
+        parameter._run_diag()
+
+        assert (
+            "ModuleNotFoundError: No module named 'e3sm_diags.driver.invalid_set_driver'"
+            in caplog.text
+        )
+
+    @pytest.mark.xfail
+    def test_logs_exception_if_driver_run_diag_function_fails(self, caplog):
+        # TODO: Need to implement this test by raising an exception through
+        # the driver's `run_diag` function
+        parameter = CoreParameter()
+        parameter.sets = ["lat_lon"]
+
+        # Make this attribute an invalid value to test exception is thrown.
+        parameter.seasons = None  # type: ignore
+
+        # NOTE: Comment out temporarily to avoid polluting the test output log.
+        # parameter._run_diag()
+
+        assert "TypeError: 'NoneType' object is not iterable" in caplog.text
+
 
 def test_ac_zonal_mean_parameter():
     param = ACzonalmeanParameter()


### PR DESCRIPTION
This PR updates the `run_diags()` function as a `CoreParameter` class method. This change is intended to make it clearer that `run_diags()` operates on a single `CoreParameter` object.

- Update VSCode workspace settings with extension and debugger configs