### PR TITLE
Add `subset_and_align_datasets()` to regrid.py

### DIFF
--- a/auxiliary_tools/cdat_regression_testing/671-lat-lon/ex1.py
+++ b/auxiliary_tools/cdat_regression_testing/671-lat-lon/ex1.py
@@ -11,7 +11,7 @@ param.test_data_path = "/global/cfs/cdirs/e3sm/e3sm_diags/test_model_data_for_ac
 param.reference_data_path = "/global/cfs/cdirs/e3sm/e3sm_diags/test_model_data_for_acme_diags/time-series/E3SM_v1"
 
 # Variables
-# param.variables = ["PRECT"]
+param.variables = ["PRECT"]
 
 # Set this parameter to True.
 # By default, e3sm_diags expects the test data to be climo data.
@@ -38,7 +38,7 @@ param.run_type = "model_vs_model"
 # Name of the folder where the results are stored.
 # Change `prefix` to use your directory.
 prefix = "/global/cfs/cdirs/e3sm/www/vo13/examples"
-param.results_dir = os.path.join(prefix, "755_ex1_modTS_vs_modTS_3years")
+param.results_dir = os.path.join(prefix, "ex1_modTS_vs_modTS_3years")
 
 # Below are more optional arguments.
 
@@ -56,7 +56,6 @@ param.multiprocessing = False
 # param.num_workers = 24
 
 # %%
-param.sets_to_run = ["lat_lon"]
 
 runner.run_diags([param])
 

--- a/auxiliary_tools/cdat_regression_testing/671-lat-lon/ex1.py
+++ b/auxiliary_tools/cdat_regression_testing/671-lat-lon/ex1.py
@@ -11,7 +11,7 @@ param.test_data_path = "/global/cfs/cdirs/e3sm/e3sm_diags/test_model_data_for_ac
 param.reference_data_path = "/global/cfs/cdirs/e3sm/e3sm_diags/test_model_data_for_acme_diags/time-series/E3SM_v1"
 
 # Variables
-param.variables = ["PRECT"]
+# param.variables = ["PRECT"]
 
 # Set this parameter to True.
 # By default, e3sm_diags expects the test data to be climo data.
@@ -38,7 +38,7 @@ param.run_type = "model_vs_model"
 # Name of the folder where the results are stored.
 # Change `prefix` to use your directory.
 prefix = "/global/cfs/cdirs/e3sm/www/vo13/examples"
-param.results_dir = os.path.join(prefix, "run_refactor_single_param")
+param.results_dir = os.path.join(prefix, "755_ex1_modTS_vs_modTS_3years")
 
 # Below are more optional arguments.
 
@@ -56,6 +56,8 @@ param.multiprocessing = False
 # param.num_workers = 24
 
 # %%
+param.sets_to_run = ["lat_lon"]
+
 runner.run_diags([param])
 
 # %%

--- a/auxiliary_tools/cdat_regression_testing/671-lat-lon/ex1.py
+++ b/auxiliary_tools/cdat_regression_testing/671-lat-lon/ex1.py
@@ -38,7 +38,7 @@ param.run_type = "model_vs_model"
 # Name of the folder where the results are stored.
 # Change `prefix` to use your directory.
 prefix = "/global/cfs/cdirs/e3sm/www/vo13/examples"
-param.results_dir = os.path.join(prefix, "ex1_modTS_vs_modTS_3years")
+param.results_dir = os.path.join(prefix, "run_refactor_single_param")
 
 # Below are more optional arguments.
 
@@ -56,7 +56,6 @@ param.multiprocessing = False
 # param.num_workers = 24
 
 # %%
-
 runner.run_diags([param])
 
 # %%

