### PR TITLE
Fix layout for sub-plot saved in pdf format

### DIFF
--- a/e3sm_diags/parser/enso_diags_parser.py
+++ b/e3sm_diags/parser/enso_diags_parser.py
@@ -50,3 +50,10 @@ class EnsoDiagsParser(CoreParser):
             help="End year for the timeseries files.",
             required=False,
         )
+
+        self.parser.add_argument(
+            "--plot_type",
+            dest="plot_type",
+            help="Type of plot to generate: 'map' or 'scatter'.",
+            required=False,
+        )

--- a/e3sm_diags/plot/aerosol_aeronet_plot.py
+++ b/e3sm_diags/plot/aerosol_aeronet_plot.py
@@ -22,7 +22,48 @@ PANEL_CFG = [
 ]
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, right, top) in page coordinates.
-BORDER_PADDING = (-0.06, -0.03, 0.13, 0.03)
+BORDER_PADDING_COLORMAP = (-0.06, 0.25, 0.13, 0.25)
+BORDER_PADDING_SCATTER = (-0.08, -0.04, 0.15, 0.04)
+
+
+def _save_plot_aerosol_aeronet(fig, parameter):
+    """Save aerosol_aeronet plots with different border padding for each panel."""
+    import os
+    from matplotlib.transforms import Bbox
+    from e3sm_diags.driver.utils.io import _get_output_dir
+    
+    # Save the main plot
+    for f in parameter.output_format:
+        f = f.lower().split(".")[-1]
+        fnm = os.path.join(
+            _get_output_dir(parameter),
+            parameter.output_file + "." + f,
+        )
+        plt.savefig(fnm)
+        logger.info(f"Plot saved in: {fnm}")
+
+    # Save individual subplots with different border padding
+    border_paddings = [BORDER_PADDING_COLORMAP, BORDER_PADDING_SCATTER]
+    
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(
+            _get_output_dir(parameter),
+            parameter.output_file,
+        )
+        page = fig.get_size_inches()
+
+        for idx, (panel, border_padding) in enumerate(zip(PANEL_CFG, border_paddings)):
+            # Extent of subplot
+            subpage = np.array(panel).reshape(2, 2)
+            subpage[1, :] = subpage[0, :] + subpage[1, :]
+            subpage = subpage + np.array(border_padding).reshape(2, 2)
+            subpage = list(((subpage) * page).flatten())
+            extent = Bbox.from_extents(*subpage)
+
+            # Save subplot
+            fname = fnm + ".%i." % idx + f
+            plt.savefig(fname, bbox_inches=extent)
+            logger.info(f"Sub-plot saved in: {fname}")
 
 
 def plot(
@@ -108,4 +149,4 @@ def plot(
 
     plt.loglog(ref_site_arr, test_site_arr, "kx", markersize=3.0, mfc="none")
 
-    _save_plot(fig, parameter, PANEL_CFG, BORDER_PADDING)
+    _save_plot_aerosol_aeronet(fig, parameter)

--- a/e3sm_diags/plot/enso_diags_plot.py
+++ b/e3sm_diags/plot/enso_diags_plot.py
@@ -41,6 +41,34 @@ logger = _setup_child_logger(__name__)
 # Use 179.99 as central longitude due to https://github.com/SciTools/cartopy/issues/946
 PROJECTION = ccrs.PlateCarree(central_longitude=179.99)
 
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+ENSO_BORDER_PADDING_MAP = (-0.07, -0.025, 0.2, 0.035)
+
+
+def _save_plot_scatter(fig: plt.Figure, parameter: EnsoDiagsParameter):
+    """Save the scatter plot using a simplified approach for single panel plots."""
+    import os
+    from e3sm_diags.driver.utils.io import _get_output_dir
+    
+    for f in parameter.output_format:
+        f = f.lower().split(".")[-1]
+        fnm = os.path.join(
+            _get_output_dir(parameter),
+            parameter.output_file + "." + f,
+        )
+        plt.savefig(fnm)
+        logger.info(f"Plot saved in: {fnm}")
+
+    # Save individual subplots (single panel for scatter)
+    for f in parameter.output_format_subplot:
+        fnm = os.path.join(
+            _get_output_dir(parameter),
+            parameter.output_file + ".0." + f,
+        )
+        plt.savefig(fnm)
+        logger.info(f"Sub-plot saved in: {fnm}")
+
 
 def plot_scatter(
     parameter: EnsoDiagsParameter, x: MetricsDictScatter, y: MetricsDictScatter
@@ -138,7 +166,7 @@ def plot_scatter(
     plt.ylabel("{} anomaly ({})".format(y["var"], y["units"]))
     plt.legend()
 
-    _save_plot(fig, parameter)
+    _save_plot_scatter(fig, parameter)
 
     plt.close()
 
@@ -192,7 +220,7 @@ def plot_map(
     )
     _plot_diff_rmse_and_corr(fig, metrics_dict["diff"])  # type: ignore
 
-    _save_plot(fig, parameter)
+    _save_plot(fig, parameter, DEFAULT_PANEL_CFG, ENSO_BORDER_PADDING_MAP)
 
     plt.close()
 

--- a/e3sm_diags/plot/qbo_plot.py
+++ b/e3sm_diags/plot/qbo_plot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Literal, TypedDict
+from typing import List, Literal, Tuple, TypedDict
 
 import matplotlib
 import numpy as np
@@ -18,10 +18,14 @@ logger = _setup_child_logger(__name__)
 PANEL_CFG = [
     (0.075, 0.75, 0.6, 0.175),
     (0.075, 0.525, 0.6, 0.175),
-    (0.725, 0.525, 0.2, 0.4),
+    (0.735, 0.525, 0.2, 0.4),
     (0.075, 0.285, 0.85, 0.175),
     (0.075, 0.04, 0.85, 0.175),
 ]
+
+# Border padding relative to subplot axes for saving individual panels
+# (left, bottom, right, top) in page coordinates
+QBO_BORDER_PADDING: Tuple[float, float, float, float] = (-0.07, -0.03, 0.009, 0.03)
 
 LABEL_SIZE = 14
 CMAP = plt.cm.RdBu_r
@@ -203,7 +207,7 @@ def plot(parameter: QboParameter, test_dict, ref_dict):
     fig.suptitle(parameter.main_title, x=0.5, y=0.97, fontsize=15)
 
     # Save figure
-    _save_plot(fig, parameter, PANEL_CFG)
+    _save_plot(fig, parameter, PANEL_CFG, QBO_BORDER_PADDING)
 
     plt.close()
 

--- a/e3sm_diags/plot/tropical_subseasonal_plot.py
+++ b/e3sm_diags/plot/tropical_subseasonal_plot.py
@@ -30,7 +30,7 @@ PANEL = [
 
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, right, top) in page coordinates
-BORDER_PADDING = (-0.06, -0.03, 0.13, 0.03)
+BORDER_PADDING = (-0.07, -0.04, 0, 0.04)
 
 CONTOUR_LEVS_SPEC_RAW = (
     -1.4,

--- a/e3sm_diags/plot/utils.py
+++ b/e3sm_diags/plot/utils.py
@@ -38,7 +38,7 @@ DEFAULT_PANEL_CFG: PanelConfig = [
 # Border padding relative to subplot axes for saving individual panels
 # (left, bottom, right, top) in page coordinates
 BorderPadding = Tuple[float, float, float, float]
-DEFAULT_BORDER_PADDING: BorderPadding = (-0.06, -0.03, 0.13, 0.03)
+DEFAULT_BORDER_PADDING: BorderPadding = (-0.07, -0.03, 0.13, 0.03)
 
 # The type annotation for the rect arg used for creating the color bar axis.
 Rect = Tuple[float, float, float, float]


### PR DESCRIPTION
## Description

## Description

When saving sub panel as pdf format, problems are reported about cropped axis, lables. This PR aims to fixes sets that have subplot saving problems.
- Closes #970 meridional and zonal mean 2d plots, closes #294 (for enso) and other sets.
- tropcial_subseasonal: fixing padding border 
- aerosol_aeronet: fixing padding border and plotting
- enso_diags: fixing parser to make command-line work and fixing padding border
- QBO: fixing fig position and padding border
## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
