### PR TITLE
make --closedcontourcmd resolution specific

### DIFF
--- a/auxiliary_tools/run_tc_analysis.py
+++ b/auxiliary_tools/run_tc_analysis.py
@@ -3,32 +3,24 @@ from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
 from e3sm_diags.run import runner
 
-param = CoreParameter()
+simulations = ['tc-v2.LR.amip.2000_2014']
+sim_names = ['v2.LR.amip_0101']
 
-#param.test_data_path = '/Users/zhang40/Documents/ACME_simulations/E3SM_v1_H1_6hourly_TC/test'
-param.test_data_path = '/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis/1_2/1_2'
-param.test_name = '20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis' 
-param.test_data_path = '/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/extendedOutput.v3.LR.historical_0101/tc-analysis'
-param.test_name = 'extendedOutput.v3.LR.historical_0101' 
-param.short_test_name = 'v3.LR.historical_threshold_1.0'
-param.reference_data_path = '/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis/0_3/0_3'
-param.ref_name = '20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis'
-param.short_ref_name = 'threshold_0.3'
-param.run_type = 'model_vs_model'
-prefix = '/Users/zhang40/Downloads'
-prefix = '/global/cfs/cdirs/e3sm/www/zhang40/tests'
-#param.multiprocessing = True
-#param.num_workers = 4
-param.results_dir = os.path.join(prefix, 'tc_anlasis_model_model')
-#param.test_timeseries_input = True
-#param.ref_timeseries_input = True
-param.test_start_yr = '0051'
-param.test_end_yr = '0060'
-param.test_start_yr = '2000'
-param.test_end_yr = '2014'
-param.ref_start_yr = '0051'
-param.ref_end_yr = '0060'
+data_path = '/global/homes/c/chengzhu/tests/tc_analysis/'
 
-runner.sets_to_run = ['tc_analysis']
-runner.run_diags([param])
+for idx, sim in enumerate(simulations):
+    print(sim)
+    param = CoreParameter()
+    param.test_data_path = data_path+sim
+    param.test_name = sim_names[idx]
+    param.test_start_yr = "2000"
+    param.test_end_yr = "2014"
 
+    param.reference_data_path = '/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/tc-analysis'
+    param.ref_start_yr = '1979'
+    param.ref_end_yr = '2018'
+
+    prefix = f'/global/cfs/cdirs/e3sm/www/chengzhu/tc_analysis_test/'
+    param.results_dir = os.path.join(prefix, sim)
+    runner.sets_to_run = ['tc_analysis']
+    runner.run_diags([param])

--- a/auxiliary_tools/run_tc_analysis.py
+++ b/auxiliary_tools/run_tc_analysis.py
@@ -1,0 +1,34 @@
+import os
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.run import runner
+
+param = CoreParameter()
+
+#param.test_data_path = '/Users/zhang40/Documents/ACME_simulations/E3SM_v1_H1_6hourly_TC/test'
+param.test_data_path = '/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis/1_2/1_2'
+param.test_name = '20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis' 
+param.test_data_path = '/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/extendedOutput.v3.LR.historical_0101/tc-analysis'
+param.test_name = 'extendedOutput.v3.LR.historical_0101' 
+param.short_test_name = 'v3.LR.historical_threshold_1.0'
+param.reference_data_path = '/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis/0_3/0_3'
+param.ref_name = '20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis'
+param.short_ref_name = 'threshold_0.3'
+param.run_type = 'model_vs_model'
+prefix = '/Users/zhang40/Downloads'
+prefix = '/global/cfs/cdirs/e3sm/www/zhang40/tests'
+#param.multiprocessing = True
+#param.num_workers = 4
+param.results_dir = os.path.join(prefix, 'tc_anlasis_model_model')
+#param.test_timeseries_input = True
+#param.ref_timeseries_input = True
+param.test_start_yr = '0051'
+param.test_end_yr = '0060'
+param.test_start_yr = '2000'
+param.test_end_yr = '2014'
+param.ref_start_yr = '0051'
+param.ref_end_yr = '0060'
+
+runner.sets_to_run = ['tc_analysis']
+runner.run_diags([param])
+

