### PR TITLE
Include metrics for model only run as in v2

### DIFF
--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -579,6 +579,7 @@ def _create_metrics_dict(
             "min": var_test.min().item(),
             "max": var_test.max().item(),
             "mean": spatial_avg(ds_test, var_key),  # type: ignore
+            "std": std(ds_test, var_key),
         },
         "unit": ds_test[var_key].attrs["units"],
     }
@@ -591,6 +592,7 @@ def _create_metrics_dict(
             "min": var_ref.min().item(),
             "max": var_ref.max().item(),
             "mean": spatial_avg(ds_ref, var_key),  # type: ignore
+            "std": std(ds_ref, var_key),
         }
 
     if ds_test_regrid is not None and ds_ref_regrid is not None:

--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -615,6 +615,10 @@ def _create_metrics_dict(
             "corr": correlation(ds_test_regrid, ds_ref_regrid, var_key),
         }
 
+    # for model-only run
+    if ds_test is not None and ds_ref_regrid is None:
+        metrics_dict["test_regrid"] = metrics_dict["test"]
+
     if ds_diff is not None:
         var_diff = ds_diff[var_key]
 


### PR DESCRIPTION
## Description

For model only run, the v2 behavior is to also print out metrics: max, mean, min, std for model data in metrics table for lat-lon. This fix preserve this behavior and to make the metrics available in the table even if a reference data is not available. Results as shown below.

In v2: 
Variables	Unit	Test_mean	Ref._mean	Mean_Bias	Test_STD	Ref._STD	RMSE	Correlation
PRECT global GPCP_v3.2	mm/day	2.993	2.812	0.181	2.133	2.065	1.061	0.876
PRECT global GPCP_v2.3	mm/day	2.993	2.69	0.302	2.102	1.934	1.024	0.886
TREFHT land_60S90N CRU	DegC	13.231	12.932	0.298	12.57	13.077	1.778	0.991
**SST global HadISST	degC	20.256	999.999	999.999	8.178	999.999	999.999	999.999**

On main:
Variables	Unit	Test_mean	Ref._mean	Mean_Bias	Test_STD	Ref._STD	RMSE	Correlation
PRECT global GPCP_v3.2	mm/day	2.993	2.812	0.181	2.133	2.067	1.035	0.883
PRECT global GPCP_v2.3	mm/day	2.993	2.69	0.302	2.102	1.934	1.024	0.886
TREFHT land_60S90N CRU	DegC	13.231	12.797	0.434	12.57	13.179	1.73	0.992
**SST global HadISST	degC	999.999	999.999	999.999	999.999	999.999	999.999	999.999**

This PR:
Variables	Unit	Test_mean	Ref._mean	Mean_Bias	Test_STD	Ref._STD	RMSE	Correlation
PRECT global GPCP_v3.2	mm/day	2.993	2.812	0.181	2.133	2.067	1.035	0.883
PRECT global GPCP_v2.3	mm/day	2.993	2.69	0.302	2.102	1.934	1.024	0.886
TREFHT land_60S90N CRU	DegC	13.231	12.797	0.434	12.57	13.179	1.73	0.992
**SST global HadISST	degC	20.256	999.999	999.999	8.178	999.999	999.999	999.999**

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
