### PR TITLE
CDAT Migration Phase 2: Refactor utilities and CoreParameter methods for reusability across diagnostic sets

### DIFF
--- a/e3sm_diags/driver/utils/type_annotations.py
+++ b/e3sm_diags/driver/utils/type_annotations.py
@@ -1,0 +1,9 @@
+from typing import Dict, List, Union
+
+# The type annotation for the metrics dictionary. The key is the
+# type of metrics and the value is a sub-dictionary of metrics (key is metrics
+# type and value is float). There is also a "unit" key representing the
+# units for the variable.
+UnitAttr = str
+MetricsSubDict = Dict[str, Union[float, None, List[float]]]
+MetricsDict = Dict[str, Union[UnitAttr, MetricsSubDict]]

--- a/e3sm_diags/metrics/metrics.py
+++ b/e3sm_diags/metrics/metrics.py
@@ -1,4 +1,6 @@
 """This module stores functions to calculate metrics using Xarray objects."""
+from __future__ import annotations
+
 from typing import List
 
 import xarray as xr
@@ -28,7 +30,9 @@ def get_weights(ds: xr.Dataset):
     return ds.spatial.get_weights(axis=["X", "Y"])
 
 
-def spatial_avg(ds: xr.Dataset, var_key: str) -> List[float]:
+def spatial_avg(
+    ds: xr.Dataset, var_key: str, as_list: bool = True
+) -> List[float] | xr.DataArray:
     """Compute a variable's weighted spatial average.
 
     Parameters
@@ -37,10 +41,13 @@ def spatial_avg(ds: xr.Dataset, var_key: str) -> List[float]:
         The dataset containing the variable.
     var_key : str
         The key of the varible.
+    as_list : bool
+        Return the spatial average as a list of floats, by default True.
+        If False, return an xr.DataArray.
 
     Returns
     -------
-    List[float]
+    List[float] | xr.DataArray
         The spatial average of the variable based on the specified axis.
 
     Raises
@@ -55,9 +62,10 @@ def spatial_avg(ds: xr.Dataset, var_key: str) -> List[float]:
     ds_avg = ds.spatial.average(var_key, axis=AXES, weights="generate")
     results = ds_avg[var_key]
 
-    results_list = results.data.tolist()
+    if as_list:
+        return results.data.tolist()
 
-    return results_list
+    return results
 
 
 def std(ds: xr.Dataset, var_key: str) -> List[float]:

--- a/e3sm_diags/plot/lat_lon_plot.py
+++ b/e3sm_diags/plot/lat_lon_plot.py
@@ -20,16 +20,18 @@ logger = custom_logger(__name__)
 
 
 def plot(
+    parameter: CoreParameter,
     da_test: xr.DataArray,
     da_ref: xr.DataArray | None,
     da_diff: xr.DataArray | None,
     metrics_dict: MetricsDict,
-    parameter: CoreParameter,
 ):
     """Plot the variable's metrics generated for the lat_lon set.
 
     Parameters
     ----------
+    parameter : CoreParameter
+        The CoreParameter object containing plot configurations.
     da_test : xr.DataArray
         The test data.
     da_ref : xr.DataArray | None
