### PR TITLE
Constrain `dask !=2024.12.0,!=2024.12.1` for performance

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -15,7 +15,7 @@ dependencies:
   - cartopy >=0.17.0
   - cartopy_offlinedata
   - cf-units
-  - dask <2024.12.0
+  - dask !=2024.12.0,!=2024.12.1
   - lxml
   - mache >=0.15.0
   - matplotlib-base >=3.8.2

--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -4,7 +4,6 @@
 name: e3sm_diags_ci
 channels:
   - conda-forge
-  - defaults
 dependencies:
   # Base
   # =================

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -2,7 +2,6 @@
 name: e3sm_diags_dev
 channels:
   - conda-forge
-  - defaults
 dependencies:
   # Base
   # =======================

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - cartopy >=0.17.0
   - cartopy_offlinedata
   - cf-units
-  - dask <2024.12.0
+  - dask !=2024.12.0,!=2024.12.1
   - lxml
   - mache >=0.15.0
   - matplotlib-base >=3.8.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   # This package is not available on PyPI.
   # "cartopy_offlinedata",
   "cf-units",
-  "dask <2024.12.0",
+  "dask !=2024.12.0,!=2024.12.1",
   "lxml",
   "mache >=0.15.0",
   "matplotlib >=3.8.2",
@@ -50,12 +50,7 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov"]
 docs = ["sphinx", "sphinx_rtd_theme", "sphinx-multiversion"]
-dev = [
-  "pre-commit",
-  "types-PyYAML",
-  "ruff",
-  "mypy",
-]
+dev = ["pre-commit", "types-PyYAML", "ruff", "mypy"]
 
 [project.urls]
 Documentation = "https://docs.e3sm.org/e3sm_diags/_build/html/main/index.html"


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #911 
- Related to https://github.com/conda-forge/e3sm_diags-feedstock/issues/42

### To do
- [x] Update dask constraint to `dask !=2024.12.0,!=2024.12.1` in `dev.yml`, `ci.yml` and `pyproject.toml`
- [x] Validate `dask=2025.1.0` update fixes performance issue using MVCE from [here ](https://github.com/pydata/xarray/issues/9926)
- [x] Perform EAMxx v3 run for `ua` variable with `dask=2025.1.0` -- pending `perlmutter` back online (2/3/25)
  - `auxiliary_tools/cdat_regression_testing/892-bottleneck/run_script.py`


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