--- a/examples/use_zppy_to_run_e3sm_diags/zstash_extract_E3SM_data_from_NERSC_HPSS.sh
+++ b/examples/use_zppy_to_run_e3sm_diags/zstash_extract_E3SM_data_from_NERSC_HPSS.sh
@@ -7,7 +7,7 @@
 # $ screen
 
 # Active e3sm_unified to use zstash
-source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
+source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_pm-cpu.sh
 
 # Make a new folder to recieve extracted datasets.
 mkdir -p /global/cfs/cdirs/e3smpub/E3SM_simulations/v2.LR.historical_0101
@@ -18,6 +18,8 @@ cd /global/cfs/cdirs/e3smpub/E3SM_simulations/v2.LR.historical_0101
 
 # retrive h0(monthly) atmospheric data, size = 821 G
 zstash extract --hpss=/home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.historical_0101 "archive/atm/hist/*h0*"
+# retrive h1(daily) atmospheric data
+zstash extract --hpss=/home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.historical_0101 "archive/atm/hist/*h1*"
 # retrive h2(6 hourly) atmospheric data, size = 195 G [Optional] only needed for Tropical Cycle Analysis
 zstash extract --hpss=/home/projects/e3sm/www/WaterCycle/E3SMv2/LR/v2.LR.historical_0101 "archive/atm/hist/*h2*"
 # retrive h4(3 hourly) atmospheric data, size = 195 G [Optional] only needed for Diurnal Cycle of Precipitation

--- a/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
+++ b/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
@@ -1,26 +1,17 @@
 #!/bin/bash
 
 # A Bash script to post-process E3SM 6 hourly (h2) instantaneous output to generate a text file storing Tropical Cyclone tracks
-# tempestremap and tempestextremes are built in e3sm-unified from version 1.5.0. This script has been tested using Cori login node.
+# tempestremap and tempestextremes are built in e3sm-unified from version 1.5.0. This script has been tested using Perlmutter login node.
 # To request an interactive session as follows: salloc --nodes=1 --partition=debug --time=30:00 -C cpu
 
 source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_pm-cpu.sh
 
 #For typical EAM v2 ne gp2 grids.
-start="0051"
-end="0060"
-caseid="20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis"
-drc_in=/global/cfs/cdirs/e3smdata/zppy_complete_run_nersc_output/${caseid}/archive/atm/hist
-
 start="2000"
 end="2014"
-caseid="extendedOutput.v3.LR.historical_0101"
-drc_in=/global/cfs/cdirs/e3sm/www/Tutorials/2024/simulations/extendedOutput.v3.LR.historical_0101/archive/atm/hist
-# Warning: because somehow tempest-remap only can writes grid file on SCRATCH space. The resulted files will be moved to another path at the end.
-result_dir_fin=/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/${caseid}/
-mkdir -p $result_dir_fin
-result_dir=$SCRATCH/tests/tc-analysis/
-
+caseid="v2.LR.amip_0101"
+drc_in=/global/cfs/cdirs/e3smpub/E3SM_simulations/${caseid}/archive/atm/hist
+result_dir=/global/homes/c/chengzhu/tests/tc_analysis/tc-v2.LR.amip.${start}_${end}/
 
 #res = 30/120 for ne30/ne120 grids
 res=30               # res = 30/120 for ne30/ne120 grids
@@ -28,47 +19,31 @@ pg2=true             # Set false for v1 production simulations
 atm_name="eam"       # Use "cam" for v1 production simulations
 
 
-##For typical v1 ne SE grids.
-#start="1880"
-#end="1881"
-#caseid="20180215.DECKv1b_H1.ne30_oEC.edison"
-#drc_in=/global/cfs/cdirs/e3smpub/E3SM_simulations/${caseid}/archive/atm/hist
-#result_dir=/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v1_data_for_e3sm_diags/${caseid}/tc-analysis/
-#
-##res = 30/120 for ne30/ne120 grids
-#res=30               # res = 30/120 for ne30/ne120 grids
-#pg2=false             # Set false for v1 production simulations
-#atm_name="cam"       # Use "cam" for v1 production simulations
-
-
-
 mkdir -p $result_dir
 file_name=${caseid}_${start}_${end}
 
 # Generate mesh files (.g).
