### PR TITLE
fix save_ncfiles for annual_cycle_zonal_mean

### DIFF
--- a/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
+++ b/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
@@ -121,8 +121,8 @@ def run_diag(parameter: ACzonalmeanParameter) -> ACzonalmeanParameter:
         )
         save_ncfiles(
             parameter.current_set,
-            ref_ac_zonal_mean,
             test_ac_zonal_mean,
+            ref_ac_zonal_mean,
             diff_ac,
             parameter,
         )


### PR DESCRIPTION
## Description

An issue captured in regression test during refactor. When saving result in nc files, the order of test and ref data flipped. Plots order is not affected.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
