### PR TITLE
Fix `--no_viewer` option breaking

### DIFF
--- a/auxiliary_tools/cdat_regression_testing/942-no-viewer/qa.py
+++ b/auxiliary_tools/cdat_regression_testing/942-no-viewer/qa.py
@@ -1,0 +1,41 @@
+import os
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.run import Run, runner
+
+simulations = [
+    "tc-v1.HR.0026_0035",
+    "tc-v2.LR.2000_2014",
+    "tc-v3.HR.0006_0025",
+    "tc-v3.LR.2000_2014",
+]
+sim_names = [
+    "theta.20180906.branch_noCNT.A_WCYCL1950S_CMIP6_HR.ne120_oRRS18v3_ICG",
+    "v2.LR.historical_0101",
+    "20240609.piCtl.ne120pg2_r025_RRSwISC6to18E3r5.chrysalis.test1",
+    "extendedOutput.v3.LR.historical_0101",
+]
+
+data_path = "/global/homes/c/chengzhu/tests/tc_analysis/"
+
+for idx, sim in enumerate(simulations):
+    print(sim)
+    # runner = Run()
+
+    param = CoreParameter()
+    param.multiprocessing = True
+    param.test_data_path = data_path + sim
+    param.test_name = sim_names[idx]
+    param.test_start_yr = sim.split(".")[-1][0:4]
+    param.test_end_yr = sim.split(".")[-1][5:9]
+
+    param.reference_data_path = (
+        "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/tc-analysis"
+    )
+    param.ref_start_yr = "1979"
+    param.ref_end_yr = "2018"
+
+    prefix = "/global/cfs/cdirs/e3sm/www/vo13/tc_analysis_test/"
+    param.results_dir = os.path.join(prefix, sim)
+    runner.sets_to_run = ["tc_analysis"]
+    runner.run_diags([param])

