### PR TITLE
Add support for saving regridded datasets to netCDF files

### DIFF
--- a/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
+++ b/e3sm_diags/driver/annual_cycle_zonal_mean_driver.py
@@ -191,6 +191,8 @@ def _run_diags_annual_cycle(
             ref_zonal_mean.to_dataset(),
             diff.to_dataset(),
             metrics_dict=None,
+            ds_test_regridded=test_reg_zonal_mean.to_dataset(),
+            ds_ref_regridded=ref_reg_zonal_mean.to_dataset(),
         )
 
 

--- a/e3sm_diags/driver/cosp_histogram_driver.py
+++ b/e3sm_diags/driver/cosp_histogram_driver.py
@@ -90,6 +90,7 @@ def run_diag(parameter: CoreParameter) -> CoreParameter:
                     ds_ref_avg,
                     ds_diff_avg,
                     metrics_dict=None,
+                    # No regridded datasets available for cosp_histogram
                 )
 
     return parameter

--- a/e3sm_diags/driver/lat_lon_driver.py
+++ b/e3sm_diags/driver/lat_lon_driver.py
@@ -354,6 +354,8 @@ def _run_diags_2d(
             ds_ref_region,
             ds_diff_region,
             metrics_dict,
+            ds_test_regridded=ds_test_region_regrid,
+            ds_ref_regridded=ds_ref_region_regrid,
         )
 
 
@@ -437,6 +439,8 @@ def _run_diags_3d(
                 ds_ref_region,
                 ds_diff_region,
                 metrics_dict,
+                ds_test_regridded=ds_test_region_regrid,
+                ds_ref_regridded=ds_ref_region_regrid,
             )
 
 

--- a/e3sm_diags/driver/meridional_mean_2d_driver.py
+++ b/e3sm_diags/driver/meridional_mean_2d_driver.py
@@ -152,6 +152,8 @@ def _run_diags_3d(
         ds_r_plevs_avg,
         ds_diff_plevs_rg_avg,
         metrics_dict,
+        ds_test_regridded=ds_t_plevs_rg_avg,
+        ds_ref_regridded=ds_r_plevs_rg_avg,
     )
 
 

--- a/e3sm_diags/driver/polar_driver.py
+++ b/e3sm_diags/driver/polar_driver.py
@@ -152,6 +152,8 @@ def _run_diags_2d(
             ds_ref_region,
             ds_diff_region,
             metrics_dict,
+            ds_test_regridded=ds_test_region_regrid,
+            ds_ref_regridded=ds_ref_region_regrid,
         )
 
 
@@ -236,6 +238,8 @@ def _run_diags_3d(
                 ds_ref_region,
                 ds_diff_region,
                 metrics_dict,
+                ds_test_regridded=ds_test_region_regrid,
+                ds_ref_regridded=ds_ref_region_regrid,
             )
 
 

