### PR TITLE
Replace `parser.readfp()` with `parser.read_file()` for Python 3.12 support

### DIFF
--- a/e3sm_diags/parser/core_parser.py
+++ b/e3sm_diags/parser/core_parser.py
@@ -820,7 +820,7 @@ class CoreParser:
         # or duplicates while reading from a single source. This is required
         # because .cfg diagnostic files might contain duplicate sections with
         # slight tweaks based on the set.
-        parser = configparser.ConfigParser({"strict": False})  # type: ignore
+        parser = configparser.ConfigParser(strict=False)
         parser.read_file(cfg_file_obj)
 
         for section in parser.sections():

--- a/e3sm_diags/parser/core_parser.py
+++ b/e3sm_diags/parser/core_parser.py
@@ -816,7 +816,7 @@ class CoreParser:
 
         cfg_file_obj = self._create_cfg_hash_titles(cfg_file)
 
-        # Setting "strict" = False enables the parser to allow for any section
+        # Setting `strict=False` enables the parser to allow for any section
         # or duplicates while reading from a single source. This is required
         # because .cfg diagnostic files might contain duplicate sections with
         # slight tweaks based on the set.

--- a/e3sm_diags/parser/core_parser.py
+++ b/e3sm_diags/parser/core_parser.py
@@ -818,18 +818,18 @@ class CoreParser:
         kwargs = (
             {"strict": False} if sys.version_info[0] >= 3 else {}
         )  # 'strict' keyword doesn't work in Python 2.
-        config = configparser.ConfigParser(  # type: ignore
+        parser = configparser.ConfigParser(  # type: ignore
             **kwargs
         )  # Allow for two lines to be the same.
-        config.readfp(cfg_file_obj)
+        parser.read_file(cfg_file_obj)
 
-        for section in config.sections():
+        for section in parser.sections():
             p = self._parameter_cls()
 
             # Remove all of the variables.
             p.__dict__.clear()
 
-            for k, v in config.items(section):
+            for k, v in parser.items(section):
                 v = yaml.safe_load(v)
                 setattr(p, k, v)
 

--- a/e3sm_diags/parser/core_parser.py
+++ b/e3sm_diags/parser/core_parser.py
@@ -815,12 +815,12 @@ class CoreParser:
         parameters = []
 
         cfg_file_obj = self._create_cfg_hash_titles(cfg_file)
-        kwargs = (
-            {"strict": False} if sys.version_info[0] >= 3 else {}
-        )  # 'strict' keyword doesn't work in Python 2.
-        parser = configparser.ConfigParser(  # type: ignore
-            **kwargs
-        )  # Allow for two lines to be the same.
+
+        # Setting "strict" = False enables the parser to allow for any section
+        # or duplicates while reading from a single source. This is required
+        # because .cfg diagnostic files might contain duplicate sections with
+        # slight tweaks based on the set.
+        parser = configparser.ConfigParser({"strict": False})  # type: ignore
         parser.read_file(cfg_file_obj)
 
         for section in parser.sections():


### PR DESCRIPTION


## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #764
- Fixes a DeprecationWarning with `.readfp()` being deprecated in Python 3.12

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
