### PR TITLE
Instantiate root logger through a function and prevent duplicate `e3sm_diags_run.log`

### DIFF
--- a/auxiliary_tools/cdat_regression_testing/940-xesmf-diffs/xesmf-warning/v2_run.cfg
+++ b/auxiliary_tools/cdat_regression_testing/940-xesmf-diffs/xesmf-warning/v2_run.cfg
@@ -1,0 +1,9 @@
+[#]
+sets = ["zonal_mean_2d"]
+case_id = "MERRA2"
+variables = ["T"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+seasons = ["ANN", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [180,185,190,200,210,220,230,240,250,260,270,280,290,295,300]
+diff_levels = [-7,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,7]

--- a/auxiliary_tools/cdat_regression_testing/940-xesmf-diffs/xesmf-warning/v2_run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/940-xesmf-diffs/xesmf-warning/v2_run_script.py
@@ -1,0 +1,137 @@
+import os
+import sys
+
+import numpy
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+from e3sm_diags.parameter.qbo_parameter import QboParameter
+from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.parameter.tropical_subseasonal_parameter import TropicalSubseasonalParameter
+
+
+from e3sm_diags.run import runner
+
+short_name = 'v2.LR.historical_0201'
+test_ts = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/ts/monthly/2yr'
+start_yr = int('1982')
+end_yr = int('1983')
+num_years = end_yr - start_yr + 1
+ref_start_yr = 1980
+
+param = CoreParameter()
+
+# Model
+# param.test_data_path = 'climo'
+param.test_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/clim/2yr"
+param.test_name = 'v2.LR.historical_0201'
+param.short_test_name = short_name
+
+# Ref
+
+# Obs
+param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/climatology/'
+param.save_netcdf = True
+
+# Output dir
+# param.results_dir = 'model_vs_obs_1982-1983'
+param.results_dir = "/lcrc/group/e3sm/public_html/cdat-migration-fy24/25-02-18-branch-940-xesmf-diffs-trefht-land"
+
+# Additional settings
+param.run_type = 'model_vs_obs'
+param.diff_title = 'Model - Observations'
+param.output_format = ['png']
+param.output_format_subplot = []
+param.multiprocessing = True
+param.num_workers = 8
+#param.fail_on_incomplete = True
+params = [param]
+
+# Model land
+enso_param = EnsoDiagsParameter()
+enso_param.test_data_path = test_ts
+enso_param.test_name = short_name
+enso_param.test_start_yr = start_yr
+enso_param.test_end_yr = end_yr
+
+# Obs
+enso_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+enso_param.ref_start_yr = ref_start_yr
+enso_param.ref_end_yr = ref_start_yr + 10
+
+params.append(enso_param)
+trop_param = TropicalSubseasonalParameter()
+trop_param.test_data_path = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/ts/daily/2yr'
+trop_param.test_name = short_name
+trop_param.test_start_yr = f'{start_yr:04}'
+trop_param.test_end_yr = f'{end_yr:04}'
+
+# Obs
+trop_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+trop_param.ref_start_yr = 2001
+trop_param.ref_end_yr = 2010
+
+params.append(trop_param)
+qbo_param = QboParameter()
+qbo_param.test_data_path = test_ts
+qbo_param.test_name = short_name
+qbo_param.test_start_yr = start_yr
+qbo_param.test_end_yr = end_yr
+qbo_param.ref_start_yr = ref_start_yr
+ref_end_yr = ref_start_yr + num_years - 1
+if (ref_end_yr <= 1981):
+  qbo_param.ref_end_yr = ref_end_yr
+else:
+  qbo_param.ref_end_yr = 1981
+
+# Obs
+qbo_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+
+params.append(qbo_param)
+dc_param = DiurnalCycleParameter()
+dc_param.test_data_path = 'climo_diurnal_8xdaily'
+dc_param.short_test_name = short_name
+# Plotting diurnal cycle amplitude on different scales. Default is True
+dc_param.normalize_test_amp = False
+
+# Obs
+dc_param.reference_data_path = '/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_complete_run/obs/climatology'
+
+params.append(dc_param)
+streamflow_param = StreamflowParameter()
+streamflow_param.test_data_path = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/rof/native/ts/monthly/2yr'
+streamflow_param.test_name = short_name
+streamflow_param.test_start_yr = start_yr
+streamflow_param.test_end_yr = end_yr
+
+# Obs
+streamflow_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+streamflow_param.ref_start_yr = "1986" # Streamflow gauge station data range from year 1986 to 1995
+streamflow_param.ref_end_yr = "1995"
+
+params.append(streamflow_param)
+tc_param = TCAnalysisParameter()
+tc_param.test_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/tc-analysis_1982_1983"
+tc_param.short_test_name = short_name
+tc_param.test_start_yr = "1982"
+tc_param.test_end_yr = "1983"
+
+# Obs
+tc_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/tc-analysis/'
+# For model vs obs, the ref start and end year can be any four digit strings
+# For now, use all available years from obs by default
+tc_param.ref_start_yr = "1979"
+tc_param.ref_end_yr = "2018"
+
+params.append(tc_param)
+
+# Run
+cfg_path = "auxiliary_tools/cdat_regression_testing/940-xesmf-diffs/trefht-land/v2_run.cfg"
+sys.argv.extend(["--diags", cfg_path])
+
+# runner.sets_to_run = ['lat_lon', 'zonal_mean_xy', 'zonal_mean_2d', 'polar', 'cosp_histogram', 'meridional_mean_2d', 'annual_cycle_zonal_mean', 'zonal_mean_2d_stratosphere', 'enso_diags', 'qbo', 'diurnal_cycle', 'streamflow', 'tc_analysis', 'tropical_subseasonal', 'aerosol_aeronet', 'aerosol_budget']
+
+runner.sets_to_run = ['lat_lon']
+runner.run_diags(params)
+

--- a/auxiliary_tools/cdat_regression_testing/954-root-logger/run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/954-root-logger/run_script.py
@@ -1,0 +1,289 @@
+"""
+Make sure to run the machine-specific commands below before
+running this script:
+
+Compy:
+    srun --pty --nodes=1 --time=01:00:00 /bin/bash
+    source /share/apps/E3SM/conda_envs/load_latest_e3sm_unified_compy.sh
+
+LCRC:
+    srun --pty --nodes=1 --time=01:00:00 /bin/bash
+    source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh
+    Or: source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_anvil.sh
+
+NERSC perlmutter cpu:
+    salloc --nodes 1 --qos interactive --time 01:00:00 --constraint cpu --account=e3sm
+    source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_pm-cpu.sh
+"""
+# flake8: noqa E501
+
+import os
+import timeit
+from typing import Tuple, TypedDict
+
+from mache import MachineInfo
+
+from e3sm_diags.parameter.annual_cycle_zonal_mean_parameter import ACzonalmeanParameter
+from e3sm_diags.parameter.area_mean_time_series_parameter import (
+    AreaMeanTimeSeriesParameter,
+)
+from e3sm_diags.parameter.arm_diags_parameter import ARMDiagsParameter
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+from e3sm_diags.parameter.mp_partition_parameter import MPpartitionParameter
+from e3sm_diags.parameter.qbo_parameter import QboParameter
+from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.parameter.zonal_mean_2d_stratosphere_parameter import (
+    ZonalMean2dStratosphereParameter,
+)
+from e3sm_diags.run import runner
+
+
+class MachinePaths(TypedDict):
+    html_path: str
+    obs_climo: str
+    test_climo: str
+    obs_ts: str
+    test_ts: str
+    dc_obs_climo: str
+    dc_test_climo: str
+    arm_obs: str
+    arm_test: str
+    tc_obs: str
+    tc_test: str
+
+
+def run_all_sets():
+    machine_paths: MachinePaths = _get_machine_paths()
+
+    param = CoreParameter()
+
+    param.reference_data_path = machine_paths["obs_climo"]
+    param.test_data_path = machine_paths["test_climo"]
+    param.test_name = "20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis"
+    param.seasons = [
+        "ANN",
+        "JJA",
+    ]  # Default setting: seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+    param.results_dir = "/lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger-complete-run"
+    param.multiprocessing = True
+    param.num_workers = 24
+
+    # Set specific parameters for new sets
+    enso_param = EnsoDiagsParameter()
+    enso_param.reference_data_path = machine_paths["obs_ts"]
+    enso_param.test_data_path = machine_paths["test_ts"]
+    enso_param.test_name = "e3sm_v2"
+    enso_param.test_start_yr = "0051"
+    enso_param.test_end_yr = "0060"
+    # Enso obs data range from year 1979 to 2016
+    enso_param.ref_start_yr = "2001"
+    enso_param.ref_end_yr = "2010"
+
+    qbo_param = QboParameter()
+    qbo_param.reference_data_path = machine_paths["obs_ts"]
+    qbo_param.test_data_path = machine_paths["test_ts"]
+    qbo_param.test_name = "e3sm_v2"
+    qbo_param.start_yr = "0051"
+    qbo_param.end_yr = "0060"
+    # Qbo obs data range from year 1979 to 2019
+    # Number of years of test and ref should match
+    qbo_param.ref_start_yr = "2001"
+    qbo_param.ref_end_yr = "2010"
+
+    ts_param = AreaMeanTimeSeriesParameter()
+    ts_param.reference_data_path = machine_paths["obs_ts"]
+    ts_param.test_data_path = machine_paths["test_ts"]
+    ts_param.test_name = "e3sm_v2"
+    ts_param.start_yr = "0051"
+    ts_param.end_yr = "0060"
+
+    dc_param = DiurnalCycleParameter()
+    dc_param.reference_data_path = machine_paths["dc_obs_climo"]
+    dc_param.test_data_path = machine_paths["dc_test_climo"]
+    dc_param.short_test_name = "e3sm_v2"
+    # Plotting diurnal cycle amplitude on different scales. Default is True
+    dc_param.normalize_test_amp = False
+
+    streamflow_param = StreamflowParameter()
+    streamflow_param.reference_data_path = machine_paths["obs_ts"]
+    streamflow_param.test_data_path = machine_paths["test_ts"]
+    streamflow_param.short_test_name = "e3sm_v2"
+    streamflow_param.test_start_yr = "0051"
+    streamflow_param.test_end_yr = "0060"
+    # Streamflow gauge station data range from year 1986 to 1995
+    streamflow_param.ref_start_yr = "1986"
+    streamflow_param.ref_end_yr = "1995"
+
+    arm_param = ARMDiagsParameter()
+    arm_param.reference_data_path = machine_paths["arm_obs"]
+    arm_param.ref_name = "armdiags"
+    arm_param.test_data_path = machine_paths["arm_test"]
+    arm_param.test_name = "e3sm_v2"
+    # arm_param.test_start_yr = "1996"
+    # arm_param.test_end_yr = "2010"
+    arm_param.test_start_yr = "1985"
+    arm_param.test_end_yr = "2014"
+    # For model vs obs, the ref start and end year can be any four digit strings.
+    # For now, will use all available years form obs
+    arm_param.ref_start_yr = "0001"
+    arm_param.ref_end_yr = "0001"
+
+    tc_param = TCAnalysisParameter()
+    tc_param.reference_data_path = machine_paths["tc_obs"]
+    tc_param.test_data_path = machine_paths["tc_test"]
+    tc_param.short_test_name = "e3sm_v2"
+    tc_param.test_start_yr = "0051"
+    tc_param.test_end_yr = "0060"
+    # For model vs obs, the ref start and end year can be any four digit strings.
+    # For now, use all available years form obs by default.
+    tc_param.ref_start_yr = "1979"
+    tc_param.ref_end_yr = "2018"
+
+    ac_param = ACzonalmeanParameter()
+
+    zm_param = ZonalMean2dStratosphereParameter()
+
+    mp_param = MPpartitionParameter()
+    # mp_param.reference_data_path = machine_paths["obs_ts"]
+    mp_param.test_data_path = machine_paths["test_ts"]
+    mp_param.short_test_name = "e3sm_v2"
+    mp_param.test_start_yr = "0051"
+    mp_param.test_end_yr = "0060"
+
+    param.save_netcdf = True
+    runner.sets_to_run = [
+        "lat_lon",
+        "zonal_mean_xy",
+        "zonal_mean_2d",
+        "zonal_mean_2d_stratosphere",
+        "polar",
+        "cosp_histogram",
+        "meridional_mean_2d",
+        "annual_cycle_zonal_mean",
+        "enso_diags",
+        "qbo",
+        "area_mean_time_series",
+        "diurnal_cycle",
+        "streamflow",
+        "arm_diags",
+        "tc_analysis",
+        "aerosol_aeronet",
+        "aerosol_budget",
+        "mp_partition",
+    ]
+
+    runner.run_diags(
+        [
+            param,
+            zm_param,
+            ac_param,
+            enso_param,
+            qbo_param,
+            ts_param,
+            dc_param,
+            streamflow_param,
+            arm_param,
+            tc_param,
+            mp_param,
+        ]
+    )
+
+    return param.results_dir
+
+
+def _get_machine_paths() -> MachinePaths:
+    """Returns the paths on the machine that are required to run e3sm_diags.
+
+    Returns
+    -------
+    MachinePaths
+        A dictionary of paths on the machine, with the key being the path type
+        and the value being the absolute path string.
+    """
+    # Get the current machine's configuration info.
+    machine_info = MachineInfo()
+    machine = machine_info.machine
+
+    if machine not in [
+        "anvil",
+        "chrysalis",
+        "compy",
+        "pm-cpu",
+        "cori-haswell",
+        "cori-knl",
+    ]:
+        raise ValueError(f"e3sm_diags is not supported on this machine ({machine}).")
+
+    # Path to the HTML outputs for the current user.
+    web_portal_base_path = machine_info.config.get("web_portal", "base_path")
+    html_path = f"{web_portal_base_path}/{machine_info.username}/"
+
+    # Path to the reference data directory.
+    diags_base_path = machine_info.diagnostics_base
+    ref_data_dir = f"{diags_base_path}/observations/Atm"
+
+    # Paths to the test data directories.
+    test_data_dir, test_data_dir2 = _get_test_data_dirs(machine)
+
+    # Construct the paths required by e3sm_diags using the base paths above.
+    machine_paths: MachinePaths = {
+        "html_path": html_path,
+        "obs_climo": f"{ref_data_dir}/climatology",
+        "test_climo": f"{test_data_dir}/climatology/rgr/",
+        "obs_ts": f"{ref_data_dir}/time-series/",
+        "test_ts": f"{test_data_dir}/time-series/rgr/",
+        "dc_obs_climo": f"{ref_data_dir}/climatology",
+        "dc_test_climo": f"{test_data_dir}/diurnal_climatology/rgr",
+        "arm_obs": f"{ref_data_dir}/arm-diags-data/",
+        "arm_test": f"{test_data_dir2}/arm-diags-data/",
+        "tc_obs": f"{ref_data_dir}/tc-analysis/",
+        "tc_test": f"{test_data_dir}/tc-analysis/",
+    }
+
+    return machine_paths
+
+
+def _get_test_data_dirs(machine: str) -> Tuple[str, str]:
+    """Get the directories for test data based on the machine.
+
+    The second path is for using the high frequency grid box output at ARM sites
+    from another simulation when the output is available.
+
+    Parameters
+    ----------
+    machine : str
+        The name of the machine.
+
+    Returns
+    -------
+    Tuple[str, str]
+        A tuple of two strings, each representing a test data directory path.
+    """
+    test_data_dirs = None
+
+    # TODO: Update this function to use `mache` after the directories are updated.
+    if machine in ["chrysalis", "anvil"]:
+        base = "/lcrc/group/e3sm/public_html/e3sm_diags_test_data/postprocessed_e3sm_v2_data_for_e3sm_diags"
+    elif machine in ["compy"]:
+        base = "/compyfs/e3sm_diags_data/postprocessed_e3sm_v2_data_for_e3sm_diags"
+    elif machine in ["cori-haswell", "cori-knl", "pm-cpu"]:
+        base = "/global/cfs/cdirs/e3sm/e3sm_diags/postprocessed_e3sm_v2_data_for_e3sm_diags"
+
+    test_data_dirs = (
+        f"{base}/20210528.v2rc3e.piControl.ne30pg2_EC30to60E2r2.chrysalis",
+        # f"{base}/20210719.PhaseII.F20TR-P3.NGD.ne30pg2.compy",
+        f"{base}/20221103.v2.LR.amip.NGD_v3atm.chrysalis",
+    )
+
+    return test_data_dirs  # type: ignore
+
+
+if __name__ == "__main__":
+    start_time = timeit.default_timer()
+    run_all_sets()
+    end_time = timeit.default_timer()
+    elapsed_time = end_time - start_time
+    print(f"Elapsed time: {elapsed_time} seconds")

--- a/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run.cfg
+++ b/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run.cfg
@@ -1,0 +1,9 @@
+[#]
+sets = ["zonal_mean_2d"]
+case_id = "MERRA2"
+variables = ["T"]
+ref_name = "MERRA2"
+reference_name = "MERRA2 Reanalysis"
+seasons = ["ANN", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "DJF", "MAM", "JJA", "SON"]
+contour_levels = [180,185,190,200,210,220,230,240,250,260,270,280,290,295,300]
+diff_levels = [-7,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,7]

--- a/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run.cfg
+++ b/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run.cfg
@@ -1,9 +1,21 @@
 [#]
-sets = ["zonal_mean_2d"]
-case_id = "MERRA2"
-variables = ["T"]
-ref_name = "MERRA2"
-reference_name = "MERRA2 Reanalysis"
-seasons = ["ANN", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "DJF", "MAM", "JJA", "SON"]
-contour_levels = [180,185,190,200,210,220,230,240,250,260,270,280,290,295,300]
-diff_levels = [-7,-6,-5,-4,-3,-2,-1,1,2,3,4,5,6,7]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["TREFHT"]
+regions = ["land"]
+ref_name = "ERA5"
+reference_name = "ERA5 Reanalysis"
+seasons=["ANN"]
+contour_levels = [-35, -30, -25, -20, -15, -10, -5, 0, 5, 10, 15, 20, 25, 30, 35, 40]
+diff_levels = [-12, -8, -4, -2, -1, -0.5, 0.5, 1, 2, 4, 8, 12]
+
+[#]
+sets = ["lat_lon"]
+case_id = "ERA5"
+variables = ["QREFHT"]
+ref_name = "ERA5_ext"
+reference_name = "ERA5 Reanalysis"
+seasons=["ANN"]
+seasons = ["ANN"]
+contour_levels = [0.2, 0.5, 1, 2.5, 5, 7.5, 10, 12.5, 15, 17.5]
+diff_levels = [-5, -4, -3, -2, -1, -0.25, 0.25, 1, 2, 3, 4, 5]

--- a/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run_script.py
@@ -1,0 +1,137 @@
+import os
+import sys
+
+import numpy
+from e3sm_diags.parameter.core_parameter import CoreParameter
+from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
+from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
+from e3sm_diags.parameter.qbo_parameter import QboParameter
+from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
+from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
+from e3sm_diags.parameter.tropical_subseasonal_parameter import TropicalSubseasonalParameter
+
+
+from e3sm_diags.run import runner
+
+short_name = 'v2.LR.historical_0201'
+test_ts = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/ts/monthly/2yr'
+start_yr = int('1982')
+end_yr = int('1983')
+num_years = end_yr - start_yr + 1
+ref_start_yr = 1980
+
+param = CoreParameter()
+
+# Model
+# param.test_data_path = 'climo'
+param.test_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/clim/2yr"
+param.test_name = 'v2.LR.historical_0201'
+param.short_test_name = short_name
+
+# Ref
+
+# Obs
+param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/climatology/'
+param.save_netcdf = True
+
+# Output dir
+# param.results_dir = 'model_vs_obs_1982-1983'
+param.results_dir = "/lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger"
+
+# Additional settings
+param.run_type = 'model_vs_obs'
+param.diff_title = 'Model - Observations'
+param.output_format = ['png']
+param.output_format_subplot = []
+param.multiprocessing = True
+param.num_workers = 8
+#param.fail_on_incomplete = True
+params = [param]
+
+# Model land
+enso_param = EnsoDiagsParameter()
+enso_param.test_data_path = test_ts
+enso_param.test_name = short_name
+enso_param.test_start_yr = start_yr
+enso_param.test_end_yr = end_yr
+
+# Obs
+enso_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+enso_param.ref_start_yr = ref_start_yr
+enso_param.ref_end_yr = ref_start_yr + 10
+
+params.append(enso_param)
+trop_param = TropicalSubseasonalParameter()
+trop_param.test_data_path = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/180x360_aave/ts/daily/2yr'
+trop_param.test_name = short_name
+trop_param.test_start_yr = f'{start_yr:04}'
+trop_param.test_end_yr = f'{end_yr:04}'
+
+# Obs
+trop_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+trop_param.ref_start_yr = 2001
+trop_param.ref_end_yr = 2010
+
+params.append(trop_param)
+qbo_param = QboParameter()
+qbo_param.test_data_path = test_ts
+qbo_param.test_name = short_name
+qbo_param.test_start_yr = start_yr
+qbo_param.test_end_yr = end_yr
+qbo_param.ref_start_yr = ref_start_yr
+ref_end_yr = ref_start_yr + num_years - 1
+if (ref_end_yr <= 1981):
+  qbo_param.ref_end_yr = ref_end_yr
+else:
+  qbo_param.ref_end_yr = 1981
+
+# Obs
+qbo_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+
+params.append(qbo_param)
+dc_param = DiurnalCycleParameter()
+dc_param.test_data_path = 'climo_diurnal_8xdaily'
+dc_param.short_test_name = short_name
+# Plotting diurnal cycle amplitude on different scales. Default is True
+dc_param.normalize_test_amp = False
+
+# Obs
+dc_param.reference_data_path = '/lcrc/group/e3sm/public_html/e3sm_diags_test_data/unit_test_complete_run/obs/climatology'
+
+params.append(dc_param)
+streamflow_param = StreamflowParameter()
+streamflow_param.test_data_path = '/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/rof/native/ts/monthly/2yr'
+streamflow_param.test_name = short_name
+streamflow_param.test_start_yr = start_yr
+streamflow_param.test_end_yr = end_yr
+
+# Obs
+streamflow_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/time-series/'
+streamflow_param.ref_start_yr = "1986" # Streamflow gauge station data range from year 1986 to 1995
+streamflow_param.ref_end_yr = "1995"
+
+params.append(streamflow_param)
+tc_param = TCAnalysisParameter()
+tc_param.test_data_path = "/lcrc/group/e3sm/ac.forsyth2/zppy_weekly_comprehensive_v2_output/test_pr651_both_commits_20250117/v2.LR.historical_0201/post/atm/tc-analysis_1982_1983"
+tc_param.short_test_name = short_name
+tc_param.test_start_yr = "1982"
+tc_param.test_end_yr = "1983"
+
+# Obs
+tc_param.reference_data_path = '/lcrc/group/e3sm/diagnostics/observations/Atm/tc-analysis/'
+# For model vs obs, the ref start and end year can be any four digit strings
+# For now, use all available years from obs by default
+tc_param.ref_start_yr = "1979"
+tc_param.ref_end_yr = "2018"
+
+params.append(tc_param)
+
+# Run
+cfg_path = "auxiliary_tools/cdat_regression_testing/940-xesmf-diffs/trefht-land/v2_run.cfg"
+sys.argv.extend(["--diags", cfg_path])
+
+# runner.sets_to_run = ['lat_lon', 'zonal_mean_xy', 'zonal_mean_2d', 'polar', 'cosp_histogram', 'meridional_mean_2d', 'annual_cycle_zonal_mean', 'zonal_mean_2d_stratosphere', 'enso_diags', 'qbo', 'diurnal_cycle', 'streamflow', 'tc_analysis', 'tropical_subseasonal', 'aerosol_aeronet', 'aerosol_budget']
+
+runner.sets_to_run = ['lat_lon']
+runner.run_diags(params)
+

--- a/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run_script.py
+++ b/auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run_script.py
@@ -127,7 +127,7 @@ tc_param.ref_end_yr = "2018"
 params.append(tc_param)
 
 # Run
-cfg_path = "auxiliary_tools/cdat_regression_testing/940-xesmf-diffs/trefht-land/v2_run.cfg"
+cfg_path = "auxiliary_tools/cdat_regression_testing/954-root-logger/v2_run.cfg"
 sys.argv.extend(["--diags", cfg_path])
 
 # runner.sets_to_run = ['lat_lon', 'zonal_mean_xy', 'zonal_mean_2d', 'polar', 'cosp_histogram', 'meridional_mean_2d', 'annual_cycle_zonal_mean', 'zonal_mean_2d_stratosphere', 'enso_diags', 'qbo', 'diurnal_cycle', 'streamflow', 'tc_analysis', 'tropical_subseasonal', 'aerosol_aeronet', 'aerosol_budget']

--- a/auxiliary_tools/tropical_subseasonal_diags/tropical_subseasonal_driver.py
+++ b/auxiliary_tools/tropical_subseasonal_diags/tropical_subseasonal_driver.py
@@ -17,10 +17,10 @@ from zwf import zwf_functions as wf
 
 import e3sm_diags
 from e3sm_diags.driver import utils
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot.mp_partition_plot import plot
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Script to compute and plot spectral powers of a subseasonal tropical field in
 #   zonal wavenumber-frequency space.  Both the plot files and files containing the

--- a/auxiliary_tools/tropical_subseasonal_diags/tropical_subseasonal_plot.py
+++ b/auxiliary_tools/tropical_subseasonal_diags/tropical_subseasonal_plot.py
@@ -12,7 +12,7 @@ from matplotlib.colors import BoundaryNorm, ListedColormap
 #from e3sm_diags.plot.utils import _add_colormap, _save_plot
 from zwf import zwf_functions as wf
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
 if TYPE_CHECKING:
@@ -22,19 +22,19 @@ if TYPE_CHECKING:
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Plot title and side title configurations.
 PLOT_TITLE = {"fontsize": 11.5}
 PLOT_SIDE_TITLE = {"fontsize": 9.5}
-        
+
 # Position and sizes of subplot axes in page coordinates (0 to 1)
 PANEL = [
     (0.17, 0.70, 0.50, 0.25),
     (0.17, 0.37, 0.50, 0.25),
     (0.17, 0.04, 0.50, 0.25),
-]       
-        
+]
+
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, right, top) in page coordinates
 BORDER_PADDING = (-0.06, -0.03, 0.13, 0.03)
@@ -49,7 +49,7 @@ CMAP_SPEC_RAW = ["white",
              "lavenderblush"]
 
 CONTOUR_LEVS_SPEC_NORM = (0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.7,1.9,2.1,2.4,2.7,3.0)
-      
+
 CMAP_SPEC_NORM = ["white",
              "gainsboro","lightgray","silver",
              "paleturquoise","skyblue",
@@ -238,7 +238,7 @@ def _wave_frequency_plot(
 
     #fig, ax = plt.subplots()
     ax = fig.add_axes(PANEL[subplot_num])
- 
+
     kmesh0, vmesh0 = np.meshgrid(z['wavenumber'], z['frequency'])
     #img = ax.contourf(kmesh0, vmesh0, z, levels=np.linspace(0.2, 3.0, 16), cmap='Spectral_r',  extend='both')
 
@@ -252,7 +252,7 @@ def _wave_frequency_plot(
             cmapSpecUse, normSpecUse = create_colormap_clevs(CMAP_SPEC_RAW, CONTOUR_LEVS_SPEC_RAW)
         img = ax.contourf(kmesh0, vmesh0, z, levels=contour_level_spec, cmap=cmapSpecUse,  norm=normSpecUse, extend='both')
         img2 = ax.contour(kmesh0, vmesh0, z, levels=contour_level_spec, linewidths=1., linestyles='solid', colors='gray', alpha=0.7)
-    
+
     # for diff ratio
     if subplot_num == 2:
         # TODO refine color bar

--- a/auxiliary_tools/tropical_subseasonal_diags/tropical_subseasonal_viewer.py
+++ b/auxiliary_tools/tropical_subseasonal_diags/tropical_subseasonal_viewer.py
@@ -3,9 +3,9 @@ from typing import Dict, List
 
 from cdp.cdp_viewer import OutputViewer
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def create_viewer(root_dir, parameters):

--- a/e3sm_diags/driver/aerosol_aeronet_driver.py
+++ b/e3sm_diags/driver/aerosol_aeronet_driver.py
@@ -11,7 +11,7 @@ from scipy import interpolate
 
 import e3sm_diags
 from e3sm_diags.driver.utils.dataset_xr import Dataset
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import spatial_avg
 from e3sm_diags.plot import aerosol_aeronet_plot
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter
 
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # This aerosol diagnostics scripts based on AERONET sites data was originally developed by Feng Yan and adapted and integrated in e3sm_diags by Jill Zhang.
 # Years include 2006–2015 average climatology for observation according to Feng et al. 2022:doi:10.1002/essoar.10510950.1, and Golaz et al. 2022 E3SMv2 paper.

--- a/e3sm_diags/driver/aerosol_budget_driver.py
+++ b/e3sm_diags/driver/aerosol_budget_driver.py
@@ -21,13 +21,13 @@ from e3sm_diags.driver.utils.dataset_xr import Dataset
 from e3sm_diags.driver.utils.io import _get_output_dir
 from e3sm_diags.driver.utils.regrid import _hybrid_to_pressure
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter
 
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # km units
 REARTH = 6.37122e6

--- a/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
+++ b/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
@@ -8,11 +8,11 @@ import xcdat as xc
 from e3sm_diags.driver.utils.dataset_xr import Dataset
 from e3sm_diags.driver.utils.io import _save_data_metrics_and_plots
 from e3sm_diags.driver.utils.regrid import align_grids_to_lower_res, has_z_axis
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import spatial_avg
 from e3sm_diags.plot.annual_cycle_zonal_mean_plot import plot as plot_func
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter

--- a/e3sm_diags/driver/area_mean_time_series_driver.py
+++ b/e3sm_diags/driver/area_mean_time_series_driver.py
@@ -11,7 +11,7 @@ from e3sm_diags.driver import LAND_OCEAN_MASK_PATH
 from e3sm_diags.driver.utils.dataset_xr import Dataset, squeeze_time_dim
 from e3sm_diags.driver.utils.io import _get_output_dir, _write_to_netcdf
 from e3sm_diags.driver.utils.regrid import _apply_land_sea_mask, _subset_on_region
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import spatial_avg
 from e3sm_diags.plot import area_mean_time_series_plot
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     )
 
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 class RefsTestMetrics(NamedTuple):

--- a/e3sm_diags/driver/arm_diags_driver.py
+++ b/e3sm_diags/driver/arm_diags_driver.py
@@ -15,13 +15,13 @@ from e3sm_diags.driver.utils.dataset_xr import Dataset
 from e3sm_diags.driver.utils.diurnal_cycle_xr import composite_diurnal_cycle
 from e3sm_diags.driver.utils.io import _get_output_dir
 from e3sm_diags.driver.utils.regrid import has_z_axis, regrid_z_axis_to_plevs
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot import arm_diags_plot
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.arm_diags_parameter import ARMDiagsParameter
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 RefsTestMetrics = collections.namedtuple(
     "RefsTestMetrics", ["refs", "test", "metrics", "misc"]

--- a/e3sm_diags/driver/cosp_histogram_driver.py
+++ b/e3sm_diags/driver/cosp_histogram_driver.py
@@ -7,14 +7,14 @@ import xarray as xr
 from e3sm_diags.driver.utils.dataset_xr import Dataset
 from e3sm_diags.driver.utils.io import _save_data_metrics_and_plots
 from e3sm_diags.driver.utils.regrid import _subset_on_region
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import spatial_avg
 from e3sm_diags.plot.cosp_histogram_plot import plot as plot_func
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def run_diag(parameter: CoreParameter) -> CoreParameter:

--- a/e3sm_diags/driver/diurnal_cycle_driver.py
+++ b/e3sm_diags/driver/diurnal_cycle_driver.py
@@ -8,10 +8,10 @@ from e3sm_diags.driver.utils.dataset_xr import Dataset
 from e3sm_diags.driver.utils.diurnal_cycle_xr import composite_diurnal_cycle
 from e3sm_diags.driver.utils.io import _get_output_filename_filepath
 from e3sm_diags.driver.utils.regrid import _apply_land_sea_mask, _subset_on_region
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot.diurnal_cycle_plot import plot as plot_func
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter

--- a/e3sm_diags/driver/enso_diags_driver.py
+++ b/e3sm_diags/driver/enso_diags_driver.py
@@ -16,7 +16,7 @@ from e3sm_diags.driver.utils.io import (
     _write_vars_to_netcdf,
 )
 from e3sm_diags.driver.utils.regrid import _subset_on_region, align_grids_to_lower_res
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import correlation, rmse, spatial_avg, std
 from e3sm_diags.plot.enso_diags_plot import plot_map, plot_scatter
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
 
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 class MetricsDictScatter(TypedDict):

--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -16,11 +16,11 @@ from e3sm_diags.driver.utils.regrid import (
     subset_and_align_datasets,
 )
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import correlation, rmse, spatial_avg, std
 from e3sm_diags.plot.lat_lon_plot import plot as plot_func
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter

--- a/e3sm_diags/driver/meridional_mean_2d_driver.py
+++ b/e3sm_diags/driver/meridional_mean_2d_driver.py
@@ -14,12 +14,12 @@ from e3sm_diags.driver.utils.regrid import (
     regrid_z_axis_to_plevs,
 )
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import correlation, rmse, spatial_avg
 from e3sm_diags.parameter.zonal_mean_2d_parameter import DEFAULT_PLEVS
 from e3sm_diags.plot.meridional_mean_2d_plot import plot as plot_func
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.meridional_mean_2d_parameter import (

--- a/e3sm_diags/driver/mp_partition_driver.py
+++ b/e3sm_diags/driver/mp_partition_driver.py
@@ -18,14 +18,14 @@ from scipy.stats import binned_statistic
 
 from e3sm_diags import INSTALL_PATH
 from e3sm_diags.driver.utils.dataset_xr import Dataset
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot.mp_partition_plot import plot
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.mp_partition_parameter import MPpartitionParameter
 
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def flatten_array(var):

--- a/e3sm_diags/driver/polar_driver.py
+++ b/e3sm_diags/driver/polar_driver.py
@@ -13,11 +13,11 @@ from e3sm_diags.driver.utils.regrid import (
     subset_and_align_datasets,
 )
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import correlation, rmse, spatial_avg
 from e3sm_diags.plot.polar_plot import plot as plot_func
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter

--- a/e3sm_diags/driver/qbo_driver.py
+++ b/e3sm_diags/driver/qbo_driver.py
@@ -14,12 +14,12 @@ from scipy.signal import detrend
 from e3sm_diags.driver.utils.dataset_xr import Dataset
 from e3sm_diags.driver.utils.io import _get_output_dir, _write_to_netcdf
 from e3sm_diags.driver.utils.regrid import _subset_on_region
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import spatial_avg
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.qbo_plot import plot
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.qbo_parameter import QboParameter

--- a/e3sm_diags/driver/streamflow_driver.py
+++ b/e3sm_diags/driver/streamflow_driver.py
@@ -9,12 +9,12 @@ import xarray as xr
 import xcdat as xc
 
 from e3sm_diags.driver.utils.dataset_xr import Dataset
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot.streamflow_plot_map import plot_annual_map
 from e3sm_diags.plot.streamflow_plot_scatter import plot_annual_scatter
 from e3sm_diags.plot.streamflow_plot_seasonality import plot_seasonality_map
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter

--- a/e3sm_diags/driver/tc_analysis_driver.py
+++ b/e3sm_diags/driver/tc_analysis_driver.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
 
     from e3sm_diags.parameter.tc_analysis_parameter import TCAnalysisParameter
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Years include 1979–2018 according to Balaguru et al. 2020
 OBS_START_YR = 1979

--- a/e3sm_diags/driver/tropical_subseasonal_driver.py
+++ b/e3sm_diags/driver/tropical_subseasonal_driver.py
@@ -18,7 +18,7 @@ import xarray as xr
 from e3sm_diags.driver.utils import zwf_functions as wf
 from e3sm_diags.driver.utils.climo_xr import ClimoFreq
 from e3sm_diags.driver.utils.dataset_xr import Dataset
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot.tropical_subseasonal_plot import plot
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     )
 
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def run_diag(parameter: TropicalSubseasonalParameter) -> TropicalSubseasonalParameter:

--- a/e3sm_diags/driver/utils/climo_xr.py
+++ b/e3sm_diags/driver/utils/climo_xr.py
@@ -10,9 +10,9 @@ import numpy.ma as ma
 import xarray as xr
 import xcdat as xc
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # A type annotation and list representing accepted climatology frequencies.
 # Accepted frequencies include the month integer and season string.

--- a/e3sm_diags/driver/utils/dataset_xr.py
+++ b/e3sm_diags/driver/utils/dataset_xr.py
@@ -32,12 +32,12 @@ from e3sm_diags.derivations.derivations import (
 from e3sm_diags.driver import FRAC_REGION_KEYS, LAND_OCEAN_MASK_PATH
 from e3sm_diags.driver.utils.climo_xr import CLIMO_FREQS, ClimoFreq, climo
 from e3sm_diags.driver.utils.regrid import HYBRID_SIGMA_KEYS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # A constant variable that defines the pattern for time series filenames.
 # Example: "ts_global_200001_200112.nc" (<VAR>_<SITE>_<TS_EXT_FILEPATTERN>)

--- a/e3sm_diags/driver/utils/diurnal_cycle_xr.py
+++ b/e3sm_diags/driver/utils/diurnal_cycle_xr.py
@@ -8,9 +8,9 @@ import xarray as xr
 import xcdat as xc
 
 from e3sm_diags.driver.utils.climo_xr import CLIMO_CYCLE_MAP, ClimoFreq
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 SEASON_IDX = {
     "01": [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/e3sm_diags/driver/utils/general.py
+++ b/e3sm_diags/driver/utils/general.py
@@ -1,6 +1,6 @@
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def monotonic(L):

--- a/e3sm_diags/driver/utils/io.py
+++ b/e3sm_diags/driver/utils/io.py
@@ -8,10 +8,10 @@ from typing import Any, Callable, Dict, Literal
 import xarray as xr
 
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def _save_data_metrics_and_plots(

--- a/e3sm_diags/driver/utils/regrid.py
+++ b/e3sm_diags/driver/utils/regrid.py
@@ -8,12 +8,12 @@ import xcdat as xc
 
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
 from e3sm_diags.driver import FRAC_REGION_KEYS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 # Valid hybrid-sigma levels keys that can be found in datasets.

--- a/e3sm_diags/driver/zonal_mean_2d_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_driver.py
@@ -12,7 +12,7 @@ from e3sm_diags.driver.utils.regrid import (
     regrid_z_axis_to_plevs,
 )
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import correlation, rmse, spatial_avg
 from e3sm_diags.parameter.zonal_mean_2d_parameter import (
     DEFAULT_PLEVS,
@@ -20,7 +20,7 @@ from e3sm_diags.parameter.zonal_mean_2d_parameter import (
 )
 from e3sm_diags.plot.zonal_mean_2d_plot import plot as plot_func
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 DEFAULT_PLEVS = copy.deepcopy(DEFAULT_PLEVS)
 

--- a/e3sm_diags/driver/zonal_mean_xy_driver.py
+++ b/e3sm_diags/driver/zonal_mean_xy_driver.py
@@ -13,11 +13,11 @@ from e3sm_diags.driver.utils.regrid import (
     has_z_axis,
     regrid_z_axis_to_plevs,
 )
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.metrics.metrics import spatial_avg
 from e3sm_diags.plot.zonal_mean_xy_plot import plot as plot_func
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.parameter.core_parameter import CoreParameter

--- a/e3sm_diags/e3sm_diags_driver.py
+++ b/e3sm_diags/e3sm_diags_driver.py
@@ -11,13 +11,13 @@ import dask
 import dask.bag as db
 
 import e3sm_diags
-from e3sm_diags.logger import LOG_FILENAME, custom_logger
+from e3sm_diags.logger import LOG_FILENAME, _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.parser import SET_TO_PARSER
 from e3sm_diags.parser.core_parser import CoreParser
 from e3sm_diags.viewer.main import create_viewer
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 class ProvPaths(TypedDict):

--- a/e3sm_diags/logger.py
+++ b/e3sm_diags/logger.py
@@ -37,12 +37,10 @@ console_handler.setFormatter(logging.Formatter(LOG_FORMAT))
 logging.getLogger().addHandler(console_handler)
 
 
-def custom_logger(name: str, propagate: bool = True) -> logging.Logger:
-    """Sets up a custom logger that is a child of the root logger.
+def _setup_child_logger(name: str, propagate: bool = True) -> logging.Logger:
+    """Sets up a logger that is a child of the root logger.
 
-    This custom logger inherits the root logger's handlers.
-
-
+    This child logger inherits the root logger's handlers.
 
     Parameters
     ----------

--- a/e3sm_diags/logger.py
+++ b/e3sm_diags/logger.py
@@ -2,8 +2,6 @@
 
 import logging
 import logging.handlers
-import os
-import shutil
 
 LOG_FILENAME = "e3sm_diags_run.log"
 LOG_FORMAT = (
@@ -12,29 +10,35 @@ LOG_FORMAT = (
 LOG_FILEMODE = "w"
 LOG_LEVEL = logging.INFO
 
-
-# Setup the root logger with a default log file.
-# `force` is set to `True` to automatically remove root handlers whenever
-# `basicConfig` called. This is required for cases where multiple e3sm_diags
-# runs are executed. Otherwise, the logger objects attempt to share the same
-# root file reference (which gets deleted between runs), resulting in
-# `FileNotFoundError: [Errno 2] No such file or directory: 'e3sm_diags_run.log'`.
-# More info here: https://stackoverflow.com/a/49202811
-logging.basicConfig(
-    format=LOG_FORMAT,
-    filename=LOG_FILENAME,
-    filemode=LOG_FILEMODE,
-    level=LOG_LEVEL,
-    force=True,
-)
-logging.captureWarnings(True)
-
 # Add a console handler to display warnings in the console. This is useful
 # for when other package loggers raise warnings (e.g, NumPy, Xarray).
 console_handler = logging.StreamHandler()
 console_handler.setLevel(logging.INFO)
 console_handler.setFormatter(logging.Formatter(LOG_FORMAT))
 logging.getLogger().addHandler(console_handler)
+
+
+def _setup_root_logger():
+    """Configures the root logger.
+
+    This function sets up the root logger with a predefined format and log level.
+    It also enables capturing of warnings issued by the `warnings` module and
+    redirects them to the logging system.
+
+    Notes
+    -----
+    - The `force=True` parameter ensures that any existing logging configuration
+      is overridden.
+    - The file handler is added dynamically to the root logger later in the
+      ``Run`` class once the log file path is known.
+    """
+    logging.basicConfig(
+        format=LOG_FORMAT,
+        level=LOG_LEVEL,
+        force=True,
+    )
+
+    logging.captureWarnings(True)
 
 
 def _setup_child_logger(name: str, propagate: bool = True) -> logging.Logger:
@@ -89,49 +93,22 @@ def _setup_child_logger(name: str, propagate: bool = True) -> logging.Logger:
     return logger
 
 
-def _update_root_logger_filepath_to_prov_dir(log_path: str):
-    """Updates the log file path to the provenance directory.
+def _add_filehandler(log_path: str):
+    """Adds a file handler to the root logger dynamically.
 
-    This method changes the log file path to a subdirectory named 'prov'
-    within the given results directory. It updates the filename of the
-    existing file handler to the new path.
+    Adding the file handler will also create the log file automatically.
 
     Parameters
     ----------
     log_path : str
-        The path to the log file, which is stored in the `results_dir`
-        sub-directory called "prov".
+        The path to the log file.
 
     Notes
     -----
-    - The method assumes that a logging file handler is already configured.
-    - The log file is closed and reopened at the new location.
-    - The log file mode is determined by the constant `LOG_FILEMODE`.
-    - The log file name is determined by the constant `LOG_FILENAME`.
+    Any warnings that appear before the log filehandler is instantiated will not
+    be captured (e.g,. esmpy VersionWarning). However, they will still be
+    captured by the console via the default StreamHandler.
     """
-    for handler in logging.root.handlers:
-        if isinstance(handler, logging.FileHandler):
-            handler.baseFilename = log_path
-            handler.stream.close()
-            handler.stream = open(log_path, LOG_FILEMODE)  # type: ignore
-            break
-
-
-def move_log_to_prov_dir(results_dir: str, logger: logging.Logger):
-    """Moves the e3sm diags log file to the provenance directory.
-
-    This function should be called at the end of the diagnostic run to capture
-    all console outputs.
-
-    Parameters
-    ----------
-    results_dir : str
-        The results directory for the run.
-    """
-    provenance_dir = f"{results_dir}/prov/{LOG_FILENAME}"
-
-    # Must copy and then delete because shutil.move does not work if different
-    # filesystems are used for the source and destination directories.
-    shutil.copy(LOG_FILENAME, provenance_dir)
-    os.remove(LOG_FILENAME)
-    logger.info(f"Log file saved in {provenance_dir}")
+    file_handler = logging.FileHandler(log_path, mode=LOG_FILEMODE)
+    file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    logging.root.addHandler(file_handler)

--- a/e3sm_diags/metrics/metrics.py
+++ b/e3sm_diags/metrics/metrics.py
@@ -9,9 +9,9 @@ import xarray as xr
 import xcdat as xc
 import xskillscore as xs
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 Axis = Literal["X", "Y", "Z"]
 DEFAULT_AXIS: List[Axis] = ["X", "Y"]

--- a/e3sm_diags/parameter/area_mean_time_series_parameter.py
+++ b/e3sm_diags/parameter/area_mean_time_series_parameter.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
 from .core_parameter import CoreParameter
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 class AreaMeanTimeSeriesParameter(CoreParameter):

--- a/e3sm_diags/parameter/core_parameter.py
+++ b/e3sm_diags/parameter/core_parameter.py
@@ -10,9 +10,9 @@ import numpy as np
 from e3sm_diags.derivations.derivations import DerivedVariablesMap
 from e3sm_diags.driver.utils.climo_xr import ClimoFreq
 from e3sm_diags.driver.utils.regrid import REGRID_TOOLS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # FIXME: There is probably a better way of defining default sets because most of
 # this is repeated in SETS_TO_PARAMETERS and SETS_TO_PARSERS.

--- a/e3sm_diags/plot/aerosol_aeronet_plot.py
+++ b/e3sm_diags/plot/aerosol_aeronet_plot.py
@@ -3,7 +3,7 @@ import numpy as np
 import xarray as xr
 
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.lat_lon_plot import _add_colormap
 from e3sm_diags.plot.utils import _save_plot
@@ -11,7 +11,7 @@ from e3sm_diags.plot.utils import _save_plot
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Plot scatter plot
 # Position and sizes of subplot axes in page coordinates (0 to 1)

--- a/e3sm_diags/plot/annual_cycle_zonal_mean_plot.py
+++ b/e3sm_diags/plot/annual_cycle_zonal_mean_plot.py
@@ -6,7 +6,7 @@ import xarray as xr
 import xcdat as xc
 from cartopy.mpl.ticker import LatitudeFormatter
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.utils import (
     DEFAULT_PANEL_CFG,
@@ -20,7 +20,7 @@ from e3sm_diags.plot.utils import (
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 # Configs for x axis ticks and x axis limits.

--- a/e3sm_diags/plot/area_mean_time_series_plot.py
+++ b/e3sm_diags/plot/area_mean_time_series_plot.py
@@ -6,7 +6,7 @@ import matplotlib
 import numpy as np
 import xarray as xr
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.area_mean_time_series_parameter import (
     AreaMeanTimeSeriesParameter,
 )
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 matplotlib.use("agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Data is a list based on the len of the regions parameter. Each element is a
 # tuple (test data, ref data and metrics) for that region.

--- a/e3sm_diags/plot/arm_diags_plot.py
+++ b/e3sm_diags/plot/arm_diags_plot.py
@@ -11,14 +11,14 @@ from matplotlib.gridspec import GridSpec
 
 from e3sm_diags.driver.utils.diurnal_cycle_xr import _fft_all_grid
 from e3sm_diags.driver.utils.io import _get_output_dir
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.arm_diags_parameter import ARMDiagsParameter
 
 matplotlib.use("agg")
 
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 if TYPE_CHECKING:
     from e3sm_diags.driver.arm_diags_driver import RefsTestMetrics

--- a/e3sm_diags/plot/colormaps/rewrite_from_colorcet.py
+++ b/e3sm_diags/plot/colormaps/rewrite_from_colorcet.py
@@ -1,6 +1,6 @@
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 try:
     import colorcet

--- a/e3sm_diags/plot/cosp_histogram_plot.py
+++ b/e3sm_diags/plot/cosp_histogram_plot.py
@@ -4,7 +4,7 @@ import matplotlib
 import numpy as np
 import xarray as xr
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.utils import _get_colormap, _save_plot
 
@@ -12,7 +12,7 @@ matplotlib.use("Agg")
 import matplotlib.colors as colors  # isort:skip  # noqa: E402
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 MAIN_TITLE_FONT = 11.5
 SECONDARY_TITLE_FONT = 9.5

--- a/e3sm_diags/plot/diurnal_cycle_plot.py
+++ b/e3sm_diags/plot/diurnal_cycle_plot.py
@@ -9,7 +9,7 @@ import xcdat as xc
 from matplotlib.colors import hsv_to_rgb
 
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.diurnal_cycle_parameter import DiurnalCycleParameter
 from e3sm_diags.plot.utils import (
     _configure_titles,
@@ -19,7 +19,7 @@ from e3sm_diags.plot.utils import (
     _save_plot,
 )
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 matplotlib.use("Agg")  # noqa: E402
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402

--- a/e3sm_diags/plot/enso_diags_plot.py
+++ b/e3sm_diags/plot/enso_diags_plot.py
@@ -10,7 +10,7 @@ import xcdat as xc
 from numpy.polynomial.polynomial import polyfit
 
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.enso_diags_parameter import EnsoDiagsParameter
 from e3sm_diags.plot.utils import (
     DEFAULT_PANEL_CFG,
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
         MetricsSubDict,
     )
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Use 179.99 as central longitude due to https://github.com/SciTools/cartopy/issues/946
 PROJECTION = ccrs.PlateCarree(central_longitude=179.99)

--- a/e3sm_diags/plot/lat_lon_plot.py
+++ b/e3sm_diags/plot/lat_lon_plot.py
@@ -9,7 +9,7 @@ import xarray as xr
 import xcdat as xc
 
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.utils import (
     DEFAULT_PANEL_CFG,
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def plot(

--- a/e3sm_diags/plot/meridional_mean_2d_plot.py
+++ b/e3sm_diags/plot/meridional_mean_2d_plot.py
@@ -5,7 +5,7 @@ import xarray as xr
 import xcdat as xc
 
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.utils import (
     DEFAULT_PANEL_CFG,
@@ -22,7 +22,7 @@ from e3sm_diags.plot.utils import (
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def plot(

--- a/e3sm_diags/plot/mp_partition_plot.py
+++ b/e3sm_diags/plot/mp_partition_plot.py
@@ -3,12 +3,12 @@ import os
 import matplotlib
 
 from e3sm_diags.driver.utils.io import _get_output_dir
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 plotTitle = {"fontsize": 11.5}
 plotSideTitle = {"fontsize": 9.5}

--- a/e3sm_diags/plot/polar_plot.py
+++ b/e3sm_diags/plot/polar_plot.py
@@ -8,7 +8,7 @@ import xarray as xr
 import xcdat as xc
 
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.utils import (
     _add_colorbar,
@@ -24,7 +24,7 @@ from e3sm_diags.plot.utils import (
 matplotlib.use("Agg")
 import matplotlib.path as mpath  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 PLOT_SECONDARY_TITLE = 9.0
 

--- a/e3sm_diags/plot/qbo_plot.py
+++ b/e3sm_diags/plot/qbo_plot.py
@@ -6,14 +6,14 @@ import matplotlib
 import numpy as np
 import xcdat as xc
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.qbo_parameter import QboParameter
 from e3sm_diags.plot.utils import _save_plot
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 PANEL_CFG = [
     (0.075, 0.75, 0.6, 0.175),

--- a/e3sm_diags/plot/streamflow_plot_map.py
+++ b/e3sm_diags/plot/streamflow_plot_map.py
@@ -6,7 +6,7 @@ import matplotlib
 import numpy as np
 
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
 from e3sm_diags.plot.utils import (
     _configure_titles,
@@ -20,7 +20,7 @@ matplotlib.use("Agg")
 import matplotlib.colors as colors  # isort:skip  # noqa: E402
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, width, height) in page coordinates.

--- a/e3sm_diags/plot/streamflow_plot_scatter.py
+++ b/e3sm_diags/plot/streamflow_plot_scatter.py
@@ -2,14 +2,14 @@ import matplotlib
 import numpy as np
 import scipy.stats
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
 from e3sm_diags.plot.utils import _save_plot
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Position and sizes of subplot axes in page coordinates (0 to 1)
 # (left, bottom, width, height) in page coordinates

--- a/e3sm_diags/plot/streamflow_plot_seasonality.py
+++ b/e3sm_diags/plot/streamflow_plot_seasonality.py
@@ -4,7 +4,7 @@ import matplotlib
 import numpy as np
 
 from e3sm_diags.derivations.default_regions_xr import REGION_SPECS
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.streamflow_parameter import StreamflowParameter
 from e3sm_diags.plot.utils import (
     _configure_titles,
@@ -19,7 +19,7 @@ import matplotlib.colors as colors  # isort:skip  # noqa: E402
 import matplotlib.lines as lines  # isort:skip  # noqa: E402
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, width, height) in page coordinates

--- a/e3sm_diags/plot/tc_analysis_plot.py
+++ b/e3sm_diags/plot/tc_analysis_plot.py
@@ -8,13 +8,13 @@ import xcdat as xc
 from cartopy.mpl.ticker import LatitudeFormatter, LongitudeFormatter
 
 from e3sm_diags.driver.utils.io import _get_output_dir
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot.utils import MAIN_TITLE_FONTSIZE
 
 matplotlib.use("agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 # Position and sizes of subplot axes in page coordinates (0 to 1)

--- a/e3sm_diags/plot/tropical_subseasonal_plot.py
+++ b/e3sm_diags/plot/tropical_subseasonal_plot.py
@@ -9,13 +9,13 @@ from matplotlib.colors import BoundaryNorm, ListedColormap
 
 from e3sm_diags.driver.utils import zwf_functions as wf
 from e3sm_diags.driver.utils.io import _get_output_dir
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Plot title and side title configurations.
 PLOT_TITLE = {"fontsize": 11.5}

--- a/e3sm_diags/plot/utils.py
+++ b/e3sm_diags/plot/utils.py
@@ -14,14 +14,14 @@ from matplotlib.transforms import Bbox
 
 from e3sm_diags import INSTALL_PATH
 from e3sm_diags.driver.utils.io import _get_output_dir
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
 matplotlib.use("Agg")
 from matplotlib import colors  # isort:skip  # noqa: E402
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Plot title and side title configurations.
 MAIN_TITLE_FONTSIZE = 11.5

--- a/e3sm_diags/plot/zonal_mean_2d_plot.py
+++ b/e3sm_diags/plot/zonal_mean_2d_plot.py
@@ -6,7 +6,7 @@ import xarray as xr
 import xcdat as xc
 
 from e3sm_diags.driver.utils.type_annotations import MetricsDict
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.parameter.zonal_mean_2d_parameter import DEFAULT_PLEVS
 from e3sm_diags.plot.utils import (
@@ -24,7 +24,7 @@ from e3sm_diags.plot.utils import (
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 # Configs for x axis ticks and x axis limits.

--- a/e3sm_diags/plot/zonal_mean_xy_plot.py
+++ b/e3sm_diags/plot/zonal_mean_xy_plot.py
@@ -2,14 +2,14 @@ import matplotlib
 import xarray as xr
 import xcdat as xc
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 from e3sm_diags.plot.utils import _save_plot
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # Plot title and side title configurations.
 PLOT_TITLE = {"fontsize": 12.5}

--- a/e3sm_diags/run.py
+++ b/e3sm_diags/run.py
@@ -8,16 +8,18 @@ import e3sm_diags  # noqa: F401
 from e3sm_diags.e3sm_diags_driver import get_default_diags_path, main
 from e3sm_diags.logger import (
     LOG_FILENAME,
-    _update_root_logger_filepath_to_prov_dir,
-    custom_logger,
+    _add_filehandler,
+    _setup_root_logger,
+    _setup_child_logger,
 )
 from e3sm_diags.parameter import SET_TO_PARAMETERS
 from e3sm_diags.parameter.core_parameter import DEFAULT_SETS, CoreParameter
 from e3sm_diags.parser.core_parser import CoreParser
 
-# Set up a module level logger object. This logger object is a child of the
-# root logger.
-logger = custom_logger(__name__)
+# Set up the root logger and module level logger. The module level logger is
+# a child of the root logger.
+_setup_root_logger()
+logger = _setup_child_logger(__name__)
 
 
 class Run:
@@ -92,7 +94,7 @@ class Run:
         pathlib.Path(prov_dir).mkdir(parents=True, exist_ok=True)
 
         log_dir = os.path.join(prov_dir, LOG_FILENAME)
-        _update_root_logger_filepath_to_prov_dir(log_dir)
+        _add_filehandler(log_dir)
 
         if params is None or len(params) == 0:
             raise RuntimeError(

--- a/e3sm_diags/run.py
+++ b/e3sm_diags/run.py
@@ -9,8 +9,8 @@ from e3sm_diags.e3sm_diags_driver import get_default_diags_path, main
 from e3sm_diags.logger import (
     LOG_FILENAME,
     _add_filehandler,
-    _setup_root_logger,
     _setup_child_logger,
+    _setup_root_logger,
 )
 from e3sm_diags.parameter import SET_TO_PARAMETERS
 from e3sm_diags.parameter.core_parameter import DEFAULT_SETS, CoreParameter

--- a/e3sm_diags/viewer/default_viewer.py
+++ b/e3sm_diags/viewer/default_viewer.py
@@ -11,13 +11,13 @@ from typing import Dict
 
 import numpy
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parser import SET_TO_PARSER
 from e3sm_diags.viewer.core_viewer import OutputViewer
 
 from . import lat_lon_viewer, utils
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 # A dictionary of the sets to a better name which
 # is displayed in the viewer.
 # These are all of the sets that this viewer supports.

--- a/e3sm_diags/viewer/enso_diags_viewer.py
+++ b/e3sm_diags/viewer/enso_diags_viewer.py
@@ -1,13 +1,13 @@
 import os
 from typing import Dict, List
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.viewer.core_viewer import OutputViewer
 
 from .default_viewer import create_metadata
 from .utils import add_header, h1_to_h3
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def create_viewer(root_dir, parameters):

--- a/e3sm_diags/viewer/lat_lon_viewer.py
+++ b/e3sm_diags/viewer/lat_lon_viewer.py
@@ -14,12 +14,12 @@ import numpy.ma as ma
 from bs4 import BeautifulSoup
 
 import e3sm_diags
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.plot.taylor_diagram import TaylorDiagram
 
 from . import utils
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # isort:skip  # noqa: E402

--- a/e3sm_diags/viewer/main.py
+++ b/e3sm_diags/viewer/main.py
@@ -5,7 +5,7 @@ from typing import List
 from bs4 import BeautifulSoup
 
 import e3sm_diags
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
 from . import (
@@ -24,7 +24,7 @@ from . import (
     utils,
 )
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 # A mapping of each diagnostics set to the viewer
 # that handles creating of the HTML pages.

--- a/e3sm_diags/viewer/mp_partition_viewer.py
+++ b/e3sm_diags/viewer/mp_partition_viewer.py
@@ -1,12 +1,12 @@
 import os
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.viewer.core_viewer import OutputViewer
 
 from .default_viewer import create_metadata
 from .utils import add_header, h1_to_h3
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def create_viewer(root_dir, parameters):

--- a/e3sm_diags/viewer/qbo_viewer.py
+++ b/e3sm_diags/viewer/qbo_viewer.py
@@ -1,12 +1,12 @@
 import os
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.viewer.core_viewer import OutputViewer
 
 from .default_viewer import create_metadata
 from .utils import add_header, h1_to_h3
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def create_viewer(root_dir, parameters):

--- a/e3sm_diags/viewer/tropical_subseasonal_viewer.py
+++ b/e3sm_diags/viewer/tropical_subseasonal_viewer.py
@@ -1,11 +1,11 @@
 import os
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.viewer.core_viewer import OutputViewer
 from e3sm_diags.viewer.default_viewer import create_metadata
 from e3sm_diags.viewer.utils import add_header, h1_to_h3
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def create_viewer(root_dir, parameters):

--- a/tests/e3sm_diags/test_e3sm_diags_driver.py
+++ b/tests/e3sm_diags/test_e3sm_diags_driver.py
@@ -1,10 +1,10 @@
 import pytest
 
 from e3sm_diags.e3sm_diags_driver import _run_serially, _run_with_dask
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter.core_parameter import CoreParameter
 
-logger = custom_logger("e3sm_diags.e3sm_diags_driver", propagate=True)
+logger = _setup_child_logger("e3sm_diags.e3sm_diags_driver", propagate=True)
 
 
 class TestRunDiag:

--- a/tests/integration/test_all_sets_image_diffs.py
+++ b/tests/integration/test_all_sets_image_diffs.py
@@ -5,7 +5,7 @@ from typing import List
 
 import pytest
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.run import runner
 from tests.integration.config import TEST_IMAGES_PATH, TEST_ROOT_PATH
 from tests.integration.utils import _compare_images, _get_test_params
@@ -13,7 +13,7 @@ from tests.integration.utils import _compare_images, _get_test_params
 CFG_PATH = os.path.join(TEST_ROOT_PATH, "all_sets.cfg")
 
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -7,7 +7,7 @@ from typing import List
 
 from PIL import Image, ImageChops, ImageDraw
 
-from e3sm_diags.logger import custom_logger
+from e3sm_diags.logger import _setup_child_logger
 from e3sm_diags.parameter import SET_TO_PARAMETERS
 from e3sm_diags.parameter.area_mean_time_series_parameter import (
     AreaMeanTimeSeriesParameter,
@@ -18,7 +18,7 @@ from e3sm_diags.parameter.meridional_mean_2d_parameter import MeridionalMean2dPa
 from e3sm_diags.parameter.zonal_mean_2d_parameter import ZonalMean2dParameter
 from tests.integration.config import TEST_ROOT_PATH
 
-logger = custom_logger(__name__)
+logger = _setup_child_logger(__name__)
 
 
 def run_cmd_and_pipe_stderr(command: str) -> List[str]:


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

- Closes #954 
- Instantiate root logger via a function (`_setup_root_logger()`) instead of at the module level
  - Although I found no repeated messages in the current logging system, instantiating the root logger through a function call rather than on every `import logger` should prevent duplicate messages from possible multiple instantiations of a root logger (via `logging.basicConfig(...)`)
- Rename `_setup_logger` to `_setup_child_logger()` for clarity of purpose
- Instantiate a logger `FileHandler` via `_add_filehandler()`
  - Remove `_update_root_logger_filepath_to_prov_dir()` because `_add_filehandler()` handles setting the log path to the `/prov` dir

💡 **Caveat**: Warnings raised during import (e.g., `esmpy` version warnings) will still appear in the console but won’t be captured in log files until `_add_filehandler()` is called. This trade-off enables dynamic log file paths and prevents duplicate log file creation.

## Examples

[Example ](https://web.lcrc.anl.gov/public/e3sm/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/e3sm_diags_run.log)log file:
```python
2025-03-19 16:49:03,675 [INFO]: e3sm_diags_driver.py(_log_diagnostic_run_info:527) >> 
================================================================================
E3SM Diagnostics Run
--------------------
Timestamp: 2025-03-19 16:49:03
Version Info: branch feature/954-root-logger with commit d18559fd6d4368fddfee2fc0e649c5f6173e2003
Results Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger
Log Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/e3sm_diags_run.log
Parameter Files Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/v2_run.cfg
Python Script Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/v2_run_script.py
Environment YML Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/environment.yml
Provenance Index HTML Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/index.html
================================================================================

2025-03-19 16:49:07,992 [INFO]: lat_lon_driver.py(run_diag:69) >> Variable: QREFHT
2025-03-19 16:49:09,276 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('QREFHT',)
2025-03-19 16:49:09,800 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('d2m', 'sp')
2025-03-19 16:49:11,498 [INFO]: regrid.py(subset_and_align_datasets:68) >> Selected region: global
2025-03-19 16:49:36,441 [INFO]: io.py(_write_to_netcdf:151) >> 'QREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global_test.nc
2025-03-19 16:49:36,448 [INFO]: io.py(_write_to_netcdf:151) >> 'QREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global_ref.nc
2025-03-19 16:49:36,454 [INFO]: io.py(_write_to_netcdf:151) >> 'QREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global_diff.nc
2025-03-19 16:49:36,455 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global.json
2025-03-19 16:49:36,500 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:49:36,912 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:49:39,269 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:49:41,533 [INFO]: utils.py(_save_plot:92) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global.png
2025-03-19 16:49:41,533 [INFO]: lat_lon_driver.py(run_diag:69) >> Variable: TREFHT
2025-03-19 16:49:42,543 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TREFHT',)
2025-03-19 16:49:42,843 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('tas',)
2025-03-19 16:49:44,426 [INFO]: regrid.py(subset_and_align_datasets:68) >> Selected region: land
2025-03-19 16:50:32,197 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land_test.nc
2025-03-19 16:50:32,204 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land_ref.nc
2025-03-19 16:50:32,209 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land_diff.nc
2025-03-19 16:50:32,210 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land.json
2025-03-19 16:50:32,225 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:50:32,640 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:50:35,465 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:50:38,724 [INFO]: utils.py(_save_plot:92) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land.png
2025-03-19 16:50:39,420 [INFO]: main.py(create_viewer:142) >> lat_lon /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/viewer
2025-03-19 16:50:39,807 [WARNING]: warnings.py(_showwarnmsg:110) >> /gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/plot/taylor_diagram.py:94: UserWarning: No artists with labels found to put in legend.  Note that artists whose label start with an underscore are ignored when legend() is called with no argument.
  ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))

2025-03-19 16:50:44,245 [INFO]: main.py(create_viewer:145) >> [('Latitude-Longitude contour maps', 'lat_lon/index.html'), ('Table', 'table/index.html'), ('Taylor Diagram', 'taylor/index.html'), ('CMIP6 Comparison', 'cmip6/index.html')]
2025-03-19 16:50:44,255 [INFO]: e3sm_diags_driver.py(main:446) >> Viewer HTML generated at /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/viewer/index.html
```

Example console output (identical to log file)

```python
2025-03-19 16:49:03,675 [INFO]: e3sm_diags_driver.py(_log_diagnostic_run_info:527) >> 
================================================================================
E3SM Diagnostics Run
--------------------
Timestamp: 2025-03-19 16:49:03
Version Info: branch feature/954-root-logger with commit d18559fd6d4368fddfee2fc0e649c5f6173e2003
Results Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger
Log Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/e3sm_diags_run.log
Parameter Files Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/v2_run.cfg
Python Script Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/v2_run_script.py
Environment YML Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/environment.yml
Provenance Index HTML Path: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/prov/index.html
================================================================================

2025-03-19 16:49:07,992 [INFO]: lat_lon_driver.py(run_diag:69) >> Variable: QREFHT
2025-03-19 16:49:09,276 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('QREFHT',)
2025-03-19 16:49:09,800 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('d2m', 'sp')
2025-03-19 16:49:11,498 [INFO]: regrid.py(subset_and_align_datasets:68) >> Selected region: global
2025-03-19 16:49:36,441 [INFO]: io.py(_write_to_netcdf:151) >> 'QREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global_test.nc
2025-03-19 16:49:36,448 [INFO]: io.py(_write_to_netcdf:151) >> 'QREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global_ref.nc
2025-03-19 16:49:36,454 [INFO]: io.py(_write_to_netcdf:151) >> 'QREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global_diff.nc
2025-03-19 16:49:36,455 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global.json
2025-03-19 16:49:36,500 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:49:36,912 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:49:39,269 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:49:41,533 [INFO]: utils.py(_save_plot:92) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5_ext-QREFHT-ANN-global.png
2025-03-19 16:49:41,533 [INFO]: lat_lon_driver.py(run_diag:69) >> Variable: TREFHT
2025-03-19 16:49:42,543 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the test climatology variable using the source variables: ('TREFHT',)
2025-03-19 16:49:42,843 [INFO]: dataset_xr.py(_get_dataset_with_derived_climo_var:713) >> Deriving the ref climatology variable using the source variables: ('tas',)
2025-03-19 16:49:44,426 [INFO]: regrid.py(subset_and_align_datasets:68) >> Selected region: land
2025-03-19 16:50:32,197 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' test variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land_test.nc
2025-03-19 16:50:32,204 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' ref variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land_ref.nc
2025-03-19 16:50:32,209 [INFO]: io.py(_write_to_netcdf:151) >> 'TREFHT' diff variable output saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land_diff.nc
2025-03-19 16:50:32,210 [INFO]: io.py(_save_data_metrics_and_plots:77) >> Metrics saved in /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land.json
2025-03-19 16:50:32,225 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:50:32,640 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:50:35,465 [WARNING]: warnings.py(_showwarnmsg:110) >> /home/ac.tvo/miniforge3/envs/e3sm_diags_dev_933/lib/python3.13/site-packages/cartopy/mpl/geoaxes.py:856: UserWarning: Attempting to set identical low and high xlims makes transformation singular; automatically expanding.
  self.set_xlim([x1, x2])

2025-03-19 16:50:38,724 [INFO]: utils.py(_save_plot:92) >> Plot saved in: /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/lat_lon/ERA5/ERA5-TREFHT-ANN-land.png
2025-03-19 16:50:39,420 [INFO]: main.py(create_viewer:142) >> lat_lon /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/viewer
2025-03-19 16:50:39,807 [WARNING]: warnings.py(_showwarnmsg:110) >> /gpfs/fs1/home/ac.tvo/E3SM-Project/e3sm_diags/e3sm_diags/plot/taylor_diagram.py:94: UserWarning: No artists with labels found to put in legend.  Note that artists whose label start with an underscore are ignored when legend() is called with no argument.
  ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))

2025-03-19 16:50:44,245 [INFO]: main.py(create_viewer:145) >> [('Latitude-Longitude contour maps', 'lat_lon/index.html'), ('Table', 'table/index.html'), ('Taylor Diagram', 'taylor/index.html'), ('CMIP6 Comparison', 'cmip6/index.html')]
2025-03-19 16:50:44,255 [INFO]: e3sm_diags_driver.py(main:446) >> Viewer HTML generated at /lcrc/group/e3sm/public_html/cdat-migration-fy24/25-03-19-branch-954-root-logger/viewer/index.html

```

### Checklist
- [x] 1. Define `_setup_root_logger()` in `logger.py` to encapsulate instantiation root logger (no `filename`/`filemode` args)
- [x] 2. Update `run.py` to call `_setup_root_logger()` at the top of the module
  - https://github.com/E3SM-Project/e3sm_diags/blob/9713ee4bee028141a602d1b1cf74955dbf86d269/e3sm_diags/run.py#L18-L20
- [x] 3. Add function called `_add_filehandler()` to `logger.py` 
- [x] 4. Remove function called `_update_root_logger_filepath_to_prov_dir()` in `logger.py` 
- [x] 5. Replace lines below to call `_add_filehandler()`
  - https://github.com/E3SM-Project/e3sm_diags/blob/9713ee4bee028141a602d1b1cf74955dbf86d269/e3sm_diags/run.py#L90-L95


### Test Cases
- [x] No duplicate logger messages in log file or console
- [x] Identical output captured between log file and console (including warnings)
- [x] Works in serial
- [x] Works in parallel


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