--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -150,8 +150,8 @@ def _run_diags_2d(
 
         (
             ds_test_region,
-            ds_ref_region,
             ds_test_region_regrid,
+            ds_ref_region,
             ds_ref_region_regrid,
             ds_diff_region,
         ) = subset_and_align_datasets(
@@ -233,8 +233,8 @@ def _run_diags_3d(
         for region in regions:
             (
                 ds_test_region,
-                ds_ref_region,
                 ds_test_region_regrid,
+                ds_ref_region,
                 ds_ref_region_regrid,
                 ds_diff_region,
             ) = subset_and_align_datasets(

--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, List
 
 import xarray as xr
 
 from e3sm_diags.driver.utils.dataset_xr import Dataset
 from e3sm_diags.driver.utils.io import _save_data_metrics_and_plots
 from e3sm_diags.driver.utils.regrid import (
-    _apply_land_sea_mask,
-    _subset_on_region,
-    align_grids_to_lower_res,
     get_z_axis,
     has_z_axis,
     regrid_z_axis_to_plevs,
+    subset_and_align_datasets,
 )
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
 from e3sm_diags.logger import custom_logger
@@ -151,11 +149,12 @@ def _run_diags_2d(
         parameter._set_param_output_attrs(var_key, season, region, ref_name, ilev=None)
 
         (
-            metrics_dict,
             ds_test_region,
             ds_ref_region,
+            ds_test_region_regrid,
+            ds_ref_region_regrid,
             ds_diff_region,
-        ) = _get_metrics_by_region(
+        ) = subset_and_align_datasets(
             parameter,
             ds_test,
             ds_ref,
@@ -163,6 +162,16 @@ def _run_diags_2d(
             var_key,
             region,
         )
+
+        metrics_dict = _create_metrics_dict(
+            var_key,
+            ds_test_region,
+            ds_test_region_regrid,
+            ds_ref_region,
+            ds_ref_region_regrid,
+            ds_diff_region,
+        )
+
         _save_data_metrics_and_plots(
             parameter,
             plot_func,
@@ -223,17 +232,27 @@ def _run_diags_3d(
 
         for region in regions:
             (
-                metrics_dict,
                 ds_test_region,
                 ds_ref_region,
+                ds_test_region_regrid,
+                ds_ref_region_regrid,
                 ds_diff_region,
-            ) = _get_metrics_by_region(
+            ) = subset_and_align_datasets(
                 parameter,
                 ds_test_ilev,
                 ds_ref_ilev,
                 ds_land_sea_mask,
                 var_key,
                 region,
+            )
+
+            metrics_dict = _create_metrics_dict(
+                var_key,
+                ds_test_region,
+                ds_test_region_regrid,
+                ds_ref_region,
+                ds_ref_region_regrid,
+                ds_diff_region,
             )
 
             parameter._set_param_output_attrs(var_key, season, region, ref_name, ilev)
@@ -246,88 +265,6 @@ def _run_diags_3d(
                 ds_diff_region,
                 metrics_dict,
             )
-
-
-def _get_metrics_by_region(
-    parameter: CoreParameter,
-    ds_test: xr.Dataset,
-    ds_ref: xr.Dataset,
-    ds_land_sea_mask: xr.Dataset,
-    var_key: str,
-    region: str,
-) -> Tuple[MetricsDict, xr.Dataset, xr.Dataset | None, xr.Dataset | None]:
-    """Get metrics by region and save data (optional), metrics, and plots
-
-    Parameters
-    ----------
-    parameter : CoreParameter
-        The parameter for the diagnostic.
-    ds_test : xr.Dataset
-        The dataset containing the test variable.
-    ds_ref : xr.Dataset
-        The dataset containing the ref variable. If this is a model-only run
-        then it will be the same dataset as ``ds_test``.
-    ds_land_sea_mask : xr.Dataset
-        The land sea mask dataset, which is only used for masking if the region
-        is "land" or "ocean".
-    var_key : str
-        The key of the variable.
-    region : str
-        The region.
-
-    Returns
-    -------
-    Tuple[MetricsDict, xr.Dataset, xr.Dataset | None, xr.Dataset | None]
-        A tuple containing the metrics dictionary, the test dataset, the ref
-        dataset (optional), and the diffs dataset (optional).
-    """
-    logger.info(f"Selected region: {region}")
-    parameter.var_region = region
-
-    # Apply a land sea mask or subset on a specific region.
-    if region == "land" or region == "ocean":
-        ds_test = _apply_land_sea_mask(
-            ds_test,
-            ds_land_sea_mask,
-            var_key,
-            region,  # type: ignore
-            parameter.regrid_tool,
-            parameter.regrid_method,
-        )
-        ds_ref = _apply_land_sea_mask(
-            ds_ref,
-            ds_land_sea_mask,
-            var_key,
-            region,  # type: ignore
-            parameter.regrid_tool,
-            parameter.regrid_method,
-        )
-    elif region != "global":
-        ds_test = _subset_on_region(ds_test, var_key, region)
-        ds_ref = _subset_on_region(ds_ref, var_key, region)
-
-    # Align the grid resolutions if the diagnostic is not model only.
-    if not parameter.model_only:
-        ds_test_regrid, ds_ref_regrid = align_grids_to_lower_res(
-            ds_test,
-            ds_ref,
-            var_key,
-            parameter.regrid_tool,
-            parameter.regrid_method,
-        )
-        ds_diff = ds_test_regrid.copy()
-        ds_diff[var_key] = ds_test_regrid[var_key] - ds_ref_regrid[var_key]
-    else:
-        ds_test_regrid = ds_test
-        ds_ref = None  # type: ignore
-        ds_ref_regrid = None
-        ds_diff = None
-
-    metrics_dict = _create_metrics_dict(
-        var_key, ds_test, ds_test_regrid, ds_ref, ds_ref_regrid, ds_diff
-    )
-
-    return metrics_dict, ds_test, ds_ref, ds_diff
 
 
 def _create_metrics_dict(

--- a/e3sm_diags/driver/utils/io.py
+++ b/e3sm_diags/driver/utils/io.py
@@ -43,7 +43,7 @@ def _save_data_metrics_and_plots(
         then it will be None.
     metrics_dict : Metrics | None
         The optional dictionary containing metrics for the variable. Some sets
-        such as cosp_histogram only calculate spatial average and does not
+        such as cosp_histogram only calculate spatial average and do not
         use ``metrics_dict``.
     """
     if parameter.save_netcdf:

--- a/e3sm_diags/driver/utils/io.py
+++ b/e3sm_diags/driver/utils/io.py
@@ -41,8 +41,10 @@ def _save_data_metrics_and_plots(
     ds_diff : xr.Dataset | None
         The optional difference dataset. If the diagnostic is a model-only run,
         then it will be None.
-    metrics_dict : Metrics
-        The dictionary containing metrics for the variable.
+    metrics_dict : Metrics | None
+        The optional dictionary containing metrics for the variable. Some sets
+        such as cosp_histogram only calculate spatial average and does not
+        use ``metrics_dict``.
     """
     if parameter.save_netcdf:
         _write_vars_to_netcdf(
@@ -68,13 +70,17 @@ def _save_data_metrics_and_plots(
         "long_name", "No long_name attr in test data"
     )
 
-    plot_func(
+    # Get the function arguments and pass to the set's plotting function.
+    args = [
         parameter,
         ds_test[var_key],
         ds_ref[var_key] if ds_ref is not None else None,
         ds_diff[var_key] if ds_diff is not None else None,
-        metrics_dict,
-    )
+    ]
+    if metrics_dict is not None:
+        args = args + [metrics_dict]
+
+    plot_func(*args)
 
 
 def _write_vars_to_netcdf(

--- a/e3sm_diags/driver/utils/regrid.py
+++ b/e3sm_diags/driver/utils/regrid.py
@@ -53,9 +53,9 @@ def subset_and_align_datasets(
     Returns
     -------
     Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]
-        A tuple containing the test dataset, the ref dataset, the regridded test
-        dataset, the regridded ref dataset, and the difference between regridded
-        datasets.
+        A tuple containing the test dataset, the regridded test
+        dataset, the ref dataset, the regridded ref dataset, and the difference
+        between regridded datasets.
     """
     logger.info(f"Selected region: {region}")
     parameter.var_region = region
@@ -93,7 +93,7 @@ def subset_and_align_datasets(
     ds_diff = ds_test_regrid.copy()
     ds_diff[var_key] = ds_test_regrid[var_key] - ds_ref_regrid[var_key]
 
-    return ds_test, ds_ref, ds_test_regrid, ds_ref_regrid, ds_diff
+    return ds_test, ds_test_regrid, ds_ref, ds_ref_regrid, ds_diff
 
 
 def has_z_axis(data_var: xr.DataArray) -> bool:

--- a/e3sm_diags/driver/utils/regrid.py
+++ b/e3sm_diags/driver/utils/regrid.py
@@ -7,6 +7,11 @@ import xcdat as xc
 
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
 from e3sm_diags.driver import MASK_REGION_TO_VAR_KEY
+from e3sm_diags.logger import custom_logger
+from e3sm_diags.parameter.core_parameter import CoreParameter
+
+logger = custom_logger(__name__)
+
 
 # Valid hybrid-sigma levels keys that can be found in datasets.
 HYBRID_SIGMA_KEYS = {
@@ -17,6 +22,78 @@ HYBRID_SIGMA_KEYS = {
 }
 
 REGRID_TOOLS = Literal["esmf", "xesmf", "regrid2"]
+
+
+def subset_and_align_datasets(
+    parameter: CoreParameter,
+    ds_test: xr.Dataset,
+    ds_ref: xr.Dataset,
+    ds_land_sea_mask: xr.Dataset,
+    var_key: str,
+    region: str,
+) -> Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]:
+    """Subset ref and test datasets on a region and regrid to align them.
+
+    Parameters
+    ----------
+    parameter : CoreParameter
+        The parameter for the diagnostic.
+    ds_test : xr.Dataset
+        The dataset containing the test variable.
+    ds_ref : xr.Dataset
+        The dataset containing the ref variable.
+    ds_land_sea_mask : xr.Dataset
+        The land sea mask dataset, which is only used for masking if the region
+        is "land" or "ocean".
+    var_key : str
+        The key of the variable.
+    region : str
+        The region.
+
+    Returns
+    -------
+    Tuple[xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset, xr.Dataset]
+        A tuple containing the test dataset, the ref dataset, the regridded test
+        dataset, the regridded ref dataset, and the difference between regridded
+        datasets.
+    """
+    logger.info(f"Selected region: {region}")
+    parameter.var_region = region
+
+    # Apply a land sea mask or subset on a specific region.
+    if region == "land" or region == "ocean":
+        ds_test = _apply_land_sea_mask(
+            ds_test,
+            ds_land_sea_mask,
+            var_key,
+            region,  # type: ignore
+            parameter.regrid_tool,
+            parameter.regrid_method,
+        )
+        ds_ref = _apply_land_sea_mask(
+            ds_ref,
+            ds_land_sea_mask,
+            var_key,
+            region,  # type: ignore
+            parameter.regrid_tool,
+            parameter.regrid_method,
+        )
+    elif region != "global":
+        ds_test = _subset_on_region(ds_test, var_key, region)
+        ds_ref = _subset_on_region(ds_ref, var_key, region)
+
+    ds_test_regrid, ds_ref_regrid = align_grids_to_lower_res(
+        ds_test,
+        ds_ref,
+        var_key,
+        parameter.regrid_tool,
+        parameter.regrid_method,
+    )
+
+    ds_diff = ds_test_regrid.copy()
+    ds_diff[var_key] = ds_test_regrid[var_key] - ds_ref_regrid[var_key]
+
+    return ds_test, ds_ref, ds_test_regrid, ds_ref_regrid, ds_diff
 
 
 def has_z_axis(data_var: xr.DataArray) -> bool:

--- a/e3sm_diags/driver/utils/regrid.py
+++ b/e3sm_diags/driver/utils/regrid.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Literal, Tuple
+from typing import TYPE_CHECKING, List, Literal, Tuple
 
 import xarray as xr
 import xcdat as xc
@@ -8,7 +8,9 @@ import xcdat as xc
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
 from e3sm_diags.driver import MASK_REGION_TO_VAR_KEY
 from e3sm_diags.logger import custom_logger
-from e3sm_diags.parameter.core_parameter import CoreParameter
+
+if TYPE_CHECKING:
+    from e3sm_diags.parameter.core_parameter import CoreParameter
 
 logger = custom_logger(__name__)
 

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import importlib
 import sys
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 from e3sm_diags.derivations.derivations import DerivedVariablesMap
 from e3sm_diags.driver.utils.climo_xr import CLIMO_FREQ
@@ -128,7 +128,7 @@ class CoreParameter:
         self.output_format_subplot: List[str] = []
         self.canvas_size_w: int = 1212
         self.canvas_size_h: int = 1628
-        self.figsize: List[float] = [8.5, 11.0]
+        self.figsize: Tuple[float, float] = (8.5, 11.0)
         self.dpi: int = 150
         self.arrows: bool = True
         self.logo: bool = False

--- a/e3sm_diags/plot/utils.py
+++ b/e3sm_diags/plot/utils.py
@@ -40,7 +40,7 @@ PANEL = [
 BORDER_PADDING = (-0.06, -0.03, 0.13, 0.03)
 
 
-def _save_plot(fig: plt.figure, parameter: CoreParameter):
+def _save_plot(fig: plt.Figure, parameter: CoreParameter):
     """Save the plot using the figure object and parameter configs.
 
     This function creates the output filename to save the plot. It also
@@ -48,7 +48,7 @@ def _save_plot(fig: plt.figure, parameter: CoreParameter):
 
     Parameters
     ----------
-    fig : plt.figure
+    fig : plt.Figure
         The plot figure.
     parameter : CoreParameter
         The CoreParameter with file configurations.
@@ -98,7 +98,7 @@ def _save_plot(fig: plt.figure, parameter: CoreParameter):
 def _add_colormap(
     subplot_num: int,
     var: xr.DataArray,
-    fig: plt.figure,
+    fig: plt.Figure,
     parameter: CoreParameter,
     color_map: str,
     contour_levels: List[float],
@@ -117,7 +117,7 @@ def _add_colormap(
         The subplot number.
     var : xr.DataArray
         The variable to plot.
-    fig : plt.figure
+    fig : plt.Figure
         The figure object to add the subplot to.
     parameter : CoreParameter
         The CoreParameter object containing plot configurations.


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #775 
- Fix unit tests failures
  - For some tests, the parameter object `.sets` attr is updated. We need to update the attr directly and not the existing list value because it affects the `DEFAULT_SETS` list too, which causes tests failures
- Update `_squeeze_time_dim` to only squeeze time dimensions if len is 1
- Make `metrics_dict` an optional arg passed to `plot_func` in `plot.plot()`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