-#/global/homes/p/paullric/tempestremap/bin/GenerateCSMesh --res $res --alt --file ${result_dir}outCSne$res.g
-GenerateCSMesh --res $res --alt --file ${result_dir}outCSne$res.g
-out_type="CGLL"
-# For v2 production simulation with pg2 grids:
 if $pg2; then
-    GenerateVolumetricMesh --in ${result_dir}outCSne$res.g  --out ${result_dir}outCSne$res.g --np 2 --uniform
+    # For v2 and v3 production simulation with pg2 grids:
+    GenerateCSMesh --res $res --alt --file ${result_dir}outCSMeshne$res.g
+    GenerateVolumetricMesh --in ${result_dir}outCSMeshne$res.g  --out ${result_dir}outCSne$res.g --np 2 --uniform
     out_type="FV"
+else
+    # For v1 production simulation with np4 grids:
+    GenerateCSMesh --res $res --alt --file ${result_dir}outCSne$res.g
+    out_type="CGLL"
 fi
 echo $out_type
 # Generate connectivity files (.dat)
-#/global/homes/p/paullric/tempestextremes/bin/GenerateConnectivityFile --in_mesh ${result_dir}outCSne$res.g --out_type CGLL --out_connect ${result_dir}connect_CSne${res}_v2.dat
 GenerateConnectivityFile --in_mesh ${result_dir}outCSne$res.g --out_type $out_type --out_connect ${result_dir}connect_CSne${res}_v2.dat
 
 # Get the list of files
 cd ${drc_in};eval ls ${drc_in}/${caseid}.$atm_name.h2.*{${start}..${end}}*.nc >${result_dir}inputfile_${file_name}.txt
 cd ${drc_in};eval ls ${caseid}.$atm_name.h2.*{${start}..${end}}*.nc >${result_dir}outputfile_${file_name}.txt
-#cd ${drc_in};eval ls ${drc_in}/${caseid}.cam.h2.*{${start}..${end}}*.nc >${result_dir}inputfile_${file_name}.txt
-#cd ${drc_in};eval ls ${caseid}.cam.h2.*{${start}..${end}}*.nc >${result_dir}outputfile_${file_name}.txt
 
 cd ${result_dir}
 # Detection threshold including:
 # The sea-level pressure (SLP) must be a local minimum; SLP must have a sufficient decrease (300 Pa) compared to surrounding nodes within 4 degree radius; The average of the 200 hPa and 500 hPa level temperature decreases by 0.6 K in all directions within a 4 degree radius from the location to fSLP minima
-#/global/homes/p/paullric/tempestextremes/bin/DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
 
 # --closedcontourcmd threshold is resolution depended.
 if [ $res == 120 ]; then
@@ -84,32 +59,26 @@ fi
 cat ${result_dir}out.dat0* > ${result_dir}cyclones_${file_name}.txt
 
 # Stitch all candidate nodes in time to form tracks, with a maximum distance between candidates of 6.0, minimum time steps of 6, and with a maximum gap size of one (most consecutive time steps with no associated candidate). And there is threshold for wind speed, lat and lon.
-#/global/homes/p/paullric/tempestextremes/bin/StitchNodes --in_fmt "lon,lat,slp,wind" --in_connect ${result_dir}connect_CSne${res}_v2.dat --range 6.0 --mintime 6 --maxgap 1 --in ${result_dir}cyclones_${file_name}.txt --out ${result_dir}cyclones_stitch_${file_name}.dat --threshold "wind,>=,17.5,6;lat,<=,40.0,6;lat,>=,-40.0,6"
 StitchNodes --in_fmt "lon,lat,slp,wind" --in_connect ${result_dir}connect_CSne${res}_v2.dat --range 6.0 --mintime 6 --maxgap 1 --in ${result_dir}cyclones_${file_name}.txt --out ${result_dir}cyclones_stitch_${file_name}.dat --threshold "wind,>=,17.5,6;lat,<=,40.0,6;lat,>=,-40.0,6"
 rm ${result_dir}cyclones_${file_name}.txt
 
 # Generate histogram of detections