--- a/e3sm_diags/driver/utils/io.py
+++ b/e3sm_diags/driver/utils/io.py
@@ -24,6 +24,8 @@ def _save_data_metrics_and_plots(
     metrics_dict: MetricsDict | None,
     plot_kwargs: Dict[str, Any] | None = None,
     viewer_descr: str | None = None,
+    ds_test_regridded: xr.Dataset | None = None,
+    ds_ref_regridded: xr.Dataset | None = None,
 ):
     """Save data (optional), metrics, and plots.
 
@@ -56,6 +58,10 @@ def _save_data_metrics_and_plots(
         An optional viewer description, by default None. For example,
         the enso_diags driver has a custom viewer description that is not
         the "long_name" variable attribute.
+    ds_test_regridded : xr.Dataset | None
+        The optional regridded test dataset. This will be saved if save_netcdf is True.
+    ds_ref_regridded : xr.Dataset | None
+        The optional regridded reference dataset. This will be saved if save_netcdf is True.
     """
     if parameter.save_netcdf:
         _write_vars_to_netcdf(
@@ -64,6 +70,8 @@ def _save_data_metrics_and_plots(
             ds_test,
             ds_ref,
             ds_diff,
+            ds_test_regridded,
+            ds_ref_regridded,
         )
 
     output_dir = _get_output_dir(parameter)
@@ -107,8 +115,11 @@ def _write_vars_to_netcdf(
     ds_test: xr.Dataset,
     ds_ref: xr.Dataset | None,
     ds_diff: xr.Dataset | None,
+    ds_test_regridded: xr.Dataset = None,
+    ds_ref_regridded: xr.Dataset = None,
 ):
     """Saves the test, reference, and difference variables to netCDF files.
+    If regridded datasets are provided, those are saved as well.
 
     Parameters
     ----------
@@ -124,6 +135,10 @@ def _write_vars_to_netcdf(
     ds_diff : Optional[xr.DataArray]
         The optional dataset containing the difference between the test and
         reference variables.
+    ds_test_regridded : Optional[xr.Dataset]
+        The optional dataset containing the regridded test variable.
+    ds_ref_regridded : Optional[xr.Dataset]
+        The optional dataset containing the regridded reference variable.
 
     Notes
     -----
@@ -136,6 +151,13 @@ def _write_vars_to_netcdf(
 
     if ds_diff is not None:
         _write_to_netcdf(parameter, ds_diff[var_key], var_key, "diff")
+        
+    # Save regridded datasets if they exist
+    if ds_test_regridded is not None:
+        _write_to_netcdf(parameter, ds_test_regridded[var_key], var_key, "test_regridded")
+        
+    if ds_ref_regridded is not None:
+        _write_to_netcdf(parameter, ds_ref_regridded[var_key], var_key, "ref_regridded")
 
 
 def _write_to_netcdf(

--- a/e3sm_diags/driver/utils/io.py
+++ b/e3sm_diags/driver/utils/io.py
@@ -115,8 +115,8 @@ def _write_vars_to_netcdf(
     ds_test: xr.Dataset,
     ds_ref: xr.Dataset | None,
     ds_diff: xr.Dataset | None,
-    ds_test_regridded: xr.Dataset = None,
-    ds_ref_regridded: xr.Dataset = None,
+    ds_test_regridded: xr.Dataset | None = None,
+    ds_ref_regridded: xr.Dataset | None = None,
 ):
     """Saves the test, reference, and difference variables to netCDF files.
     If regridded datasets are provided, those are saved as well.
@@ -151,11 +151,13 @@ def _write_vars_to_netcdf(
 
     if ds_diff is not None:
         _write_to_netcdf(parameter, ds_diff[var_key], var_key, "diff")
-        
+
     # Save regridded datasets if they exist
     if ds_test_regridded is not None:
-        _write_to_netcdf(parameter, ds_test_regridded[var_key], var_key, "test_regridded")
-        
+        _write_to_netcdf(
+            parameter, ds_test_regridded[var_key], var_key, "test_regridded"
+        )
+
     if ds_ref_regridded is not None:
         _write_to_netcdf(parameter, ds_ref_regridded[var_key], var_key, "ref_regridded")
 
@@ -164,7 +166,7 @@ def _write_to_netcdf(
     parameter: CoreParameter,
     var: xr.DataArray,
     var_key: str,
-    data_type: Literal["test", "ref", "diff"],
+    data_type: Literal["test", "ref", "diff", "test_regridded", "ref_regridded"],
 ):
     filename, filepath = _get_output_filename_filepath(parameter, data_type)
 

--- a/e3sm_diags/driver/zonal_mean_2d_driver.py
+++ b/e3sm_diags/driver/zonal_mean_2d_driver.py
@@ -128,6 +128,8 @@ def _run_diags_3d(
         ds_r_plevs_avg,
         ds_diff_rg_avg,
         metrics_dict,
+        ds_test_regridded=ds_t_plevs_rg_avg,
+        ds_ref_regridded=ds_r_plevs_rg_avg,
     )
 
 

--- a/e3sm_diags/parser/meridional_mean_2d_parser.py
+++ b/e3sm_diags/parser/meridional_mean_2d_parser.py
@@ -1,10 +1,11 @@
+from e3sm_diags.parameter.meridional_mean_2d_parameter import MeridionalMean2dParameter
 from e3sm_diags.parser.core_parser import CoreParser
 
 
 class MeridionalMean2dParser(CoreParser):
     def __init__(self, *args, **kwargs):
         # FIXME: B026 Star-arg unpacking after a keyword argument is strongly discouraged
-        super().__init__(parameter_cls=MeridionalMean2dParser, *args, **kwargs)  # type: ignore  # noqa: B026
+        super().__init__(parameter_cls=MeridionalMean2dParameter, *args, **kwargs)  # type: ignore  # noqa: B026
 
     def add_arguments(self):
         super().add_arguments()


### PR DESCRIPTION
This change allows saving both original and regridded datasets to netCDF files when the save_netcdf flag is enabled. The new feature helps users analyze the effects of regridding on the data.

- Updated io.py to accept and save regridded datasets
- Modified multiple driver files to pass regridded datasets to the save function
- Added optional parameters to maintain backward compatibility



## Test plan
- [x] Run e3sm_diags with save_netcdf=True and verify that regridded datasets are saved
- [x] Check that both original files (test_*.nc, ref_*.nc, diff_*.nc) and regridded files (test_regridded_*.nc, ref_regridded_*.nc) are created
- [x] Ensure the existing functionality still works properly

🤖 Generated with [Claude Code](https://claude.ai/code)")

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
