### PR TITLE
Revamp logger module for additional features and bug fixes

### DIFF
--- a/auxiliary_tools/cdat_regression_testing/909-prov-log/qa.py
+++ b/auxiliary_tools/cdat_regression_testing/909-prov-log/qa.py
@@ -1,0 +1,41 @@
+import os
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.run import Run, runner
+
+simulations = [
+    "tc-v1.HR.0026_0035",
+    "tc-v2.LR.2000_2014",
+    "tc-v3.HR.0006_0025",
+    "tc-v3.LR.2000_2014",
+]
+sim_names = [
+    "theta.20180906.branch_noCNT.A_WCYCL1950S_CMIP6_HR.ne120_oRRS18v3_ICG",
+    "v2.LR.historical_0101",
+    "20240609.piCtl.ne120pg2_r025_RRSwISC6to18E3r5.chrysalis.test1",
+    "extendedOutput.v3.LR.historical_0101",
+]
+
+data_path = "/global/homes/c/chengzhu/tests/tc_analysis/"
+
+for idx, sim in enumerate(simulations):
+    print(sim)
+    # runner = Run()
+
+    param = CoreParameter()
+    param.multiprocessing = True
+    param.test_data_path = data_path + sim
+    param.test_name = sim_names[idx]
+    param.test_start_yr = sim.split(".")[-1][0:4]
+    param.test_end_yr = sim.split(".")[-1][5:9]
+
+    param.reference_data_path = (
+        "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/tc-analysis"
+    )
+    param.ref_start_yr = "1979"
+    param.ref_end_yr = "2018"
+
+    prefix = "/global/cfs/cdirs/e3sm/www/vo13/tc_analysis_test/"
+    param.results_dir = os.path.join(prefix, sim)
+    runner.sets_to_run = ["tc_analysis"]
+    runner.run_diags([param])

--- a/auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg
+++ b/auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg
@@ -28,94 +28,94 @@ contour_levels = [0.5, 1, 1.5, 2, 3, 4, 5, 7.5, 10]
 diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
 
 
-# [#]
-# sets = ["polar"]
-# case_id = "GPCP_v2.3"
-# variables = ["PRECT"]
-# ref_name = "GPCP_v2.3"
-# reference_name = "GPCP v2.3"
-# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-# regions = ["polar_S"]
-# test_colormap = "WhiteBlueGreenYellowRed.rgb"
-# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-# diff_colormap = "BrBG"
-# contour_levels = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
-# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+[#]
+sets = ["polar"]
+case_id = "GPCP_v2.3"
+variables = ["PRECT"]
+ref_name = "GPCP_v2.3"
+reference_name = "GPCP v2.3"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_S"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
+diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
 
 
-# [#]
-# sets = ["polar"]
-# case_id = "GPCP_v2.3"
-# variables = ["PRECT"]
-# ref_name = "GPCP_v2.3"
-# reference_name = "GPCP v2.3"
-# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-# regions = ["polar_N"]
-# test_colormap = "WhiteBlueGreenYellowRed.rgb"
-# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-# diff_colormap = "BrBG"
-# contour_levels = [0.5, 1, 1.5, 2, 3, 4, 5, 7.5, 10]
-# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+[#]
+sets = ["polar"]
+case_id = "GPCP_v2.3"
+variables = ["PRECT"]
+ref_name = "GPCP_v2.3"
+reference_name = "GPCP v2.3"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_N"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 1.5, 2, 3, 4, 5, 7.5, 10]
+diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
 
 
-# [#]
-# sets = ["polar"]
-# case_id = "CRU_IPCC"
-# variables = ["TREFHT"]
-# regions = ["polar_N"]
-# ref_name = "CRU"
-# reference_name = "CRU Global Monthly Mean T"
-# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-# contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
-# diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0, 0.2, 0.5, 1, 2, 5, 10, 15]
+[#]
+sets = ["polar"]
+case_id = "CRU_IPCC"
+variables = ["TREFHT"]
+regions = ["polar_N"]
+ref_name = "CRU"
+reference_name = "CRU Global Monthly Mean T"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0, 0.2, 0.5, 1, 2, 5, 10, 15]
 
 
-# [#]
-# sets = ["polar"]
-# case_id = "SST_HadISST"
-# variables = ["SST"]
-# ref_name = "HadISST"
-# reference_name = "HadISST"
-# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-# regions = ["polar_S", "polar_N"]
-# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
-# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+[#]
+sets = ["polar"]
+case_id = "SST_HadISST"
+variables = ["SST"]
+ref_name = "HadISST"
+reference_name = "HadISST"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_S", "polar_N"]
+contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
 
 
-# [#]
-# sets = ["polar"]
-# case_id = "SST_CL_HadISST"
-# variables = ["SST"]
-# ref_name = "HadISST_CL"
-# reference_name = "HadISST (Climatology)"
-# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-# regions = ["polar_S", "polar_N"]
-# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
-# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+[#]
+sets = ["polar"]
+case_id = "SST_CL_HadISST"
+variables = ["SST"]
+ref_name = "HadISST_CL"
+reference_name = "HadISST (Climatology)"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_S", "polar_N"]
+contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
 
 
-# [#]
-# sets = ["polar"]
-# case_id = "SST_PI_HadISST"
-# variables = ["SST"]
-# ref_name = "HadISST_PI"
-# reference_name = "HadISST (Pre-Indust)"
-# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-# regions = ["polar_S", "polar_N"]
-# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
-# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+[#]
+sets = ["polar"]
+case_id = "SST_PI_HadISST"
+variables = ["SST"]
+ref_name = "HadISST_PI"
+reference_name = "HadISST (Pre-Indust)"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_S", "polar_N"]
+contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
 
 
-# [#]
-# sets = ["polar"]
-# case_id = "SST_PD_HadISST"
-# variables = ["SST"]
-# ref_name = "HadISST_PD"
-# reference_name = "HadISST (Present Day)"
-# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-# regions = ["polar_S", "polar_N"]
-# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
-# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+[#]
+sets = ["polar"]
+case_id = "SST_PD_HadISST"
+variables = ["SST"]
+ref_name = "HadISST_PD"
+reference_name = "HadISST (Present Day)"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_S", "polar_N"]
+contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
 
 
 

