### PR TITLE
Skip regriding for two datasets on same lat-lon grids

### DIFF
--- a/e3sm_diags/driver/utils/regrid.py
+++ b/e3sm_diags/driver/utils/regrid.py
@@ -398,7 +398,7 @@ def align_grids_to_lower_res(
 
 
 def _are_grids_equal(ds_a: xr.Dataset, ds_b: xr.Dataset) -> bool:
-    """Check if the latitude and longitude grids of two datasets are identical.
+    """Check if the grids of two datasets are identical.
 
     This function checks if the grids of the two datasets have the same shape
     and same values. If they do, then the grids are identical

--- a/e3sm_diags/driver/utils/regrid.py
+++ b/e3sm_diags/driver/utils/regrid.py
@@ -96,6 +96,25 @@ def subset_and_align_datasets(
         ds_test_new = _subset_on_region(ds_test_new, var_key, region)
         ds_ref_new = _subset_on_region(ds_ref_new, var_key, region)
 
+    # Check if lat lon grids match, skip regriding in this case
+    test_lat = xc.get_dim_coords(ds_test_new, axis="Y")
+    ref_lat = xc.get_dim_coords(ds_ref_new, axis="Y")
+
+    test_lon = xc.get_dim_coords(ds_test_new, axis="X")
+    ref_lon = xc.get_dim_coords(ds_ref_new, axis="X")
+
+    if test_lat.shape == ref_lat.shape and test_lon.shape == ref_lon.shape:
+        if np.allclose(test_lat.values, ref_lat.values) and np.allclose(
+            test_lon.values, ref_lon.values
+        ):
+            ds_test_regrid = ds_test_new.copy()
+            ds_ref_regrid = ds_ref_new.copy()
+
+            ds_diff = ds_test_regrid.copy()
+            ds_diff[var_key] = ds_test_regrid[var_key] - ds_ref_regrid[var_key]
+
+            return ds_test_new, ds_test_regrid, ds_ref_new, ds_ref_regrid, ds_diff
+
     ds_test_regrid, ds_ref_regrid = align_grids_to_lower_res(
         ds_test_new,
         ds_ref_new,

--- a/e3sm_diags/driver/utils/regrid.py
+++ b/e3sm_diags/driver/utils/regrid.py
@@ -96,25 +96,6 @@ def subset_and_align_datasets(
         ds_test_new = _subset_on_region(ds_test_new, var_key, region)
         ds_ref_new = _subset_on_region(ds_ref_new, var_key, region)
 
-    # Check if lat lon grids match, skip regriding in this case
-    test_lat = xc.get_dim_coords(ds_test_new, axis="Y")
-    ref_lat = xc.get_dim_coords(ds_ref_new, axis="Y")
-
-    test_lon = xc.get_dim_coords(ds_test_new, axis="X")
-    ref_lon = xc.get_dim_coords(ds_ref_new, axis="X")
-
-    if test_lat.shape == ref_lat.shape and test_lon.shape == ref_lon.shape:
-        if np.allclose(test_lat.values, ref_lat.values) and np.allclose(
-            test_lon.values, ref_lon.values
-        ):
-            ds_test_regrid = ds_test_new.copy()
-            ds_ref_regrid = ds_ref_new.copy()
-
-            ds_diff = ds_test_regrid.copy()
-            ds_diff[var_key] = ds_test_regrid[var_key] - ds_ref_regrid[var_key]
-
-            return ds_test_new, ds_test_regrid, ds_ref_new, ds_ref_regrid, ds_diff
-
     ds_test_regrid, ds_ref_regrid = align_grids_to_lower_res(
         ds_test_new,
         ds_ref_new,
@@ -386,6 +367,12 @@ def align_grids_to_lower_res(
     ds_a_new = ds_a.copy()
     ds_b_new = ds_b.copy()
 
+    # If grids are equal, then no regridding is required. This ensures no
+    # performance cost is incurred.
+    equal_grids = _are_grids_equal(ds_a_new, ds_b_new)
+    if equal_grids:
+        return ds_a_new, ds_b_new
+
     ds_a_new = _drop_unused_ilev_axis(ds_a_new)
     ds_b_new = _drop_unused_ilev_axis(ds_b_new)
 
@@ -408,6 +395,35 @@ def align_grids_to_lower_res(
     )
 
     return ds_a_regrid, ds_b_new
+
+
+def _are_grids_equal(ds_a: xr.Dataset, ds_b: xr.Dataset) -> bool:
+    """Check if the latitude and longitude grids of two datasets are identical.
+
+    This function checks if the grids of the two datasets have the same shape
+    and same values. If they do, then the grids are identical
+
+    Parameters
+    ----------
+    ds_a : xr.Dataset
+        The first dataset.
+    ds_b : xr.Dataset
+        The second dataset.
+
+    Returns
+    -------
+    bool
+        True if the grids are identical, False otherwise.
+    """
+    lat_a, lat_b = xc.get_dim_coords(ds_a, axis="Y"), xc.get_dim_coords(ds_b, axis="Y")
+    lon_a, lon_b = xc.get_dim_coords(ds_a, axis="X"), xc.get_dim_coords(ds_b, axis="X")
+
+    return (
+        lat_a.shape == lat_b.shape
+        and lon_a.shape == lon_b.shape
+        and np.allclose(lat_a.values, lat_b.values)
+        and np.allclose(lon_a.values, lon_b.values)
+    )
 
 
 def _drop_unused_ilev_axis(ds: xr.Dataset) -> xr.Dataset:

--- a/tests/e3sm_diags/driver/utils/test_regrid.py
+++ b/tests/e3sm_diags/driver/utils/test_regrid.py
@@ -375,6 +375,19 @@ class TestAlignGridstoLowerRes:
 
         assert_identical(result_b, expected_b)
 
+    @pytest.mark.parametrize("tool", ("xesmf", "regrid2"))
+    def test_returns_original_datasets_if_grids_are_equal(self, tool):
+        ds_a = generate_lev_dataset("pressure", pressure_vars=False)
+        ds_b = generate_lev_dataset("pressure", pressure_vars=False)
+
+        result_a, result_b = align_grids_to_lower_res(
+            ds_a, ds_b, "so", tool, "conservative_normed"
+        )
+
+        # Since the grids are equal, the original datasets should be returned
+        assert_identical(result_a, ds_a)
+        assert_identical(result_b, ds_b)
+
 
 class TestRegridZAxisToPlevs:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description
Recent zppy testing with e3sm-unified rc13 on other machines (esp. Perlmutter), shows that running model vs model can be time consuming, see comment. https://github.com/E3SM-Project/zppy/discussions/634#discussioncomment-12555600, but it is not obvious why Perlmutter runs much slower. 
This PR attempted to skip regriding with same lat-lon grids, to make code more performant. 

Initial tests show that on Chrysalis, time for model-vs-model atm reduced from 24 ->16 mins, lnd reduced from 31 ->18 mins, individually. 

Testing results 
with [this PR](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.zhang40/E3SMv3_eu11rc13_skip_reg/v3.LR.historical_0051/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1985-2014/viewer/index.html). 
with [main](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.zhang40/E3SMv3_eu11rc13/v3.LR.historical_0051/e3sm_diags/atm_monthly_180x360_aave/model_vs_obs_1985-2014/viewer/index.html).

All plots are created completely, with only truncation difference in global metrics.


Other that the performance improvement, some oddball metrics  ([main](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.zhang40/E3SMv3_eu11rc13/v3.LR.historical_0051/e3sm_diags/atm_monthly_180x360_aave_mvm/v3.LR.historical_0051_1985-2014/viewer/table-data/ANN_metrics_table.html) vs [this PR](https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.zhang40/E3SMv3_eu11rc13_skip_reg/v3.LR.historical_0051/e3sm_diags/atm_monthly_180x360_aave_mvm/v3.LR.historical_0051_1985-2014/viewer/table-data/ANN_metrics_table.html))result from regridding masked datasets were fixed in this case. 

- Closes #960 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
