### PR TITLE
Fix `cosp_histogram_driver.py` not writing mean variables to netCDF

### DIFF
--- a/e3sm_diags/driver/cosp_histogram_driver.py
+++ b/e3sm_diags/driver/cosp_histogram_driver.py
@@ -121,8 +121,8 @@ def run_diag(parameter: CoreParameter) -> CoreParameter:
                 )
                 utils.general.save_ncfiles(
                     parameter.current_set,
-                    mv1_domain,
-                    mv2_domain,
+                    mv1_domain_mean,
+                    mv2_domain_mean,
                     diff,
                     parameter,
                 )


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #781 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
