### PR TITLE
Add viewer `index.html` to top level of results directory

### DIFF
--- a/auxiliary_tools/cdat_regression_testing/562-index-html/562_index_html.cfg
+++ b/auxiliary_tools/cdat_regression_testing/562-index-html/562_index_html.cfg
@@ -1,0 +1,13 @@
+[#]
+sets = ["polar"]
+case_id = "GPCP_v3.2"
+variables = ["PRECT"]
+ref_name = "GPCP_v3.2"
+reference_name = "GPCP v2.2"
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["polar_S"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5]
+diff_levels = [-2, -1.5, -1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1, 1.5, 2]

--- a/auxiliary_tools/cdat_regression_testing/562-index-html/run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/562-index-html/run_script.py
@@ -1,0 +1,11 @@
+# python -m auxiliary_tools.cdat_regression_testing.792-lat-lon-run-script.792_lat_lon_run_script
+from auxiliary_tools.cdat_regression_testing.base_run_script import run_set
+
+SET_NAME = "polar"
+SET_DIR = "562-index-html"
+# CFG_PATH: str | None = None
+CFG_PATH: str | None = "auxiliary_tools/cdat_regression_testing/562-index-html/562_index_html.cfg"
+MULTIPROCESSING = False
+
+# %%
+run_set(SET_NAME, SET_DIR, CFG_PATH, MULTIPROCESSING)

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -141,26 +141,21 @@ def save_provenance(results_dir, parser):
     if not os.path.exists(results_dir):
         os.makedirs(results_dir, 0o755)
 
-    # Create a PHP file to list the contents of the prov dir.
-    php_path = os.path.join(results_dir, "index.php")
-    with open(php_path, "w") as f:
-        contents = """
-        <?php
-        # Taken from:
-        # https://stackoverflow.com/questions/3785055/how-can-i-create-a-simple-index-html-file-which-lists-all-files-directories
-        $path = ".";
-        $dh = opendir($path);
-        $i=1;
-        while (($file = readdir($dh)) !== false) {
-            if($file != "." && $file != ".." && $file != "index.php" && $file != ".htaccess" && $file != "error_log" && $file != "cgi-bin") {
-                echo "<a href='$path/$file'>$file</a><br /><br />";
-                $i++;
-            }
-        }
-        closedir($dh);
-        ?>
-        """
-        f.write(contents)
+    # Create an HTML file to list the contents of the prov dir.
+    index_html_path = os.path.join(results_dir, "index.html")
+
+    with open(index_html_path, "w") as f:
+        f.write("<html><body><h1>Provenance Files</h1><ul>")
+
+        for file_name in os.listdir(results_dir):
+            file_path = os.path.join(results_dir, file_name)
+            if os.path.isfile(file_path):
+                f.write(f'<li><a href="{file_name}">{file_name}</a></li>')
+
+        f.write("</ul></body></html>")
+
+    logger.info("Created provenance index HTML file at: {}".format(index_html_path))
+
     try:
         _save_env_yml(results_dir)
     except Exception:

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -388,13 +388,7 @@ def main(parameters=[]) -> List[CoreParameter]:  # noqa B006
         if parameters_results[0].no_viewer:
             logger.info("Viewer not created because the no_viewer parameter is True.")
         else:
-            path = os.path.join(parameters_results[0].results_dir, "viewer")
-            if not os.path.exists(path):
-                os.makedirs(path)
-
-            # TODO: This is where the path is passed for the viewer, which
-            # is where the index.html is stored.
-            index_path = create_viewer(path, parameters_results)
+            index_path = create_viewer(parameters_results)
             logger.info("Viewer HTML generated at {}".format(index_path))
 
     # Validate actual and expected parameters are aligned

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -392,6 +392,8 @@ def main(parameters=[]) -> List[CoreParameter]:  # noqa B006
             if not os.path.exists(path):
                 os.makedirs(path)
 
+            # TODO: This is where the path is passed for the viewer, which
+            # is where the index.html is stored.
             index_path = create_viewer(path, parameters_results)
             logger.info("Viewer HTML generated at {}".format(index_path))
 

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -150,7 +150,9 @@ def save_provenance(results_dir, parser):
         for file_name in os.listdir(results_dir):
             file_path = os.path.join(results_dir, file_name)
             if os.path.isfile(file_path):
-                f.write(f'<li><a href="{file_name}">{file_name}</a></li>')
+                f.write(
+                    f'<li><a href="{file_name}" target="_blank">{file_name}</a></li>'
+                )
 
         f.write("</ul></body></html>")
 

--- a/e3sm_diags/viewer/core_viewer.py
+++ b/e3sm_diags/viewer/core_viewer.py
@@ -100,7 +100,7 @@ class OutputViewer(object):
             )
             return url
 
