### PR TITLE
Add function to add CF axis attr to Z axis if missing for downstream xCDAT operations

### DIFF
--- a/e3sm_diags/driver/utils/dataset_xr.py
+++ b/e3sm_diags/driver/utils/dataset_xr.py
@@ -393,6 +393,11 @@ class Dataset:
         filepath = self._get_climo_filepath(season)
         ds = self._open_climo_dataset(filepath)
 
+        # Add CF attributes to Z axes if they are missing.
+        # NOTE: This is a temporary workaround for xCDAT.
+        # Refer to https://github.com/xCDAT/xcdat/pull/708
+        ds = self._add_cf_attrs_to_z_axes(ds)
+
         if self.var in self.derived_vars_map:
             ds = self._get_dataset_with_derived_climo_var(ds)
         elif self.var in ds.data_vars.keys():
@@ -405,6 +410,32 @@ class Dataset:
 
         ds = squeeze_time_dim(ds)
         ds = self._subset_vars_and_load(ds)
+
+        return ds
+
+    def _add_cf_attrs_to_z_axes(self, ds: xr.Dataset) -> xr.Dataset:
+        """Add CF attributes to the Z axes of the dataset.
+
+        This method is a temporary solution to enable xCDAT to properly
+        retrieve bounds for Z axes that do not have CF attributes, which
+        is required for downstream regridding operations.
+
+        Parameters
+        ----------
+        ds : xr.Dataset
+            The dataset.
+
+        Returns
+        -------
+        xr.Dataset
+            The dataset with CF attributes added to the Z axes.
+        """
+        dim = xc.get_dim_keys(ds, axis="Z")
+
+        axis_attr = ds[dim].attrs.get("axis")
+
+        if axis_attr is None:
+            ds[dim].attrs["axis"] = "Z"
 
         return ds
 
@@ -449,7 +480,7 @@ class Dataset:
         args = {
             "paths": filepath,
             "decode_times": True,
-            "add_bounds": ["X", "Y"],
+            "add_bounds": ["X", "Y", "Z"],
             "coords": "minimal",
             "compat": "override",
         }

--- a/e3sm_diags/driver/utils/dataset_xr.py
+++ b/e3sm_diags/driver/utils/dataset_xr.py
@@ -414,7 +414,7 @@ class Dataset:
         return ds
 
     def _add_cf_attrs_to_z_axes(self, ds: xr.Dataset) -> xr.Dataset:
-        """Add CF attributes to the Z axes of the dataset.
+        """Add CF attributes to the Z axis of the dataset if the Z axis exists.
 
         This method is a temporary solution to enable xCDAT to properly
         retrieve bounds for Z axes that do not have CF attributes, which
@@ -430,12 +430,15 @@ class Dataset:
         xr.Dataset
             The dataset with CF attributes added to the Z axes.
         """
-        dim = xc.get_dim_keys(ds, axis="Z")
+        try:
+            dim = xc.get_dim_keys(ds, axis="Z")
+        except KeyError:
+            pass
+        else:
+            axis_attr = ds[dim].attrs.get("axis")
 
-        axis_attr = ds[dim].attrs.get("axis")
-
-        if axis_attr is None:
-            ds[dim].attrs["axis"] = "Z"
+            if axis_attr is None:
+                ds[dim].attrs["axis"] = "Z"
 
         return ds
 


### PR DESCRIPTION

## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #863 863
- This is a temporary workaround for variables that have Z axes without CF axis attr, which is required for xCDAT to map to for bounds for downstream operations such as regridding


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
