### PR TITLE
add intermediate output in json for ARM Diags

### DIFF
--- a/e3sm_diags/driver/arm_diags_driver.py
+++ b/e3sm_diags/driver/arm_diags_driver.py
@@ -343,6 +343,8 @@ def run_diag_annual_cycle(parameter: ARMDiagsParameter) -> ARMDiagsParameter:
                 vars_to_data[season] = result
                 # Saving the metrics as a json.
                 metrics_dict["unit"] = test.units
+                metrics_dict["ref_domain"] = list(ref_domain)
+                metrics_dict["test_domain"] = list(test_domain)
                 parameter.output_file = "-".join([ref_name, var, season, region])
                 fnm = os.path.join(
                     utils.general.get_output_dir(parameter.current_set, parameter),
@@ -538,6 +540,8 @@ def run_diag_annual_cycle_aerosol(parameter: ARMDiagsParameter) -> ARMDiagsParam
                 vars_to_data[season] = result
                 # Saving the metrics as a json.
                 metrics_dict["unit"] = test.units
+                metrics_dict["ref_domain"] = list(ref_domain)
+                metrics_dict["test_domain"] = list(test_domain)
                 print(parameter.var_units, test.units)
                 parameter.output_file = "-".join(
                     [ref_name, var, season, "aerosol", region]


### PR DESCRIPTION
## Description

@yunpengshan2014 contributed this enhancement to allow two ARM Diags sets to output intermediate metrics for offline analysis.

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
