### PR TITLE
Add Amazon and East Asia regional domains for the v3.RRM release

### DIFF
--- a/e3sm_diags/derivations/default_regions_xr.py
+++ b/e3sm_diags/derivations/default_regions_xr.py
@@ -68,6 +68,8 @@ REGION_SPECS = {
     # Below is for RRM(regionally refined model) domains.
     # 'CONUS_RRM': {'domain': "lat":(20., 50., 'ccb'), "lon":(-125., -65., 'ccb'))},For RRM dataset, negative value won't work
     "CONUS_RRM": {"lat": (20.0, 50.0), "lon": (235.0, 295.0)},
+    "EastAsia_RRM": {"lat": (8.0, 50.0), "lon": (70.0, 142.5)},
+    "Amazon_RRM": {"lat": (-28.5, 14.0), "lon": (-88.5, -31.0)},
     # Below is for debugging. A smaller latitude range reduces processing time.
     "DEBUG": {"lat": (-2.0, 2)},
 }


### PR DESCRIPTION
## Description

The v3.RRM standard release will include two new RRMs at Amazon and East Asia. The PR adds the regional domains defined for these two new RRMs. Tests are successful and can be found at:

**Amazon**: https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.qtang/E3SMv3_dev/20250809.v3.amazonrrm.F20TR.chrysalis/e3sm_diags/ERA5_0.25x0.25_aave/model_vs_obs_1992-1992/viewer

**East Asia**:
https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.qtang/E3SMv3_dev/20250810.v3.eastasiarrm.F20TR.chrysalis/e3sm_diags/ERA5_0.25x0.25_aave/model_vs_obs_1993-1995/viewer/index.html

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