-        raise RuntimeError("Error geneating the page.")
+        raise RuntimeError("Error generating the page.")
 
     def generate_viewer(self, prompt_user=True):
         """Generate the webpage and ask the user if they want to see it."""

--- a/e3sm_diags/viewer/main.py
+++ b/e3sm_diags/viewer/main.py
@@ -1,10 +1,12 @@
 import collections
 import os
+from typing import List
 
 from bs4 import BeautifulSoup
 
 import e3sm_diags
 from e3sm_diags.logger import custom_logger
+from e3sm_diags.parameter.core_parameter import CoreParameter
 
 from . import (
     aerosol_budget_viewer,
@@ -115,11 +117,16 @@ def create_index(root_dir, title_and_url_list):
     return output
 
 
-def create_viewer(root_dir, parameters):
+def create_viewer(parameters: List[CoreParameter]) -> str:
     """
     Based of the parameters, find the files with the
     certain extension and create the viewer in root_dir.
     """
+    root_dir = parameters[0].results_dir
+
+    if not os.path.exists(root_dir):
+        os.makedirs(root_dir)
+
     # Group each parameter object based on the `sets` parameter.
     set_to_parameters = collections.defaultdict(list)
     for param in parameters:
@@ -129,6 +136,7 @@ def create_viewer(root_dir, parameters):
     # A list of (title, url) tuples that each viewer generates.
     # This is used to create the main index.
     title_and_url_list = []
+
     # Now call the viewers with the list of parameters as the arguments.
     for set_name, parameters in set_to_parameters.items():
         logger.info(f"{set_name} {root_dir}")

--- a/e3sm_diags/viewer/main.py
+++ b/e3sm_diags/viewer/main.py
@@ -77,6 +77,8 @@ def create_index(root_dir, title_and_url_list):
         row_obj.append(td)
 
     path = os.path.join(e3sm_diags.INSTALL_PATH, "viewer", "index_template.html")
+    # TODO: root_dir is the results_dir with "viewer" appended to it. We
+    # want the index.html to work in the results_dir too.
     output = os.path.join(root_dir, "index.html")
 
     soup = BeautifulSoup(open(path), "lxml")

--- a/e3sm_diags/viewer/main.py
+++ b/e3sm_diags/viewer/main.py
@@ -74,6 +74,7 @@ def create_index(root_dir, title_and_url_list):
         td = soup.new_tag("td")
         a = soup.new_tag("a")
         a["href"] = url
+        a["target"] = "_blank"  # Open link in a new tab
         a.string = name
         td.append(a)
         row_obj.append(td)

--- a/e3sm_diags/viewer/main.py
+++ b/e3sm_diags/viewer/main.py
@@ -79,8 +79,6 @@ def create_index(root_dir, title_and_url_list):
         row_obj.append(td)
 
     path = os.path.join(e3sm_diags.INSTALL_PATH, "viewer", "index_template.html")
-    # TODO: root_dir is the results_dir with "viewer" appended to it. We
-    # want the index.html to work in the results_dir too.
     output = os.path.join(root_dir, "index.html")
 
     soup = BeautifulSoup(open(path), "lxml")


### PR DESCRIPTION
## Description
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
This pull request updates the viewer to generate a top-level `index.html` in the root directory (`results_dir`) that redirects to the `/viewer/index.html`. It fixes the `/prov` index page not displaying properly and makes links open in a new tab for convenience. 

Example: https://web.lcrc.anl.gov/public/e3sm/cdat-migration-fy24/562-index-html/ 

### HTML Generation Improvements:
* Replaced the PHP file creation with an HTML file to list the contents of the provenance directory in `e3sm_diags_driver.py` (closes #928)
* Modified the `create_viewer` function to create a root-level `index.html` that redirects to the viewer index. [[1]](diffhunk://#diff-f5574c2ff6e46f2a24cb255e62d5f4270dc6e7a19ef0c04e572d3e35d1a1495bL116-R129) [[2]](diffhunk://#diff-f5574c2ff6e46f2a24cb255e62d5f4270dc6e7a19ef0c04e572d3e35d1a1495bR139-R186) (closes #562)

### Minor Fixes:
* Corrected a typo in an error message in `core_viewer.py`.
* Added missing type annotations and imports in `main.py`.
* Updated the `insert_data_in_row` function to open links in a new tab.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