-#/global/homes/p/paullric/tempestextremes/bin/HistogramNodes --in ${result_dir}cyclones_stitch_${file_name}.txt --iloncol 2 --ilatcol 3 --out ${result_dir}cyclones_hist_${file_name}.nc
 HistogramNodes --in ${result_dir}cyclones_stitch_${file_name}.dat --iloncol 2 --ilatcol 3 --out ${result_dir}cyclones_hist_${file_name}.nc
 
 # Calculate relative vorticity
-sed -i 's/.nc/_vorticity.nc/' ${result_dir}outputfile_${file_name}.txt
-#/global/homes/p/paullric/tempestextremes/bin/VariableProcessor --in_data_list ${result_dir}inputfile_${file_name}.txt --out_data_list ${result_dir}outputfile_${file_name}.txt --var "_CURL{4,0.5}(U850,V850)" --varout "VORT" --in_connect ${result_dir}connect_CSne${res}_v2.dat
+sed -i 's/\.nc/_vorticity.nc/' ${result_dir}outputfile_${file_name}.txt
 VariableProcessor --in_data_list ${result_dir}inputfile_${file_name}.txt --out_data_list ${result_dir}outputfile_${file_name}.txt --var "_CURL{4,0.5}(U850,V850)" --varout "VORT" --in_connect ${result_dir}connect_CSne${res}_v2.dat
 
-#/global/homes/p/paullric/tempestextremes/bin/DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "VORT,-5.e-6,4,0" --mergedist 2.0 --searchbymax VORT --outputcmd "VORT,max,0" --in_data_list ${result_dir}outputfile_${file_name}.txt --out ${result_dir}aew_out.dat --minlat -35.0 --maxlat 35.0
 DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "VORT,-5.e-6,4,0" --mergedist 2.0 --searchbymax VORT --outputcmd "VORT,max,0" --in_data_list ${result_dir}outputfile_${file_name}.txt --out ${result_dir}aew_out.dat --minlat -35.0 --maxlat 35.0
 cat ${result_dir}aew_out.dat0* > ${result_dir}aew_${file_name}.txt
 
-#/global/homes/p/paullric/tempestextremes/bin/StitchNodes --in_fmt "lon,lat,VORT" --in_connect ${result_dir}connect_CSne${res}_v2.dat --range 3.0 --minlength 8 --maxgap 0 --min_endpoint_dist 10.0 --in ${result_dir}aew_${file_name}.txt --out ${result_dir}aew_stitch_5e-6_${file_name}.dat --threshold "lat,<=,25.0,8;lat,>=,0.0,8"
 StitchNodes --in_fmt "lon,lat,VORT" --in_connect ${result_dir}connect_CSne${res}_v2.dat --range 3.0 --minlength 8 --maxgap 0 --min_endpoint_dist 10.0 --in ${result_dir}aew_${file_name}.txt --out ${result_dir}aew_stitch_5e-6_${file_name}.dat --threshold "lat,<=,25.0,8;lat,>=,0.0,8"
 rm ${result_dir}aew_${file_name}.txt
 
-#/global/homes/p/paullric/tempestextremes/bin/HistogramNodes --in ${result_dir}aew_stitch_5e-6_${file_name}.dat --iloncol 2 --ilatcol 3 --nlat 256 --nlon 512 --out ${result_dir}aew_hist_${file_name}.nc
 HistogramNodes --in ${result_dir}aew_stitch_5e-6_${file_name}.dat --iloncol 2 --ilatcol 3 --nlat 256 --nlon 512 --out ${result_dir}aew_hist_${file_name}.nc
+
 rm ${result_dir}*out.dat00*.dat
 rm ${result_dir}${caseid}*.nc
 rm ${result_dir}*.txt
-mv $result_dir $result_dir_fin
 
 exit

--- a/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
+++ b/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
@@ -64,7 +64,15 @@ cd ${result_dir}
 # Detection threshold including:
 # The sea-level pressure (SLP) must be a local minimum; SLP must have a sufficient decrease (300 Pa) compared to surrounding nodes within 4 degree radius; The average of the 200 hPa and 500 hPa level temperature decreases by 0.6 K in all directions within a 4 degree radius from the location to fSLP minima
 #/global/homes/p/paullric/tempestextremes/bin/DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
-DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
+
+# --closedcontourcmd threshold is resolution depended.
+if [ res==120 ]; then
+    DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
+elif [ res==30 ]; then
+    DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,1.0" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
+else
+    echo “$res not supported”
+fi
 
 cat ${result_dir}out.dat0* > ${result_dir}cyclones_${file_name}.txt
 

--- a/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
+++ b/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
@@ -2,9 +2,9 @@
 
 # A Bash script to post-process E3SM 6 hourly (h2) instantaneous output to generate a text file storing Tropical Cyclone tracks
 # tempestremap and tempestextremes are built in e3sm-unified from version 1.5.0. This script has been tested using Cori login node.
-# To request an interactive session as follows: salloc --nodes=1 --partition=debug --time=30:00 -C haswell
+# To request an interactive session as follows: salloc --nodes=1 --partition=debug --time=30:00 -C cpu
 
-source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
+source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_pm-cpu.sh
 
 #For typical EAM v2 ne gp2 grids.
 start="0051"
@@ -66,9 +66,9 @@ cd ${result_dir}
 #/global/homes/p/paullric/tempestextremes/bin/DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
 
 # --closedcontourcmd threshold is resolution depended.
-if [ res==120 ]; then
-    DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
-elif [ res==30 ]; then
+#if [ res==120 ]; then
+#    DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
+if [ $res==30 ]; then
     DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,1.0" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
 else
     echo “$res not supported”

--- a/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
+++ b/model_data_preprocess/postprocessing_E3SM_data_for_TC_analysis.sh
@@ -11,6 +11,11 @@ start="0051"
 end="0060"
 caseid="20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis"
 drc_in=/global/cfs/cdirs/e3smdata/zppy_complete_run_nersc_output/${caseid}/archive/atm/hist
+
+start="2000"
+end="2014"
+caseid="extendedOutput.v3.LR.historical_0101"
+drc_in=/global/cfs/cdirs/e3sm/www/Tutorials/2024/simulations/extendedOutput.v3.LR.historical_0101/archive/atm/hist
 # Warning: because somehow tempest-remap only can writes grid file on SCRATCH space. The resulted files will be moved to another path at the end.
 result_dir_fin=/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags/${caseid}/
 mkdir -p $result_dir_fin
@@ -66,12 +71,14 @@ cd ${result_dir}
 #/global/homes/p/paullric/tempestextremes/bin/DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
 
 # --closedcontourcmd threshold is resolution depended.
-#if [ res==120 ]; then
-#    DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
-if [ $res==30 ]; then
+if [ $res == 120 ]; then
+    echo $res
+    DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
+elif [ $res == 30 ]; then
+    echo $res
     DetectNodes --verbosity 0 --in_connect ${result_dir}connect_CSne${res}_v2.dat --closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,1.0" --mergedist 6.0 --searchbymin PSL --outputcmd "PSL,min,0;_VECMAG(UBOT,VBOT),max,2" --timestride 1 --in_data_list ${result_dir}inputfile_${file_name}.txt --out ${result_dir}out.dat
 else
-    echo “$res not supported”
+    echo “$res value not supported”
 fi
 
 cat ${result_dir}out.dat0* > ${result_dir}cyclones_${file_name}.txt


### PR DESCRIPTION
## Description

TC detection threshold should be model data resolution depended, currently the pre-processing script is using a threshold for ne120, resulted small number of detected TC events in ne30 simulations. Now update to add resolution specific thresholds.
Note: this fix should bring into cdat migration branch, and zppy implementation.

The original closed contour criteria (--closedcontourcmd "PSL,300.0,4.0,0;_AVG(T200,T500),-0.6,4,0.30"):
requiring an increase in PSL of at least 300 Pa (3 hPa) within 4 Degree of the candidate node,
and a decrease in 200  and 500 hPa average air temperature of 0.6 K within 4 Degree of the node within 0.3 degree of the candidate with maximum air temperature.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