@@ -38,8 +40,6 @@ def plot(
         The difference between ``ds_test_regrid`` and ``ds_ref_regrid``.
     metrics_dict : Metrics
         The metrics.
-    parameter : CoreParameter
-        The CoreParameter object containing plot configurations.
     """
     fig = plt.figure(figsize=parameter.figsize, dpi=parameter.dpi)
     fig.suptitle(parameter.main_title, x=0.5, y=0.96, fontsize=18)

--- a/e3sm_diags/plot/utils.py
+++ b/e3sm_diags/plot/utils.py
@@ -101,7 +101,7 @@ def _add_colormap(
     fig: plt.figure,
     parameter: CoreParameter,
     color_map: str,
-    contour_levels: List[str],
+    contour_levels: List[float],
     title: Tuple[str | None, str, str],
     metrics: Tuple[float, ...],
 ):
@@ -123,7 +123,7 @@ def _add_colormap(
         The CoreParameter object containing plot configurations.
     color_map : str
         The colormap styling to use (e.g., "cet_rainbow.rgb").
-    contour_levels : List[str]
+    contour_levels : List[float]
         The map contour levels.
     title : Tuple[str | None, str, str]
         A tuple of strings to form the title of the colormap, in the format
@@ -427,14 +427,12 @@ def _determine_tick_step(degrees_covered: float) -> int:
         return 1
 
 
-def _get_contour_label_format_and_pad(
-    c_levels: List[str] | List[str | float],
-) -> Tuple[str, int]:
+def _get_contour_label_format_and_pad(c_levels: List[float]) -> Tuple[str, int]:
     """Get the label format and padding for each contour level.
 
     Parameters
     ----------
-    c_levels : List[str] | List[str | float]
+    c_levels : List[float]
         The contour levels.
 
     Returns

--- a/tests/e3sm_diags/driver/utils/test_dataset_xr.py
+++ b/tests/e3sm_diags/driver/utils/test_dataset_xr.py
@@ -205,6 +205,181 @@ class TestDataSetProperties:
         assert ds.is_climo
 
 
+class TestGetReferenceClimoDataset:
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        # Create temporary directory to save files.
+        self.data_path = tmp_path / "input_data"
+        self.data_path.mkdir()
+
+        # Set up climatology dataset and save to a temp file.
+        # TODO: Update this to an actual climatology dataset structure
+        self.ds_climo = xr.Dataset(
+            coords={
+                "lat": [-90, 90],
+                "lon": [0, 180],
+                "time": xr.DataArray(
+                    dims="time",
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(
+                                2000, 1, 1, 12, 0, 0, 0, has_year_zero=False
+                            )
+                        ],
+                        dtype="object",
+                    ),
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
+            },
+            data_vars={
+                "ts": xr.DataArray(
+                    name="ts",
+                    data=np.array(
+                        [
+                            [[1.0, 1.0], [1.0, 1.0]],
+                        ]
+                    ),
+                    dims=["time", "lat", "lon"],
+                )
+            },
+        )
+        self.ds_climo.time.encoding = {"units": "days since 2000-01-01"}
+
+        # Set up time series dataset and save to a temp file.
+        self.ds_ts = xr.Dataset(
+            coords={
+                "lat": [-90, 90],
+                "lon": [0, 180],
+                "time": xr.DataArray(
+                    dims="time",
+                    data=np.array(
+                        [
+                            cftime.DatetimeGregorian(
+                                2000, 1, 1, 12, 0, 0, 0, has_year_zero=False
+                            ),
+                            cftime.DatetimeGregorian(
+                                2000, 2, 1, 12, 0, 0, 0, has_year_zero=False
+                            ),
+                            cftime.DatetimeGregorian(
+                                2000, 3, 1, 12, 0, 0, 0, has_year_zero=False
+                            ),
+                            cftime.DatetimeGregorian(
+                                2001, 1, 1, 12, 0, 0, 0, has_year_zero=False
+                            ),
+                        ],
+                        dtype="object",
+                    ),
+                    attrs={
+                        "axis": "T",
+                        "long_name": "time",
+                        "standard_name": "time",
+                        "bounds": "time_bnds",
+                    },
+                ),
+            },
+            data_vars={
+                "time_bnds": xr.DataArray(
+                    name="time_bnds",
+                    data=np.array(
+                        [
+                            [
+                                cftime.DatetimeGregorian(
+                                    2000, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                                cftime.DatetimeGregorian(
+                                    2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                            ],
+                            [
+                                cftime.DatetimeGregorian(
+                                    2000, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                                cftime.DatetimeGregorian(
+                                    2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                            ],
+                            [
+                                cftime.DatetimeGregorian(
+                                    2000, 3, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                                cftime.DatetimeGregorian(
+                                    2000, 4, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                            ],
+                            [
+                                cftime.DatetimeGregorian(
+                                    2001, 1, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                                cftime.DatetimeGregorian(
+                                    2001, 2, 1, 0, 0, 0, 0, has_year_zero=False
+                                ),
+                            ],
+                        ],
+                        dtype=object,
+                    ),
+                    dims=["time", "bnds"],
+                ),
+                "ts": xr.DataArray(
+                    xr.DataArray(
+                        data=np.array(
+                            [
+                                [[1.0, 1.0], [1.0, 1.0]],
+                                [[1.0, 1.0], [1.0, 1.0]],
+                                [[1.0, 1.0], [1.0, 1.0]],
+                                [[1.0, 1.0], [1.0, 1.0]],
+                            ]
+                        ),
+                        dims=["time", "lat", "lon"],
+                    )
+                ),
+            },
+        )
+        self.ds_ts.time.encoding = {"units": "days since 2000-01-01"}
+
+    def test_raises_error_if_dataset_data_type_is_not_ref(self):
+        parameter = _create_parameter_object(
+            "test", "climo", self.data_path, "2000", "2001"
+        )
+        parameter.ref_file = "test.nc"
+        ds = Dataset(parameter, data_type="test")
+
+        with pytest.raises(RuntimeError):
+            ds.get_ref_climo_dataset("ts", "ANN", self.ds_climo.copy())
+
+    def test_returns_reference_climo_dataset_from_file(self):
+        parameter = _create_parameter_object(
+            "ref", "climo", self.data_path, "2000", "2001"
+        )
+        parameter.ref_file = "ref_file.nc"
+
+        self.ds_climo.to_netcdf(f"{self.data_path}/{parameter.ref_file}")
+
+        ds = Dataset(parameter, data_type="ref")
+        result = ds.get_ref_climo_dataset("ts", "ANN", self.ds_climo.copy())
+        expected = self.ds_climo.squeeze(dim="time").drop_vars("time")
+
+        assert result.identical(expected)
+        assert not ds.model_only
+
+    def test_returns_test_dataset_as_default_value_if_climo_dataset_not_found(self):
+        parameter = _create_parameter_object(
+            "ref", "climo", self.data_path, "2000", "2001"
+        )
+        parameter.ref_file = "ref_file.nc"
+        ds = Dataset(parameter, data_type="ref")
+
+        ds_test = self.ds_climo.copy()
+        result = ds.get_ref_climo_dataset("ts", "ANN", ds_test)
+
+        assert result.identical(ds_test)
+        assert ds.model_only
+
+
 class TestGetClimoDataset:
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):

--- a/tests/e3sm_diags/metrics/test_metrics.py
+++ b/tests/e3sm_diags/metrics/test_metrics.py
@@ -75,6 +75,13 @@ class TestSpatialAvg:
 
         np.testing.assert_allclose(expected, result, atol=1e-5, rtol=1e-5)
 
+    def test_returns_spatial_avg_for_x_y_as_xr_dataarray(self):
+        expected = [1.5, 1.333299, 1.5]
+        result = spatial_avg(self.ds, "ts", as_list=False)
+
+        assert isinstance(result, xr.DataArray)
+        np.testing.assert_allclose(expected, result, atol=1e-5, rtol=1e-5)
+
 
 class TestStd:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR refactors code that was originally implemented in PR #658 to be reusable across other diagnostic sets.

### Additional Changes:
- Move driver type annotations to `type_annotations.py`
- Move `lat_lon_driver._save_data_metrics_and_plots()` to `io.py`
- Update `_save_data_metrics_and_plots` args to accept `plot_func` callable
- Update `metrics.spatial_avg` to return an optionally `xr.DataArray` with `as_list=False`
- Move `parameter` arg to the top in `lat_lon_plot.plot`
- Move `_set_param_output_attrs` and `_set_name_yr_attrs` from `lat_lon_driver` to `CoreParameter` class

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