--- a/auxiliary_tools/cdat_regression_testing/942-no-viewer/v2_run.cfg
+++ b/auxiliary_tools/cdat_regression_testing/942-no-viewer/v2_run.cfg
@@ -1,0 +1,11 @@
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["TREFHT"]
+regions = ["land"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons=["ANN"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+regrid_method = "bilinear"

--- a/auxiliary_tools/cdat_regression_testing/942-no-viewer/v2_run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/942-no-viewer/v2_run_script.py
@@ -1,0 +1,167 @@
+"""
+Source: /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_comprehensive_v2_www/test_pr651_both_commits_20250117/v2.LR.historical_0201/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1982-1983/prov/e3sm.py
+
+Webpage: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.forsyth2/zppy_weekly_comprehensive_v2_www/test_pr651_both_commits_20250117/v2.LR.historical_0201/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1982-1983/prov/e3sm.py
+
+Diffs: https://github.com/E3SM-Project/zppy/pull/651#issuecomment-2628445196
+ /lcrc/group/e3sm/public_html/diagnostic_output/ac.forsyth2/zppy_weekly_comprehensive_v2_www/test_pr651_both_commits_20250117/v2.LR.historical_0201/image_check_failures_comprehensive_v2/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1982-1983
+
+ERA5-TREFHT-ANN-land.png
+ERA5_ext-QREFHT-ANN-global.png
+ERA5_ext-U10-ANN-global.png
+GPCP_v3.2-PRECT-ANN-global.png
+HadISST_CL-SST-ANN-global.png
+HadISST_PD-SST-ANN-global.png
+HadISST_PI-SST-ANN-global.png
+MACv2-AODVIS-ANN-global.png
+MERRA2-OMEGA-850-ANN-global.png
+MERRA2-PSL-ANN-global.png
+MERRA2-T-850-ANN-global.png
+MERRA2-TAUXY-ANN-ocean.png
+MERRA2-TREFHT-ANN-land.png
+MERRA2-TREFMNAV-ANN-global.png
+MERRA2-TREFMXAV-ANN-global.png
+_MISRCOSP-CLDLOW_TAU1.3_9.4_MISR-ANN-global.png
+MISRCOSP-CLDLOW_TAU1.3_MISR-ANN-global.png
+MISRCOSP-CLDLOW_TAU9.4_MISR-ANN-global.png_
+OMI-MLS-TCO-ANN-60S60N.png
+ceres_ebaf_surface_v4.1-ALBEDO_SRF-ANN-global.png
+"""
+
+import os
+import sys
+
+import numpy
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+from e3sm_diags.parameter.qbo_parameter import QboParameter
+from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.parameter.tropical_subseasonal_parameter import TropicalSubseasonalParameter
+
+
+from e3sm_diags.run import runner
+
+short_name = 'v2.LR.historical_0201'
+test_ts = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/ts/monthly/2yr'
+start_yr = int('1982')
+end_yr = int('1983')
+num_years = end_yr - start_yr + 1
+ref_start_yr = 1980
+
+param = CoreParameter()
+
+# Model
+# param.test_data_path = 'climo'
+param.test_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/clim/2yr"
+param.test_name = 'v2.LR.historical_0201'
+param.short_test_name = short_name
+
+# Ref
+
+# Obs
+param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/climatology/'
+param.save_netcdf = True
+
+# Output dir
+# param.results_dir = 'model_vs_obs_1982-1983'
+param.results_dir = "/lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer"
+
+# Additional settings
+param.run_type = 'model_vs_obs'
+param.diff_title = 'Model - Observations'
+param.output_format = ['png']
+param.output_format_subplot = []
+param.multiprocessing = True
+param.num_workers = 8
+#param.fail_on_incomplete = True
+params = [param]
+
+# Model land
+enso_param = EnsoDiagsParameter()
+enso_param.test_data_path = test_ts
+enso_param.test_name = short_name
+enso_param.test_start_yr = start_yr
+enso_param.test_end_yr = end_yr
+
+# Obs
+enso_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+enso_param.ref_start_yr = ref_start_yr
+enso_param.ref_end_yr = ref_start_yr + 10
+
+params.append(enso_param)
+trop_param = TropicalSubseasonalParameter()
+trop_param.test_data_path = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/ts/daily/2yr'
+trop_param.test_name = short_name
+trop_param.test_start_yr = f'{start_yr:04}'
+trop_param.test_end_yr = f'{end_yr:04}'
+
+# Obs
+trop_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+trop_param.ref_start_yr = 2001
+trop_param.ref_end_yr = 2010
+
+params.append(trop_param)
+qbo_param = QboParameter()
+qbo_param.test_data_path = test_ts
+qbo_param.test_name = short_name
+qbo_param.test_start_yr = start_yr
+qbo_param.test_end_yr = end_yr
+qbo_param.ref_start_yr = ref_start_yr
+ref_end_yr = ref_start_yr + num_years - 1
+if (ref_end_yr <= 1981):
+  qbo_param.ref_end_yr = ref_end_yr
+else:
+  qbo_param.ref_end_yr = 1981
+
+# Obs
+qbo_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+
+params.append(qbo_param)
+dc_param = DiurnalCycleParameter()
+dc_param.test_data_path = 'climo_diurnal_8xdaily'
+dc_param.short_test_name = short_name
+# Plotting diurnal cycle amplitude on different scales. Default is True
+dc_param.normalize_test_amp = False
+
+# Obs
+dc_param.reference_data_path = '/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_complete_run/obs/climatology'
+
+params.append(dc_param)
+streamflow_param = StreamflowParameter()
+streamflow_param.test_data_path = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/rof/native/ts/monthly/2yr'
+streamflow_param.test_name = short_name
+streamflow_param.test_start_yr = start_yr
+streamflow_param.test_end_yr = end_yr
+
+# Obs
+streamflow_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+streamflow_param.ref_start_yr = "1986" # Streamflow gauge station data range from year 1986 to 1995
+streamflow_param.ref_end_yr = "1995"
+
+params.append(streamflow_param)
+tc_param = TCAnalysisParameter()
+tc_param.test_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/tc-analysis_1982_1983"
+tc_param.short_test_name = short_name
+tc_param.test_start_yr = "1982"
+tc_param.test_end_yr = "1983"
+
+# Obs
+tc_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/tc-analysis/'
+# For model vs obs, the ref start and end year can be any four digit strings
+# For now, use all available years from obs by default
+tc_param.ref_start_yr = "1979"
+tc_param.ref_end_yr = "2018"
+
+params.append(tc_param)
+
+# Run
+cfg_path = "auxiliary_tools/cdat_regression_testing/942-no-viewer/v2_run.cfg"
+sys.argv.extend(["--diags", cfg_path, "--no_viewer"])
+
+# runner.sets_to_run = ['lat_lon', 'zonal_mean_xy', 'zonal_mean_2d', 'polar', 'cosp_histogram', 'meridional_mean_2d', 'annual_cycle_zonal_mean', 'zonal_mean_2d_stratosphere', 'enso_diags', 'qbo', 'diurnal_cycle', 'streamflow', 'tc_analysis', 'tropical_subseasonal', 'aerosol_aeronet', 'aerosol_budget']
+
+runner.sets_to_run = ['lat_lon']
+runner.run_diags(params)
+

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -467,7 +467,7 @@ def main(parameters=[]) -> List[CoreParameter]:  # noqa B006
     return parameters_results
 
 
-def _log_diagnostic_run_info(prov_paths: ProvPaths | None):
+def _log_diagnostic_run_info(prov_paths: ProvPaths):
     """Logs information about the diagnostic run.
 
     This method is useful for tracking the provenance of the diagnostic run
@@ -481,9 +481,8 @@ def _log_diagnostic_run_info(prov_paths: ProvPaths | None):
 
     Parameters
     ----------
-    prov_paths : ProvPaths | None
-        The paths to the provenance files. The value will be None if the
-        ``no_viewer`` option is set to True.
+    prov_paths : ProvPaths
+        The paths to the provenance files.
 
     Notes
     -----

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -68,7 +68,7 @@ def get_default_diags_path(set_name, run_type, print_path=True):
     return pth
 
 
-def save_provenance(results_dir: str, parser: CoreParser) -> ProvPaths:
+def save_provenance(results_dir: str, parser: CoreParser, no_viewer: bool) -> ProvPaths:
     """
     Store the provenance in results_dir.
     """
@@ -82,6 +82,18 @@ def save_provenance(results_dir: str, parser: CoreParser) -> ProvPaths:
         "env_yml_path": None,
         "index_html_path": None,
     }
+
+    if no_viewer:
+        paths.update(
+            {
+                "parameter_files_path": "N/A (No viewer generated)",
+                "python_script_path": "N/A (No viewer generated)",
+                "env_yml_path": "N/A (No viewer generated)",
+                "index_html_path": "N/A (No viewer generated)",
+            }
+        )
+
+        return paths
 
     paths["parameter_files_path"] = _save_parameter_files(prov_dir, parser)
     paths["python_script_path"] = _save_python_script(prov_dir, parser)
@@ -406,12 +418,9 @@ def main(parameters=[]) -> List[CoreParameter]:  # noqa B006
     if not os.path.exists(parameters[0].results_dir):
         os.makedirs(parameters[0].results_dir, 0o755)
 
-    # Only save provenance for full runs.
-    if not parameters[0].no_viewer:
-        prov_paths = save_provenance(parameters[0].results_dir, parser)
-    else:
-        prov_paths = None
-
+    prov_paths = save_provenance(
+        parameters[0].results_dir, parser, parameters[0].no_viewer
+    )
     _log_diagnostic_run_info(prov_paths)
 
     # Perform the diagnostic run
@@ -507,19 +516,14 @@ def _log_diagnostic_run_info(prov_paths: ProvPaths | None):
     except subprocess.CalledProcessError:
         version_info = f"version {e3sm_diags.__version__}"
 
-    results_dir = log_path = parameter_files_path = python_script_path = (
-        env_yml_path
-    ) = index_html_path = "N/A (No viewer generated)"
-
-    if prov_paths is not None:
-        (
-            results_dir,
-            log_path,
-            parameter_files_path,
-            python_script_path,
-            env_yml_path,
-            index_html_path,
-        ) = prov_paths.values()  # type: ignore
+    (
+        results_dir,
+        log_path,
+        parameter_files_path,
+        python_script_path,
+        env_yml_path,
+        index_html_path,
+    ) = prov_paths.values()  # type: ignore
 
     logger.info(
         f"\n{'=' * 80}\n"

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -409,8 +409,11 @@ def main(parameters=[]) -> List[CoreParameter]:  # noqa B006
     if not os.path.exists(parameters[0].results_dir):
         os.makedirs(parameters[0].results_dir, 0o755)
 
-    if not parameters[0].no_viewer:  # Only save provenance for full runs.
+    # Only save provenance for full runs.
+    if not parameters[0].no_viewer:
         prov_paths = save_provenance(parameters[0].results_dir, parser)
+    else:
+        prov_paths = None
 
     _log_diagnostic_run_info(prov_paths)
 
@@ -458,7 +461,7 @@ def main(parameters=[]) -> List[CoreParameter]:  # noqa B006
     return parameters_results
 
 
-def _log_diagnostic_run_info(prov_paths: ProvPaths):
+def _log_diagnostic_run_info(prov_paths: ProvPaths | None):
     """Logs information about the diagnostic run.
 
     This method is useful for tracking the provenance of the diagnostic run
@@ -472,8 +475,9 @@ def _log_diagnostic_run_info(prov_paths: ProvPaths):
 
     Parameters
     ----------
-    prov_paths : ProvPaths
-        The paths to the provenance files.
+    prov_paths : ProvPaths | None
+        The paths to the provenance files. The value will be None if the
+        ``no_viewer`` option is set to True.
 
     Notes
     -----
@@ -506,14 +510,20 @@ def _log_diagnostic_run_info(prov_paths: ProvPaths):
     except subprocess.CalledProcessError:
         version_info = f"version {e3sm_diags.__version__}"
 
-    (
-        results_dir,
-        log_path,
-        parameter_files_path,
-        python_script_path,
-        env_yml_path,
-        index_html_path,
-    ) = prov_paths.values()
+    results_dir = log_path = parameter_files_path = python_script_path = (
+        env_yml_path
+    ) = index_html_path = "N/A (No viewer generated)"
+
+    if prov_paths is not None:
+        (
+            results_dir,
+            log_path,
+            parameter_files_path,
+            python_script_path,
+            env_yml_path,
+            index_html_path,
+        ) = prov_paths.values()  # type: ignore
+
     logger.info(
         f"\n{'=' * 80}\n"
         f"E3SM Diagnostics Run\n"

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# The above line is needed for `test_all_sets.test_all_sets_mpl`.
-# Otherwise, OSError: [Errno 8] Exec format error: 'e3sm_diags_driver.py'.
 from __future__ import annotations
 
 import os

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -522,7 +522,7 @@ def _log_diagnostic_run_info(prov_paths: ProvPaths):
         python_script_path,
         env_yml_path,
         index_html_path,
-    ) = prov_paths.values()  # type: ignore
+    ) = prov_paths.values()
 
     logger.info(
         f"\n{'=' * 80}\n"


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #942 
- Example: https://web.lcrc.anl.gov/public/e3sm/cdat-migration-fy24/942-no-viewer/
- Example [log](https://web.lcrc.anl.gov/public/e3sm/cdat-migration-fy24/942-no-viewer/prov/e3sm_diags_run.log)

```python
2025-02-18 16:39:47,976 [INFO]: e3sm_diags_driver.py(_log_diagnostic_run_info:523) >> 
================================================================================
E3SM Diagnostics Run
--------------------
Timestamp: 2025-02-18 16:39:47
Version Info: branch bug/942-no-viewer with commit eb1a96e683bdab67d9bd420f4dadf2591d451c98
Results Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer
Log Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer/prov/e3sm_diags_run.log
Parameter Files Path: N/A (No viewer generated)
Python Script Path: N/A (No viewer generated)
Environment YML Path: N/A (No viewer generated)
Provenance Index HTML Path: N/A (No viewer generated)
================================================================================

2025-02-18 16:39:52,525 [INFO]: lat_lon_driver.py(run_diag:69) >> Variable: TREFHT
2025-02-18 16:39:54,208 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TREFHT',)
2025-02-18 16:39:54,676 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('tas',)
2025-02-18 16:39:56,547 [INFO]: regrid.py(subset_and_align_datasets:70) >> Selected region: land
2025-02-18 16:40:45,476 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer/lat_lon/ERA5/ERA5-TREFHT-ANN-land_test.nc
2025-02-18 16:40:45,482 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer/lat_lon/ERA5/ERA5-TREFHT-ANN-land_ref.nc
2025-02-18 16:40:45,487 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer/lat_lon/ERA5/ERA5-TREFHT-ANN-land_diff.nc
2025-02-18 16:40:45,489 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer/lat_lon/ERA5/ERA5-TREFHT-ANN-land.json
2025-02-18 16:40:45,536 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_930/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-02-18 16:40:46,049 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_930/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-02-18 16:40:48,733 [WARNING]: warnings.py(_showwarnmsg:112) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_930/lib/python3.12/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-02-18 16:40:53,335 [INFO]: utils.py(_save_plot:92) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/942-no-viewer/lat_lon/ERA5/ERA5-TREFHT-ANN-land.png
2025-02-18 16:40:53,412 [INFO]: e3sm_diags_driver.py(main:438) >> Viewer not created because the no_viewer parameter is True.

```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