--- a/auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg
+++ b/auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg
@@ -1,0 +1,1055 @@
+[#]
+sets = ["polar"]
+case_id = "GPCP_v3.2"
+variables = ["PRECT"]
+ref_name = "GPCP_v3.2"
+reference_name = "GPCP v2.2"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_S"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
+diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+[#]
+sets = ["polar"]
+case_id = "GPCP_v3.2"
+variables = ["PRECT"]
+ref_name = "GPCP_v3.2"
+reference_name = "GPCP v2.2"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_N"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 1.5, 2, 3, 4, 5, 7.5, 10]
+diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "GPCP_v2.3"
+# variables = ["PRECT"]
+# ref_name = "GPCP_v2.3"
+# reference_name = "GPCP v2.3"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# test_colormap = "WhiteBlueGreenYellowRed.rgb"
+# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+# diff_colormap = "BrBG"
+# contour_levels = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
+# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "GPCP_v2.3"
+# variables = ["PRECT"]
+# ref_name = "GPCP_v2.3"
+# reference_name = "GPCP v2.3"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# test_colormap = "WhiteBlueGreenYellowRed.rgb"
+# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+# diff_colormap = "BrBG"
+# contour_levels = [0.5, 1, 1.5, 2, 3, 4, 5, 7.5, 10]
+# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CRU_IPCC"
+# variables = ["TREFHT"]
+# regions = ["polar_N"]
+# ref_name = "CRU"
+# reference_name = "CRU Global Monthly Mean T"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+# diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0, 0.2, 0.5, 1, 2, 5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "SST_HadISST"
+# variables = ["SST"]
+# ref_name = "HadISST"
+# reference_name = "HadISST"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "SST_CL_HadISST"
+# variables = ["SST"]
+# ref_name = "HadISST_CL"
+# reference_name = "HadISST (Climatology)"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "SST_PI_HadISST"
+# variables = ["SST"]
+# ref_name = "HadISST_PI"
+# reference_name = "HadISST (Pre-Indust)"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "SST_PD_HadISST"
+# variables = ["SST"]
+# ref_name = "HadISST_PD"
+# reference_name = "HadISST (Present Day)"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [-1, 0, 1, 3, 5, 7, 9, 11, 13, 15]
+# diff_levels = [-5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5]
+
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["ALBEDO_SRF"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95]
+# diff_levels = [-0.25, -0.2, -0.15, -0.1, -0.07, -0.05, -0.02, 0.02, 0.05, 0.07, 0.1, 0.15, 0.2, 0.25]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["SWCFSRF"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [-170, -150, -135, -120, -105, -90, -75, -60, -45, -30, -15, 0, 15, 30, 45]
+# diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["LWCFSRF"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 10, 20, 30, 40, 50, 60, 70, 80]
+# diff_levels = [-35, -30, -25, -20, -15, -10, -5, -2, 2, 5, 10, 15, 20, 25, 30, 35]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FLDS"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+# diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FLDSC"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+# diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FLNS"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 10, 20, 30, 40, 50, 60, 70, 80]
+# diff_levels = [-50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FLNSC"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 20, 40, 60, 80, 100, 120, 140, 160]
+# diff_levels = [-50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FSDS"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+# diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FSDSC"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400, 450]
+# diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FSNS"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400]
+# diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "CERES-EBAF-surface-v4.1"
+# variables = ["FSNSC"]
+# ref_name = "ceres_ebaf_surface_v4.1"
+# reference_name = "CERES-EBAF v4.1"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0, 50, 100, 150, 200, 250, 300, 350, 400]
+# diff_levels = [-75, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 75]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["LHFLX"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [-15, 0, 15, 30, 45, 60, 75, 90, 105, 120]
+# diff_levels = [-65, -55, -45, -35, -25, -15, -5, 5, 15, 25, 35, 45, 55, 65]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["TAUXY"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0., 0.01, 0.02,0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.5, 1.0]
+# diff_levels = [-0.1, -0.08, -0.06, -0.05, -0.04, -0.03, -0.02, -0.01,  0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.08, 0.1]
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["TREFHT"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# regions = ["polar_N", "polar_S"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+# diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0, 0.2, 0.5, 1, 2, 5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["PSL"]
+# ref_name = "ERA5"
+# regions = ["polar_S", "polar_N"]
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [955, 965, 975,980, 985, 990, 995, 1000, 1005, 1010, 1015, 1020, 1025, 1035]
+# diff_levels = [ -16, -12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12, 16]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["PRECT"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# test_colormap = "WhiteBlueGreenYellowRed.rgb"
+# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+# diff_colormap = "BrBG"
+# contour_levels = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
+# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["PRECT"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# test_colormap = "WhiteBlueGreenYellowRed.rgb"
+# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+# diff_colormap = "BrBG"
+# contour_levels = [0.5, 1, 1.5, 2, 3, 4, 5, 7.5, 10]
+# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["TMQ"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [0, 1, 2, 4, 6, 8, 12, 14, 16, 18, 20, 22]
+# diff_levels = [-5, -4, -3, -2, -1, 1, 2, 3, 4, 5]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["U"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [850.0]
+# test_colormap = "PiYG_r"
+# reference_colormap = "PiYG_r"
+# contour_levels = [-20, -15, -10, -8, -5, -3, -1, 1, 3, 5, 8, 10, 15, 20]
+# diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["U"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [200.0]
+# test_colormap = "PiYG_r"
+# reference_colormap = "PiYG_r"
+# contour_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+# diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["Z3"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [500.0]
+# contour_levels = [48, 49, 50, 51, 52, 53, 54, 55, 56]
+# diff_levels = [-1.8, -1.4, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.4, 1.8]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["T"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_S"]
+# plevs = [850.0]
+# contour_levels = [240, 244, 248, 252, 256, 260, 264, 268, 272]
+# diff_levels = [-15, -10, -7.5, -5, -2.5, -1, 1, 2.5, 5, 7.5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["T"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_N"]
+# plevs = [850.0]
+# contour_levels = [256, 258, 260, 262, 264, 268, 270, 272, 274, 276]
+# diff_levels = [-15, -10, -7.5, -5, -2.5, -1, 1, 2.5, 5, 7.5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["T"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [850.0]
+# contour_levels = [230, 240, 250, 260, 270, 280, 290, 300, 310]
+# diff_levels = [-15, -10, -7.5, -5, -2.5, -1, 1, 2.5, 5, 7.5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["T"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_S"]
+# plevs = [200.0]
+# contour_levels = [210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220]
+# diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["T"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_N"]
+# plevs = [200.0]
+# contour_levels = [215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225]
+# diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "ERA5"
+# variables = ["T"]
+# ref_name = "ERA5"
+# reference_name = "ERA5 Reanalysis"
+# seasons = ["DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [200.0]
+# contour_levels = [200, 205, 210, 215, 220, 225, 230, 235, 240]
+# diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["LHFLX"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [-15, 0, 15, 30, 45, 60, 75, 90, 105, 120]
+# diff_levels = [-65, -55, -45, -35, -25, -15, -5, 5, 15, 25, 35, 45, 55, 65]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["PRECT"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# test_colormap = "WhiteBlueGreenYellowRed.rgb"
+# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+# diff_colormap = "BrBG"
+# contour_levels = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
+# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["PRECT"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# test_colormap = "WhiteBlueGreenYellowRed.rgb"
+# reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+# diff_colormap = "BrBG"
+# contour_levels = [0.5, 1, 1.5, 2, 3, 4, 5, 7.5, 10]
+# diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["TMQ"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [0, 1, 2, 4, 6, 8, 12, 14, 16, 18, 20, 22]
+# diff_levels = [-5, -4, -3, -2, -1, 1, 2, 3, 4, 5]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["U"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [850.0]
+# test_colormap = "PiYG_r"
+# reference_colormap = "PiYG_r"
+# contour_levels = [-20, -15, -10, -8, -5, -3, -1, 1, 3, 5, 8, 10, 15, 20]
+# diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["U"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [200.0]
+# test_colormap = "PiYG_r"
+# reference_colormap = "PiYG_r"
+# contour_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+# diff_levels = [-8, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 8]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["Z3"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [500.0]
+# contour_levels = [48, 49, 50, 51, 52, 53, 54, 55, 56]
+# diff_levels = [-1.8, -1.4, -1.0, -0.6, -0.2, 0.2, 0.6, 1.0, 1.4, 1.8]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["T"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_S"]
+# plevs = [850.0]
+# contour_levels = [240, 244, 248, 252, 256, 260, 264, 268, 272]
+# diff_levels = [-15, -10, -7.5, -5, -2.5, -1, 1, 2.5, 5, 7.5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["T"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_N"]
+# plevs = [850.0]
+# contour_levels = [256, 258, 260, 262, 264, 268, 270, 272, 274, 276]
+# diff_levels = [-15, -10, -7.5, -5, -2.5, -1, 1, 2.5, 5, 7.5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["T"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [850.0]
+# contour_levels = [230, 240, 250, 260, 270, 280, 290, 300, 310]
+# diff_levels = [-15, -10, -7.5, -5, -2.5, -1, 1, 2.5, 5, 7.5, 10, 15]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["T"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_S"]
+# plevs = [200.0]
+# contour_levels = [210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220]
+# diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["T"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["ANN"]
+# regions = ["polar_N"]
+# plevs = [200.0]
+# contour_levels = [215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225]
+# diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["T"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# seasons = ["DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# plevs = [200.0]
+# contour_levels = [200, 205, 210, 215, 220, 225, 230, 235, 240]
+# diff_levels = [-10, -7.5, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 7.5, 10]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["TAUXY"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [0., 0.01, 0.02,0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.5, 1.0]
+# diff_levels = [-0.1, -0.08, -0.06, -0.05, -0.04, -0.03, -0.02, -0.01,  0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.08, 0.1]
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["TREFHT"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# regions = ["polar_N", "polar_S"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+# diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0, 0.2, 0.5, 1, 2, 5, 10, 15]
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["TREFMNAV"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# regions = ["polar_N", "polar_S"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+# diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0, 0.2, 0.5, 1, 2, 5, 10, 15]
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["TREFMXAV"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# regions = ["polar_N", "polar_S"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+# diff_levels = [-15, -10, -5, -2, -1, -0.5, -0.2, 0, 0.2, 0.5, 1, 2, 5, 10, 15]
+
+# [#]
+# sets = ["polar"]
+# case_id = "MERRA2"
+# variables = ["PSL"]
+# ref_name = "MERRA2"
+# reference_name = "MERRA2 Reanalysis"
+# regions = ["polar_S", "polar_N"]
+# seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+# contour_levels = [955, 965, 975,980, 985, 990, 995, 1000, 1005, 1010, 1015, 1020, 1025, 1035]
+# diff_levels = [ -16, -12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12, 16]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_bc_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 50, 100, 200, 300, 400, 500, 600, 700]
+# diff_levels = [-700, -600, -500, -400, -300, -200, -100, -50, -25, -10, 10, 25, 50, 100, 200, 300, 400, 500, 600, 700]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_bc_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 0.5, 1, 2, 3, 4, 5]
+# diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_ncl_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N", "polar_S"]
+# contour_levels = [0, 100, 500, 1000, 2000, 5000, 10000, 15000, 20000]
+# diff_levels = [-800, -600, -500, -400, -300, -200, -100, -50, -25, -10, 10, 25, 50, 100, 200, 300, 400, 500, 600, 800]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_so4_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 50, 100, 200, 400, 600, 800, 1000, 1200, 1400, 1600]
+# diff_levels = [-1200, -1000, -800, -600, -400, -200, -100, -50, -25, -10, 10, 25, 50, 100, 200, 400, 600, 800, 1000, 1200]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_so4_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 10, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200]
+# diff_levels = [-20, -10, -5, -2, -1, 1, 2, 5, 10, 20]
+
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_dst_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N", "polar_S"]
+# contour_levels = [0, 100, 500, 1000, 2000, 5000, 10000, 15000, 20000, 30000]
+# diff_levels = [-6000, -5000, -4000, -3000, -2000, -1000, -500, -100, -50, -25, -10, 10, 25, 50, 100, 500, 1000, 2000, 3000, 4000, 5000, 6000]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_pom_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 50, 100, 200, 400, 600, 800, 1000, 1200, 1400, 1600, 1800, 2000, 2400]
+# diff_levels = [-1500, -1200, -1000, -800, -600, -400, -200, -100, -50, -25, -10, 10, 25, 50, 100, 200, 400, 600, 800, 1000, 1200, 1500]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_pom_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+# diff_levels = [-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_mom_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 1, 2, 4, 6, 8, 10, 12, 14, 20, 30, 40, 50]
+# diff_levels = [-25, -20, -15, -10, -5, -2, -1, 1, 2, 5, 10, 15, 20, 25]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_mom_srf"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 25, 50, 100, 150, 200, 300, 400, 500]
+# diff_levels = [-40, -30, -20, -10, -5, -2, -1, 1, 2, 5, 10, 20, 30, 40]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_bc_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 0.1, 0.2, 0.5, 1, 2, 3, 3.5]
+# diff_levels = [-3, -2, -1, -0.5, -0.2, -0.1, -0.05, -0.02, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 3]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_ncl_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 100, 200, 500, 1000, 2000, 3000, 4000, 5000, 7000]
+# diff_levels = [-250, -200, -150, -100, -50, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 50, 100, 150, 200, 250]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_so4_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 1, 2, 5, 10, 20, 30, 40, 50, 100, 150]
+# diff_levels = [-25, -20, -15, -10, -5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5, 10, 15, 20, 25]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_dst_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 10, 20, 50, 100, 200, 300, 400, 500, 700, 1000]
+# diff_levels = [-100, -80, -60, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 60, 80, 100]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_pom_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 0.5, 1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+# diff_levels = [-10, -7, -5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5, 7, 10]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_soa_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+# diff_levels = [-40, -30, -20, -10, -5, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 5, 10, 20, 30, 40]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_mom_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 0.5, 1, 2, 4, 6, 8, 10, 20, 40, 60, 80]
+# diff_levels = [-8, -6, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 6, 8]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_bc_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 0.1, 0.2, 0.5, 1, 2, 4, 6, 8, 10, 12, 15]
+# diff_levels = [-10, -8, -6, -4, -3, -2, -1, -0.5, -0.2, 0.2, 0.5, 1, 2, 3, 4, 6, 8, 10]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_ncl_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 5, 10, 20, 40, 60, 80, 100, 150, 200, 250, 300, 350]
+# diff_levels = [-30, -25, -20, -15, -10, -8, -6, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 6, 8, 10, 15, 20, 25, 30]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_so4_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 10, 20, 40, 60, 80, 100, 150, 200, 250, 300]
+# diff_levels = [-150, -100, -80, -60, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 60, 80, 100, 150]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_dst_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 10, 20, 40, 60, 80, 100, 150, 200, 300, 400, 500, 600, 800, 1000, 1200]
+# diff_levels = [-200, -150, -100, -80, -60, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 60, 80, 100, 150, 200]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_pom_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 2, 4, 6, 8, 10, 20, 30, 40, 50, 60, 80, 100]
+# diff_levels = [-50, -40, -30, -20, -10, -5, -2, -1, -0.5, 0.5, 1, 2, 5, 10, 20, 30, 40, 50]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_soa_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 10, 20, 40, 60, 80, 100, 150, 200, 250, 300, 350]
+# diff_levels = [-150, -100, -80, -60, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 60, 80, 100, 150]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_mom_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S"]
+# contour_levels = [0, 0.1, 0.2, 0.5, 1, 2, 4, 6, 8, 10]
+# diff_levels = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, -0.02, -0.01, -0.005, -0.002, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_bc_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 10, 20, 40, 60, 80, 100, 150]
+# diff_levels = [-100, -80, -60, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 60, 80, 100]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_ncl_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 100, 200, 400, 600, 800, 1000, 1500, 2000, 2500, 3000, 4000, 5000]
+# diff_levels = [-250, -200, -150, -100, -80, -60, -40, -30, -20, -10, -5, -2, 2, 5, 10, 20, 30, 40, 60, 80, 100, 150, 200, 250]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_so4_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 20, 40, 60, 80, 100, 150, 200, 300, 400, 500, 600, 700, 800, 1000]
+# diff_levels = [-900, -700, -500, -400, -300, -200, -150, -100, -80, -60, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 60, 80, 100, 150, 200, 300, 400, 500, 700, 800, 900]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_dst_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 1000, 2000, 4000, 6000, 8000, 10000, 15000, 20000]
+# diff_levels = [-2000, -1500, -1000, -800, -600, -400, -300, -200, -150, -100, -80, -60, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 60, 80, 100, 150, 200, 300, 400, 600, 800, 1000, 1500, 2000]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_pom_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 50, 100, 200, 300, 400, 600, 800, 1000, 1200]
+# diff_levels = [-300, -200, -150, -100, -80, -60, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 60, 80, 100, 150, 200, 300]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_soa_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 100, 200, 400, 600, 800, 1000, 1500, 2000, 2500, 3000, 3600]
+# diff_levels = [-700, -500, -400, -300, -200, -150, -100, -80, -60, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 60, 80, 100, 150, 200, 300, 400, 500, 700]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_mom_850"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 2, 4, 6, 8, 10, 20, 30, 40, 50, 60, 80, 100]
+# diff_levels = [-10, -8, -6, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 6, 8, 10]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_bc_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 1, 2, 4, 6, 8, 10, 20, 30, 40, 50]
+# diff_levels = [-50, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 50]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_ncl_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 5, 10, 20, 30, 40, 50, 60, 80, 100, 120, 150]
+# diff_levels = [-30, -20, -15, -10, -8, -6, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 6, 8, 10, 15, 20, 30]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_so4_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 50, 100, 200, 300, 400, 500, 600, 700]
+# diff_levels = [-600, -500, -400, -300, -200, -150, -100, -80, -60, -40, -30, -20, -10, 10, 20, 30, 40, 60, 80, 100, 150, 200, 300, 400, 500, 600]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_dst_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 500, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 9000]
+# diff_levels = [-1000, -700, -500, -400, -300, -200, -150, -100, -80, -60, -40, -30, -20, -10, 10, 20, 30, 40, 60, 80, 100, 150, 200, 300, 400, 500, 700, 1000]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_pom_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 10, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200]
+# diff_levels = [-120, -100, -80, -60, -40, -30, -20, -10, -5, 5, 10, 20, 30, 40, 60, 80, 100, 120]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_soa_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 50, 100, 200, 300, 400, 500, 600, 700, 1000]
+# diff_levels = [-400, -300, -200, -150, -100, -80, -60, -40, -30, -20, -10, 10, 20, 30, 40, 60, 80, 100, 150, 200, 300, 400]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["Mass_mom_330"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_N"]
+# contour_levels = [0, 0.1, 0.2, 0.4, 0.6, 0.8, 1, 2, 3, 4]
+# diff_levels = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["AODDUST", "AODBC", "AODSS", "AODPOM", "AODMOM", "AODSOA", "AODSO4", "AODSO4_STR", "AODSO4_TRO"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [0, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12]
+# diff_levels = [-0.02, -0.01, -0.005, -0.0025, -0.0010, -0.0005, 0.0005, 0.0010, 0.0025, 0.005, 0.01, 0.02]
+
+# [#]
+# sets = ["polar"]
+# case_id = "aero-no-ref-data"
+# variables = ["AODVIS"]
+# seasons = ["ANN","DJF", "MAM", "JJA", "SON"]
+# regions = ["polar_S", "polar_N"]
+# contour_levels = [0, 0.03, 0.06, 0.09, 0.12, 0.15, 0.18]
+# diff_levels = [-0.05, -0.04, -0.03, -0.02, -0.01, -0.005, -0.0025, 0.0025, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05]

--- a/auxiliary_tools/cdat_regression_testing/909-prov-log/run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/909-prov-log/run_script.py
@@ -3,7 +3,8 @@ from auxiliary_tools.cdat_regression_testing.base_run_script import run_set
 SET_NAME = "polar"
 SET_DIR = "909-prov-log"
 
-CFG_PATH: str | None = "/global/u2/v/vo13/E3SM-Project/e3sm_diags/auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg"
+# CFG_PATH: str | None = "/global/u2/v/vo13/E3SM-Project/e3sm_diags/auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg"
+CFG_PATH = "auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg"
 MULTIPROCESSING = True
 
 # %%

--- a/auxiliary_tools/cdat_regression_testing/909-prov-log/run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/909-prov-log/run_script.py
@@ -1,0 +1,10 @@
+from auxiliary_tools.cdat_regression_testing.base_run_script import run_set
+
+SET_NAME = "polar"
+SET_DIR = "909-prov-log"
+
+CFG_PATH: str | None = "/global/u2/v/vo13/E3SM-Project/e3sm_diags/auxiliary_tools/cdat_regression_testing/909-prov-log/run.cfg"
+MULTIPROCESSING = True
+
+# %%
+run_set(SET_NAME, SET_DIR, CFG_PATH, MULTIPROCESSING)

--- a/auxiliary_tools/cdat_regression_testing/base_run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/base_run_script.py
@@ -27,8 +27,25 @@ from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import (
 )
 from e3sm_diags.run import runner
 
+# Get the current machine's configuration info.
+MACHINE_INFO = MachineInfo()
+MACHINE = MACHINE_INFO.machine
+
+if MACHINE not in [
+    "anvil",
+    "chrysalis",
+    "compy",
+    "pm-cpu",
+    "cori-haswell",
+    "cori-knl",
+]:
+    raise ValueError(f"e3sm_diags is not supported on this machine ({MACHINE}).")
+
 # The location where results will be stored based on your branch changes.
-BASE_RESULTS_DIR = "/global/cfs/cdirs/e3sm/www/cdat-migration-fy24/"
+if MACHINE in ["chrysalis", "anvil"]:
+    BASE_RESULTS_DIR = "/lcrc/group/e3sm/public_html/cdat-migration-fy24/"
+elif MACHINE in ["cori-haswell", "cori-knl", "pm-cpu"]:
+    BASE_RESULTS_DIR = "/global/cfs/cdirs/e3sm/www/cdat-migration-fy24/"
 
 
 class MachinePaths(TypedDict):
@@ -200,30 +217,16 @@ def _get_machine_paths() -> MachinePaths:
         A dictionary of paths on the machine, with the key being the path type
         and the value being the absolute path string.
     """
-    # Get the current machine's configuration info.
-    machine_info = MachineInfo()
-    machine = machine_info.machine
-
-    if machine not in [
-        "anvil",
-        "chrysalis",
-        "compy",
-        "pm-cpu",
-        "cori-haswell",
-        "cori-knl",
-    ]:
-        raise ValueError(f"e3sm_diags is not supported on this machine ({machine}).")
-
     # Path to the HTML outputs for the current user.
-    web_portal_base_path = machine_info.config.get("web_portal", "base_path")
-    html_path = f"{web_portal_base_path}/{machine_info.username}/"
+    web_portal_base_path = MACHINE_INFO.config.get("web_portal", "base_path")
+    html_path = f"{web_portal_base_path}/{MACHINE_INFO.username}/"
 
     # Path to the reference data directory.
-    diags_base_path = machine_info.diagnostics_base
+    diags_base_path = MACHINE_INFO.diagnostics_base
     ref_data_dir = f"{diags_base_path}/observations/Atm"
 
     # Paths to the test data directories.
-    test_data_dir, test_data_dir2 = _get_test_data_dirs(machine)
+    test_data_dir, test_data_dir2 = _get_test_data_dirs(MACHINE)
 
     # Construct the paths required by e3sm_diags using the base paths above.
     machine_paths: MachinePaths = {

--- a/e3sm_diags/driver/utils/dataset_xr.py
+++ b/e3sm_diags/driver/utils/dataset_xr.py
@@ -422,7 +422,7 @@ class Dataset:
             using other datasets.
         """
         filepath = self._get_climo_filepath(season)
-        logger.info(f"Opening climatology file: {filepath}")
+        logger.debug(f"Opening climatology file: {filepath}")
 
         ds = self._open_climo_dataset(filepath)
 
@@ -711,7 +711,8 @@ class Dataset:
             src_var_keys = list(matching_target_var_map.keys())[0]
 
             logger.info(
-                f"Deriving the climatology variable using the source variables: {src_var_keys}"
+                f"Deriving the {self.data_type} climatology variable using the source "
+                f"variables: {src_var_keys}"
             )
             ds_sub = squeeze_time_dim(ds)
             ds_sub = self._subset_vars_and_load(ds_sub, list(src_var_keys))
@@ -1032,7 +1033,7 @@ class Dataset:
             The dataset for the variable.
         """
         filepaths = self._get_time_series_filepaths(self.root_path, var)
-        logger.info(f"Opening time series files: {filepaths}")
+        logger.debug(f"Opening time series files: {filepaths}")
 
         if filepaths is None:
             raise IOError(

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -11,13 +11,13 @@ import dask
 import dask.bag as db
 
 import e3sm_diags
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import get_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.parser import SET_TO_PARSER
 from e3sm_diags.parser.core_parser import CoreParser
 from e3sm_diags.viewer.main import create_viewer
 
-logger = custom_logger(__name__)
+logger = get_logger()
 
 
 def get_default_diags_path(set_name, run_type, print_path=True):

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -11,13 +11,13 @@ import dask
 import dask.bag as db
 
 import e3sm_diags
-from e3sm_diags.logger import get_logger
+from e3sm_diags.logger import custom_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.parser import SET_TO_PARSER
 from e3sm_diags.parser.core_parser import CoreParser
 from e3sm_diags.viewer.main import create_viewer
 
-logger = get_logger()
+logger = custom_logger(__name__)
 
 
 def get_default_diags_path(set_name, run_type, print_path=True):

--- a/e3sm_diags/logger.py
+++ b/e3sm_diags/logger.py
@@ -60,7 +60,7 @@ def custom_logger(name: str, propagate: bool = True) -> logging.Logger:
     >>> logger.critical("")
     """
     log_format = "%(asctime)s [%(levelname)s]: %(filename)s(%(funcName)s:%(lineno)s) >> %(message)s"
-    log_filemode = "w"
+    log_filemode = "a"
 
     # Setup
     logging.basicConfig(
@@ -75,19 +75,22 @@ def custom_logger(name: str, propagate: bool = True) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.propagate = propagate
 
-    # Console output
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.INFO)
-    console_handler.setFormatter(logging.Formatter(log_format))
-    logger.addHandler(console_handler)
+    if not logger.handlers:
+        # Console output
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.INFO)
+        console_handler.setFormatter(logging.Formatter(log_format))
+        logger.addHandler(console_handler)
 
     return logger
 
 
-logger = custom_logger(__name__)
+def get_logger():
+    """Get the custom logger for multiprocessing."""
+    return custom_logger(__name__)
 
 
-def move_log_to_prov_dir(results_dir: str):
+def move_log_to_prov_dir(results_dir: str, logger: logging.Logger):
     """Moves the e3sm diags log file to the provenance directory.
 
     This function should be called at the end of the diagnostic run to capture

--- a/e3sm_diags/run.py
+++ b/e3sm_diags/run.py
@@ -4,7 +4,7 @@ from typing import List, Union
 
 import e3sm_diags  # noqa: F401
 from e3sm_diags.e3sm_diags_driver import get_default_diags_path, main
-from e3sm_diags.logger import custom_logger, move_log_to_prov_dir
+from e3sm_diags.logger import get_logger, move_log_to_prov_dir
 from e3sm_diags.parameter import SET_TO_PARAMETERS
 from e3sm_diags.parameter.core_parameter import DEFAULT_SETS, CoreParameter
 from e3sm_diags.parser.core_parser import CoreParser
@@ -19,7 +19,7 @@ class Run:
 
     def __init__(self):
         self.parser = CoreParser()
-        self.logger = custom_logger(__name__)
+        self.logger = get_logger()
 
         # The list of sets to run based on diagnostic parameters.
         self.sets_to_run = []
@@ -92,7 +92,7 @@ class Run:
 
         # param_results might be None because the run(s) failed, so move
         # the log using the `params[0].results_dir` instead.
-        move_log_to_prov_dir(params[0].results_dir)
+        move_log_to_prov_dir(params[0].results_dir, self.logger)
 
         return params_results
 
@@ -369,9 +369,6 @@ class Run:
                     attr_value = getattr(parent, attr)
                     setattr(parameters[i], attr, attr_value)
 
-            self.logger.info(
-                list(set(nondefault_param_parent) - set(nondefault_param_child))
-            )
             for attr in list(
                 set(nondefault_param_parent) - set(nondefault_param_child)
             ):

--- a/e3sm_diags/run.py
+++ b/e3sm_diags/run.py
@@ -9,8 +9,6 @@ from e3sm_diags.parameter import SET_TO_PARAMETERS
 from e3sm_diags.parameter.core_parameter import DEFAULT_SETS, CoreParameter
 from e3sm_diags.parser.core_parser import CoreParser
 
-logger = custom_logger(__name__)
-
 
 class Run:
     """
@@ -21,6 +19,7 @@ class Run:
 
     def __init__(self):
         self.parser = CoreParser()
+        self.logger = custom_logger(__name__)
 
         # The list of sets to run based on diagnostic parameters.
         self.sets_to_run = []
@@ -76,6 +75,7 @@ class Run:
         RuntimeError
             If a diagnostic run using a parameter fails for any reason.
         """
+
         params = self.get_run_parameters(parameters, use_cfg)
         params_results = None
 
@@ -88,7 +88,7 @@ class Run:
         try:
             params_results = main(params)
         except Exception:
-            logger.exception("Error traceback:", exc_info=True)
+            self.logger.exception("Error traceback:", exc_info=True)
 
         # param_results might be None because the run(s) failed, so move
         # the log using the `params[0].results_dir` instead.
@@ -369,7 +369,7 @@ class Run:
                     attr_value = getattr(parent, attr)
                     setattr(parameters[i], attr, attr_value)
 
-            logger.info(
+            self.logger.info(
                 list(set(nondefault_param_parent) - set(nondefault_param_child))
             )
             for attr in list(


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

1. **Log File Handling**:
   - Save log files directly to the `prov` directory (`parameter.results_dir`) upon calling `run_diags()` instead of moving them at the end (Closes #848).
   - Support one log file per simulation using a for-loop (fixed by above change)

2. **Diagnostic Run Information**:
   - Add a feature to print diagnostic run details at the top of the log file.
     - Include readable formatting displaying timestamp, git branch, commit or version info, and log file path.

3. **Logger Fixes and Improvements**:
   - Make root logger the central source of logger handlers (console and log file) and remove handlers from child loggers.
     - Prevent repeated messages due to duplicate StreamHandlers on child loggers.
   - Fix an issue where the logger was not saving complete console output to the log file (Closes #909).
     - Root cause: Logger outputs being overwritten.
   - Ensure consistent outputs between the console and log files 
     - Set log file mode to `w` for both outputs. 


## Test file used

```
conda env create -f conda-env/dev.yml -n e3sm_diags_dev_848
conda activate e3sm_diags_dev_848

make install
python auxiliary_tools/cdat_regression_testing/909-prov-log/run_script.py 
```

### Results: Log now prints all output, log + console outputs align, and no repeated messages. Works with serial and multiprocessing, and multiple simulations in a for-loop. 

Example log file output (https://web.lcrc.anl.gov/public/e3sm/cdat-migration-fy24/909-prov-log/prov/e3sm_diags_run.log)
```
2025-01-27 14:53:26,245 [INFO]: run.py(_log_diagnostic_run_info:152) >> 
================================================================================
E3SM Diagnostics Run
--------------------
Timestamp: 2025-01-27 14:53:26
Version Info: branch bug/848-log with commit a96b1de892aa8a013288c3de9a11471db647c25b
Log Filepath: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/e3sm_diags_run.log
================================================================================

2025-01-27 14:53:31,866 [INFO]: e3sm_diags_driver.py(_save_env_yml:58) >> Saved environment yml file to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/environment.yml
2025-01-27 14:53:31,867 [INFO]: e3sm_diags_driver.py(_save_parameter_files:69) >> Saved command used to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/cmd_used.txt
2025-01-27 14:53:31,872 [INFO]: e3sm_diags_driver.py(_save_parameter_files:99) >> Saved cfg file to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/run.cfg
2025-01-27 14:53:31,874 [INFO]: e3sm_diags_driver.py(_save_python_script:133) >> Saved Python script to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/ipykernel_launcher.py
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: TREFHT
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:36,876 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:39,266 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:39,271 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:39,276 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TREFHT',)
2025-01-27 14:53:39,278 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:39,446 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:39,457 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:39,475 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('TREFHT_LAND',)
2025-01-27 14:53:39,476 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:39,476 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:39,490 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:39,494 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:39,495 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:39,502 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:39,519 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:39,705 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:39,722 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:40,751 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S_test.nc
2025-01-27 14:53:40,757 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S_ref.nc
2025-01-27 14:53:40,762 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S_diff.nc
2025-01-27 14:53:40,763 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S.json
2025-01-27 14:53:40,792 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N_test.nc
2025-01-27 14:53:40,800 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N_ref.nc
2025-01-27 14:53:40,807 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N_diff.nc
2025-01-27 14:53:40,809 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N.json
2025-01-27 14:53:41,168 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N_test.nc
2025-01-27 14:53:41,174 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N_ref.nc
2025-01-27 14:53:41,179 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N_diff.nc
2025-01-27 14:53:41,181 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N.json
2025-01-27 14:53:41,442 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S_test.nc
2025-01-27 14:53:41,448 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S_ref.nc
2025-01-27 14:53:41,454 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S_diff.nc
2025-01-27 14:53:41,455 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S.json
2025-01-27 14:53:41,862 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N_test.nc
2025-01-27 14:53:41,869 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N_ref.nc
2025-01-27 14:53:41,874 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N_diff.nc
2025-01-27 14:53:41,876 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N.json
2025-01-27 14:53:42,718 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N.png
2025-01-27 14:53:42,720 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:42,824 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S.png
2025-01-27 14:53:42,826 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:43,980 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N.png
2025-01-27 14:53:43,981 [INFO]: polar_driver.py(run_diag:36) >> Variable: TREFHT
2025-01-27 14:53:44,397 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:45,420 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S.png
2025-01-27 14:53:45,422 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:45,443 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:45,625 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:45,647 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:45,664 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:45,894 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:45,911 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:46,434 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TREFHT',)
2025-01-27 14:53:46,583 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:46,600 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('TREFHT_LAND',)
2025-01-27 14:53:46,614 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:46,720 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S_test.nc
2025-01-27 14:53:46,726 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S_ref.nc
2025-01-27 14:53:46,732 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S_diff.nc
2025-01-27 14:53:46,733 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N.png
2025-01-27 14:53:46,734 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S.json
2025-01-27 14:53:46,735 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:47,483 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N_test.nc
2025-01-27 14:53:47,492 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N_ref.nc
2025-01-27 14:53:47,498 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N_diff.nc
2025-01-27 14:53:47,500 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N.json
2025-01-27 14:53:47,724 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N_test.nc
2025-01-27 14:53:47,730 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N_ref.nc
2025-01-27 14:53:47,735 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N_diff.nc
2025-01-27 14:53:47,736 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N.json
2025-01-27 14:53:47,843 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:48,047 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:48,064 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:49,074 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S.png
2025-01-27 14:53:49,076 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:49,437 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:49,667 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:49,684 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:49,727 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S_test.nc
2025-01-27 14:53:49,733 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S_ref.nc
2025-01-27 14:53:49,739 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S_diff.nc
2025-01-27 14:53:49,740 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S.json
2025-01-27 14:53:50,666 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N.png
2025-01-27 14:53:50,667 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:50,775 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N_test.nc
2025-01-27 14:53:50,782 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N_ref.nc
2025-01-27 14:53:50,787 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N_diff.nc
2025-01-27 14:53:50,789 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N.json
2025-01-27 14:53:51,096 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:51,590 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:51,722 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N.png
2025-01-27 14:53:51,724 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:51,742 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'JJA' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:53:51,786 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:52,035 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N.png
2025-01-27 14:53:52,037 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:52,569 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S.png
2025-01-27 14:53:53,121 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:53,271 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:53,298 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:53:53,315 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:53,955 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N_test.nc
2025-01-27 14:53:53,967 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N_ref.nc
2025-01-27 14:53:53,973 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N_diff.nc
2025-01-27 14:53:53,974 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N.json
2025-01-27 14:53:54,316 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:54,453 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:54,463 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'JJA' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:53:54,468 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:54,543 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:54,622 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:54,639 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:54,776 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:54,791 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:55,408 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S_test.nc
2025-01-27 14:53:55,414 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S_ref.nc
2025-01-27 14:53:55,415 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N.png
2025-01-27 14:53:55,417 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:55,420 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S_diff.nc
2025-01-27 14:53:55,421 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S.json
2025-01-27 14:53:55,855 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N_test.nc
2025-01-27 14:53:55,861 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N_ref.nc
2025-01-27 14:53:55,867 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N_diff.nc
2025-01-27 14:53:55,868 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N.json
2025-01-27 14:53:55,983 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:56,977 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N.png
2025-01-27 14:53:56,978 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:57,221 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:57,367 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'ANN' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:53:57,370 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:57,621 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S.png
2025-01-27 14:53:57,623 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:58,018 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:58,165 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:58,191 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:53:58,209 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:58,839 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N_test.nc
2025-01-27 14:53:58,850 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N_ref.nc
2025-01-27 14:53:58,856 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N_diff.nc
2025-01-27 14:53:58,858 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N.json
2025-01-27 14:53:59,404 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:59,575 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:59,591 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:59,925 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:00,073 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'ANN' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:54:00,095 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:00,269 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:00,285 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:54:00,305 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N.png
2025-01-27 14:54:00,307 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:54:00,359 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S_test.nc
2025-01-27 14:54:00,365 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S_ref.nc
2025-01-27 14:54:00,373 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S_diff.nc
2025-01-27 14:54:00,374 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S.json
2025-01-27 14:54:00,823 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:01,208 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N_test.nc
2025-01-27 14:54:01,214 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N_ref.nc
2025-01-27 14:54:01,220 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N_diff.nc
2025-01-27 14:54:01,221 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N.json
2025-01-27 14:54:01,931 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S.png
2025-01-27 14:54:01,933 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:02,494 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N.png
2025-01-27 14:54:02,496 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:03,024 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:54:03,171 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:03,200 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:54:03,217 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:03,807 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S_test.nc
2025-01-27 14:54:03,820 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S_ref.nc
2025-01-27 14:54:03,826 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S_diff.nc
2025-01-27 14:54:03,827 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S.json
2025-01-27 14:54:04,353 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:04,590 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:04,606 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:54:05,072 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:05,242 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:05,258 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:05,531 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N_test.nc
2025-01-27 14:54:05,537 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N_ref.nc
2025-01-27 14:54:05,543 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N_diff.nc
2025-01-27 14:54:05,545 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N.json
2025-01-27 14:54:06,012 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S.png
2025-01-27 14:54:06,013 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:54:06,023 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S_test.nc
2025-01-27 14:54:06,029 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S_ref.nc
2025-01-27 14:54:06,034 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S_diff.nc
2025-01-27 14:54:06,036 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S.json
2025-01-27 14:54:06,420 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:06,785 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N.png
2025-01-27 14:54:06,787 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:07,453 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S.png
2025-01-27 14:54:07,455 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:08,467 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:54:08,614 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:08,641 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:54:08,659 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:09,247 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S_test.nc
2025-01-27 14:54:09,259 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S_ref.nc
2025-01-27 14:54:09,265 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S_diff.nc
2025-01-27 14:54:09,266 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S.json
2025-01-27 14:54:09,327 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:09,495 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:09,511 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:10,016 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:10,184 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:10,201 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:54:10,273 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S_test.nc
2025-01-27 14:54:10,281 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S_ref.nc
2025-01-27 14:54:10,286 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S_diff.nc
2025-01-27 14:54:10,288 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S.json
2025-01-27 14:54:10,568 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S.png
2025-01-27 14:54:11,130 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N_test.nc
2025-01-27 14:54:11,136 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N_ref.nc
2025-01-27 14:54:11,142 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N_diff.nc
2025-01-27 14:54:11,144 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N.json
2025-01-27 14:54:11,708 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S.png
2025-01-27 14:54:12,313 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N.png
2025-01-27 14:54:12,361 [INFO]: main.py(create_viewer:132) >> polar /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/viewer
2025-01-27 14:54:12,503 [INFO]: main.py(create_viewer:135) >> ('Polar contour maps', 'polar/index.html')
2025-01-27 14:54:12,507 [INFO]: e3sm_diags_driver.py(main:396) >> Viewer HTML generated at /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/viewer/index.html
```

Example console output (matches log file)
```
2025-01-27 14:53:26,245 [INFO]: run.py(_log_diagnostic_run_info:152) >> 
================================================================================
E3SM Diagnostics Run
--------------------
Timestamp: 2025-01-27 14:53:26
Version Info: branch bug/848-log with commit a96b1de892aa8a013288c3de9a11471db647c25b
Log Filepath: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/e3sm_diags_run.log
================================================================================

2025-01-27 14:53:31,866 [INFO]: e3sm_diags_driver.py(_save_env_yml:58) >> Saved environment yml file to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/environment.yml
2025-01-27 14:53:31,867 [INFO]: e3sm_diags_driver.py(_save_parameter_files:69) >> Saved command used to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/cmd_used.txt
2025-01-27 14:53:31,872 [INFO]: e3sm_diags_driver.py(_save_parameter_files:99) >> Saved cfg file to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/run.cfg
2025-01-27 14:53:31,874 [INFO]: e3sm_diags_driver.py(_save_python_script:133) >> Saved Python script to: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/prov/ipykernel_launcher.py
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:36,192 [INFO]: polar_driver.py(run_diag:36) >> Variable: TREFHT
2025-01-27 14:53:36,876 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:39,266 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:39,271 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:39,276 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TREFHT',)
2025-01-27 14:53:39,278 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:39,446 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:39,457 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:39,475 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('TREFHT_LAND',)
2025-01-27 14:53:39,476 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:39,476 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:39,490 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:39,494 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:39,495 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:39,502 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:39,519 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:39,705 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:39,722 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:40,751 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S_test.nc
2025-01-27 14:53:40,757 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S_ref.nc
2025-01-27 14:53:40,762 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S_diff.nc
2025-01-27 14:53:40,763 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S.json
2025-01-27 14:53:40,792 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N_test.nc
2025-01-27 14:53:40,800 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N_ref.nc
2025-01-27 14:53:40,807 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N_diff.nc
2025-01-27 14:53:40,809 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N.json
2025-01-27 14:53:41,168 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N_test.nc
2025-01-27 14:53:41,174 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N_ref.nc
2025-01-27 14:53:41,179 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N_diff.nc
2025-01-27 14:53:41,181 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N.json
2025-01-27 14:53:41,442 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S_test.nc
2025-01-27 14:53:41,448 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S_ref.nc
2025-01-27 14:53:41,454 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S_diff.nc
2025-01-27 14:53:41,455 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S.json
2025-01-27 14:53:41,862 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N_test.nc
2025-01-27 14:53:41,869 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N_ref.nc
2025-01-27 14:53:41,874 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N_diff.nc
2025-01-27 14:53:41,876 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N.json
2025-01-27 14:53:42,718 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_N.png
2025-01-27 14:53:42,720 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:42,824 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_S.png
2025-01-27 14:53:42,826 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:43,980 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-JJA-polar_N.png
2025-01-27 14:53:43,981 [INFO]: polar_driver.py(run_diag:36) >> Variable: TREFHT
2025-01-27 14:53:44,397 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:45,420 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_S.png
2025-01-27 14:53:45,422 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:45,443 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:45,625 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:45,647 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:45,664 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:45,894 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:45,911 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:46,434 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TREFHT',)
2025-01-27 14:53:46,583 [WARNING]: dataset.py(_preprocess:458) >> "No time coordinates were found in this dataset to decode. If time coordinates were expected to exist, make sure they are detectable by setting the CF 'axis' or 'standard_name' attribute (e.g., ds['time'].attrs['axis'] = 'T' or ds['time'].attrs['standard_name'] = 'time'). Afterwards, try decoding again with `xcdat.decode_time`."
2025-01-27 14:53:46,600 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('TREFHT_LAND',)
2025-01-27 14:53:46,614 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:46,720 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S_test.nc
2025-01-27 14:53:46,726 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S_ref.nc
2025-01-27 14:53:46,732 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S_diff.nc
2025-01-27 14:53:46,734 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S.json
2025-01-27 14:53:46,733 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-JJA-polar_N.png
2025-01-27 14:53:46,735 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:47,483 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N_test.nc
2025-01-27 14:53:47,492 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N_ref.nc
2025-01-27 14:53:47,498 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N_diff.nc
2025-01-27 14:53:47,500 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N.json
2025-01-27 14:53:47,724 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N_test.nc
2025-01-27 14:53:47,730 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N_ref.nc
2025-01-27 14:53:47,735 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N_diff.nc
2025-01-27 14:53:47,736 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N.json
2025-01-27 14:53:47,843 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:48,047 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sat_gauge_precip',)
2025-01-27 14:53:48,064 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:49,074 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-ANN-polar_S.png
2025-01-27 14:53:49,076 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:49,437 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:49,667 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:49,684 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:49,727 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S_test.nc
2025-01-27 14:53:49,733 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S_ref.nc
2025-01-27 14:53:49,739 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S_diff.nc
2025-01-27 14:53:49,740 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S.json
2025-01-27 14:53:50,666 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/CRU_IPCC/CRU-TREFHT-ANN-polar_N.png
2025-01-27 14:53:50,667 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:50,775 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N_test.nc
2025-01-27 14:53:50,782 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N_ref.nc
2025-01-27 14:53:50,787 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N_diff.nc
2025-01-27 14:53:50,789 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N.json
2025-01-27 14:53:51,096 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:51,590 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:51,722 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_N.png
2025-01-27 14:53:51,724 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:51,742 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'JJA' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:53:51,786 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:52,035 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_N.png
2025-01-27 14:53:52,037 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:52,569 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v3.2/GPCP_v3.2-PRECT-ANN-polar_S.png
2025-01-27 14:53:53,121 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:53,271 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:53,298 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:53:53,315 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:53,955 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N_test.nc
2025-01-27 14:53:53,967 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N_ref.nc
2025-01-27 14:53:53,973 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N_diff.nc
2025-01-27 14:53:53,974 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N.json
2025-01-27 14:53:54,316 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:54,453 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:54,463 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'JJA' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:53:54,468 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:54,543 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:54,622 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:54,639 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:54,776 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:54,791 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:55,408 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S_test.nc
2025-01-27 14:53:55,414 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S_ref.nc
2025-01-27 14:53:55,415 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_N.png
2025-01-27 14:53:55,417 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:53:55,420 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S_diff.nc
2025-01-27 14:53:55,421 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S.json
2025-01-27 14:53:55,855 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N_test.nc
2025-01-27 14:53:55,861 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N_ref.nc
2025-01-27 14:53:55,867 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N_diff.nc
2025-01-27 14:53:55,868 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N.json
2025-01-27 14:53:55,983 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:56,977 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_N.png
2025-01-27 14:53:56,978 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:57,221 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:57,367 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'ANN' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:53:57,370 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:57,621 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-JJA-polar_S.png
2025-01-27 14:53:57,623 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:53:58,018 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:53:58,165 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:53:58,191 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:53:58,209 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:53:58,839 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N_test.nc
2025-01-27 14:53:58,850 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N_ref.nc
2025-01-27 14:53:58,856 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N_diff.nc
2025-01-27 14:53:58,858 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N.json
2025-01-27 14:53:59,404 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:53:59,575 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:53:59,591 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:53:59,925 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:00,073 [ERROR]: core_parameter.py(_run_diag:343) >> Error in e3sm_diags.driver.polar_driver
Traceback (most recent call last):
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/parameter/core_parameter.py", line 340, in _run_diag
    single_result = module.run_diag(self)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/polar_driver.py", line 46, in run_diag
    ds_ref = ref_ds.get_climo_dataset(var_key, season)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 401, in get_climo_dataset
    ds = self._get_climo_dataset(season)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 424, in _get_climo_dataset
    filepath = self._get_climo_filepath(season)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/driver/utils/dataset_xr.py", line 571, in _get_climo_filepath
    raise IOError(
OSError: No file found for 'HadISST' and 'ANN' in /lcrc/group/e3sm/diagnostics/observations/Atm/climatology
2025-01-27 14:54:00,095 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:00,269 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:00,285 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:54:00,305 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_N.png
2025-01-27 14:54:00,307 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:54:00,359 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S_test.nc
2025-01-27 14:54:00,365 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S_ref.nc
2025-01-27 14:54:00,373 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S_diff.nc
2025-01-27 14:54:00,374 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S.json
2025-01-27 14:54:00,823 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:01,208 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N_test.nc
2025-01-27 14:54:01,214 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N_ref.nc
2025-01-27 14:54:01,220 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N_diff.nc
2025-01-27 14:54:01,221 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N.json
2025-01-27 14:54:01,931 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-ANN-polar_S.png
2025-01-27 14:54:01,933 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:02,494 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_N.png
2025-01-27 14:54:02,496 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:03,024 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:54:03,171 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:03,200 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:54:03,217 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:03,807 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S_test.nc
2025-01-27 14:54:03,820 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S_ref.nc
2025-01-27 14:54:03,826 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S_diff.nc
2025-01-27 14:54:03,827 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S.json
2025-01-27 14:54:04,353 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:04,590 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:04,606 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:54:05,072 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:05,242 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:05,258 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:05,531 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N_test.nc
2025-01-27 14:54:05,537 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N_ref.nc
2025-01-27 14:54:05,543 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N_diff.nc
2025-01-27 14:54:05,545 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N.json
2025-01-27 14:54:06,012 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-JJA-polar_S.png
2025-01-27 14:54:06,013 [INFO]: polar_driver.py(run_diag:36) >> Variable: PRECT
2025-01-27 14:54:06,023 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S_test.nc
2025-01-27 14:54:06,029 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S_ref.nc
2025-01-27 14:54:06,034 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S_diff.nc
2025-01-27 14:54:06,036 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S.json
2025-01-27 14:54:06,420 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:06,785 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_N.png
2025-01-27 14:54:06,787 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:07,453 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PD_HadISST/HadISST_PD-SST-ANN-polar_S.png
2025-01-27 14:54:07,455 [INFO]: polar_driver.py(run_diag:36) >> Variable: SST
2025-01-27 14:54:08,467 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('PRECC', 'PRECL')
2025-01-27 14:54:08,614 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_848/lib/python3.12/site-packages/xarray/conventions.py:193: SerializationWarning: variable 'PRECT' has multiple fill values {np.float32(1e+20), np.float64(1e+20)} defined, decoding all values to NaN.
  var = coder.decode(var, name=name)

2025-01-27 14:54:08,641 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('PRECT',)
2025-01-27 14:54:08,659 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:09,247 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S_test.nc
2025-01-27 14:54:09,259 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S_ref.nc
2025-01-27 14:54:09,265 [INFO]: io.py(_write_to_netcdf:151) >> 'PRECT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S_diff.nc
2025-01-27 14:54:09,266 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S.json
2025-01-27 14:54:09,327 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:09,495 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:09,511 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_S
2025-01-27 14:54:10,016 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TS', 'OCNFRAC')
2025-01-27 14:54:10,184 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('sst',)
2025-01-27 14:54:10,201 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: polar_N
2025-01-27 14:54:10,273 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S_test.nc
2025-01-27 14:54:10,281 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S_ref.nc
2025-01-27 14:54:10,286 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S_diff.nc
2025-01-27 14:54:10,288 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S.json
2025-01-27 14:54:10,568 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/GPCP_v2.3/GPCP_v2.3-PRECT-ANN-polar_S.png
2025-01-27 14:54:11,130 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N_test.nc
2025-01-27 14:54:11,136 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N_ref.nc
2025-01-27 14:54:11,142 [INFO]: io.py(_write_to_netcdf:151) >> 'SST' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N_diff.nc
2025-01-27 14:54:11,144 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N.json
2025-01-27 14:54:11,708 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_CL_HadISST/HadISST_CL-SST-JJA-polar_S.png
2025-01-27 14:54:12,313 [INFO]: utils.py(_save_plot:91) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/polar/SST_PI_HadISST/HadISST_PI-SST-JJA-polar_N.png
2025-01-27 14:54:12,361 [INFO]: main.py(create_viewer:132) >> polar /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/viewer
2025-01-27 14:54:12,503 [INFO]: main.py(create_viewer:135) >> ('Polar contour maps', 'polar/index.html')
2025-01-27 14:54:12,507 [INFO]: e3sm_diags_driver.py(main:396) >> Viewer HTML generated at /lcrc/group/e3sm/public_html/cdat-migration-fy24/909-prov-log/viewer/index.html

```

- [x] Testing
  - [x] Works with serial
  - [x] Works with multiprocessing
  - [x] Works with multiple simulations in a for-loop


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)


## Additional Info

https://docs.python.org/3/library/logging.html#logging.basicConfig

> Note
> 
> This function should be called from the main thread before other threads are started. In versions of Python prior to 2.7.1 and 3.2, if this function is called from multiple threads, it is possible (in rare circumstances) that a handler will be added to the root logger more than once, leading to unexpected results such as messages being duplicated in the log. 