### PR TITLE
Tweak behaviors of build and release CI workflows

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -10,13 +10,13 @@ on:
   workflow_dispatch:
 
 env:
-  CANCEL_OTHERS: true
+  CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**", "**/examples/**", "**/misc/**", "**/.vscode/**", "**/.github/pull_request_template.md", "**/.github/ISSUE_TEMPLATE"]'
 
 jobs:
   pre-commit-hooks:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
@@ -78,10 +78,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: "e3sm_diags_ci"
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           environment-file: conda-env/ci.yml
           channel-priority: strict
           auto-update-conda: true
@@ -95,8 +93,8 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Check conda env
         run: |
-          mamba list
-          mamba info
+          conda list
+          conda info
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Run Unit Tests
@@ -139,10 +137,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: "e3sm_diags_ci"
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           environment-file: conda-env/ci.yml
           channel-priority: strict
           auto-update-conda: true

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -33,10 +33,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: "e3sm_diags_ci"
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           environment-file: conda-env/ci.yml
           channel-priority: strict
           auto-update-conda: true


### PR DESCRIPTION
## Description
Hello! With this PR I've tweaked some settings that @xylar and I have determined work out better in CI workflows on other repos. I've made the same changes here. These changes include:
1. `cancel_others` is now set to false by default, which should make it easier to decipher if a bug is isolated to a specific version of python via CI
2. All references to `mamba`/ `Mambaforge` have been removed and/or changed to `conda` / `Miniforge3`
3. The timeout for the `pre-commit` job has been upped to 5 minutes (we were having some timeout issues during the caching step)

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

