### PR TITLE
Add full land variable set for model vs model comparison

### DIFF
--- a/auxiliary_tools/debug/999-add-all-land-var/comprehensive_unit_conversion_reference.txt
+++ b/auxiliary_tools/debug/999-add-all-land-var/comprehensive_unit_conversion_reference.txt
@@ -1,0 +1,102 @@
+COMPREHENSIVE UNIT CONVERSION REFERENCE FOR ELM VARIABLES IN LAT_LON MAPS
+==========================================================================
+
+BASED ON EXISTING E3SM_DIAGS DERIVATIONS AND CSV ANALYSIS
+
+=== CARBON FLUX VARIABLES ===
+Original Units: gC/m²/s, kgC/m²/s  
+Conversion Factor: 86400 (seconds per day)
+Target Units: gC/m²/day, kgC/m²/day  
+Derivation: convert_units(target_units="g*/m^2/day")
+
+Variables in original config using this pattern:
+- GPP: gC/m²/s -> gC/m²/day 
+- HR: gC/m²/s -> gC/m²/day
+- NBP: gC/m²/s -> gC/m²/day  
+- NPP: gC/m²/s -> gC/m²/day
+
+Variables from CSV needing this pattern (currently using 3.15360E-02):
+- GPP, HR, NBP, NPP (apply to config variables too for consistency)
+- All other gC/m²/s variables in CSV: AR, ER, AGNPP, BGNPP, CH4PROD, etc.
+
+=== CARBON STOCK VARIABLES ===
+Original Units: gC/m²
+Conversion Factor: 1.00000E-09 (gC/m² -> PgC in CSV) OR 1/1000 (gC/m² -> kgC/m² in derivations)  
+Target Units: kgC/m² (for spatial maps)
+Derivation: convert_units(target_units="kgC/m^2")
+
+Variables in original config using this pattern:
+- TOTVEGC: gC/m² -> kgC/m²
+- TOTSOMC: gC/m² -> kgC/m²  
+- CPOOL: gC/m² -> kgC/m²
+- LEAFC: gC/m² -> kgC/m²
+
+Variables from CSV needing this pattern:
+- CPOOL, LEAFC, TOTSOMC, TOTVEGC (use derivations conversion, not CSV 1.00000E-09)
+- Other carbon stock variables with scale factor 1.00000E-09
+
+=== NITROGEN FLUX VARIABLES ===  
+Original Units: gN/m²/s
+CSV Factor: 3.15360E+01 (includes area integration gN/m²/s -> TgN/yr)
+Proper lat_lon Factor: 86400 (seconds per day only)
+Target Units: gN/m²/day (or mgN/m²/day with factor 86400*1000)
+
+Variables from CSV needing this pattern:
+- DENIT, GROSS_NMIN, NDEP_TO_SMINN, NFIX_TO_SMINN, SMINN_TO_PLANT
+
+=== NITROGEN STOCK VARIABLES ===
+Original Units: gN/m²  
+CSV Factor: 1.00000E-06 (gN/m² -> TgN includes area integration)
+Proper lat_lon Factor: 1.0 (no conversion needed)
+Target Units: gN/m² (or mgN/m² with factor 1000)
+
+Variables from CSV needing this pattern:
+- SMINN
+
+=== PHOSPHORUS FLUX VARIABLES ===
+Original Units: gP/m²/s
+CSV Factor: 3.15360E+01 (includes area integration gP/m²/s -> TgP/yr)  
+Proper lat_lon Factor: 86400 (seconds per day only)
+Target Units: gP/m²/day (or mgP/m²/day with factor 86400*1000)
+
+Variables from CSV needing this pattern:
+- GROSS_PMIN, SMINP_TO_PLANT
+
+=== PHOSPHORUS STOCK VARIABLES ===
+Original Units: gP/m²
+CSV Factor: 1.00000E-06 (gP/m² -> TgP includes area integration)
+Proper lat_lon Factor: 1.0 (no conversion needed)  
+Target Units: gP/m² (or mgP/m² with factor 1000)
+
+Variables from CSV needing this pattern:
+- SMINP
+
+=== WATER FLUX VARIABLES ===
+Original Units: kg/m²/s  
+Existing Derivation: qflxconvert_units() -> mm/day (factor: 86400)
+Target Units: mm/day
+
+Variables in original config using this pattern:
+- QRUNOFF: kg/m²/s -> mm/day
+
+=== NO CONVERSION VARIABLES ===
+Variables that keep original units:
+- Temperature (K), fractions (unitless), rates already in daily units
+- Most CSV variables with scale factor 1.00000E+00
+
+=== SUMMARY FOR CSV VARIABLE PROCESSING ===
+
+1. Variables with CSV scale factor 3.15360E-02 (gC/m²/s to PgC/yr):
+   -> Use factor 86400 for lat_lon maps (gC/m²/s to gC/m²/day)
+
+2. Variables with CSV scale factor 3.15360E+01 (gN or gP per m²/s to Tg/yr):  
+   -> Use factor 86400 for lat_lon maps (g*/m²/s to g*/m²/day)
+
+3. Variables with CSV scale factor 1.00000E-09 (gC/m² to PgC):
+   -> Use factor 1/1000 for lat_lon maps (gC/m² to kgC/m²)  
+
+4. Variables with CSV scale factor 1.00000E-06 (gN or gP per m² to Tg):
+   -> Use factor 1.0 for lat_lon maps (keep g*/m²)
+
+5. Variables with CSV scale factor 1.00000E+00:
+   -> Use factor 1.0 (no conversion needed)

--- a/auxiliary_tools/debug/999-add-all-land-var/generate_land_config_with_data.py
+++ b/auxiliary_tools/debug/999-add-all-land-var/generate_land_config_with_data.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+Generate Land Configuration File with Actual NetCDF Data
+========================================================
+
+1. Keep original variables from lat_lon_land_model_vs_model.cfg (preserve contour levels)
+2. Update case_id for original variables with CSV group information  
+3. Add new variables from CSV with proper unit conversions and 5th/95th percentile contours from actual data
+"""
+
+import csv
+import re
+import numpy as np
+import xarray as xr
+from pathlib import Path
+
+def read_csv_data(csv_path):
+    """Read CSV file and return variable lookup dictionary."""
+    csv_vars = {}
+    with open(csv_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            csv_vars[row['Variable']] = row
+    return csv_vars
+
+def parse_original_config(config_path):
+    """Parse original config file and extract variable sections."""
+    sections = []
+    current_section = []
+    current_var = None
+    
+    with open(config_path, 'r') as f:
+        for line in f:
+            line = line.rstrip()
+            
+            if line.startswith('[#]'):
+                # Start of new section
+                if current_section:
+                    sections.append((current_var, '\n'.join(current_section)))
+                current_section = [line]
+                current_var = None
+            elif line.startswith('variables = '):
+                # Extract variable name
+                match = re.search(r'variables = \["([^"]+)"\]', line)
+                if match:
+                    current_var = match.group(1)
+                current_section.append(line)
+            else:
+                current_section.append(line)
+        
+        # Add final section
+        if current_section and current_var:
+            sections.append((current_var, '\n'.join(current_section)))
+    
+    return sections
+
+def update_case_id_in_section(section_text, new_case_id):
+    """Update case_id in a configuration section."""
+    lines = section_text.split('\n')
+    updated_lines = []
+    
+    for line in lines:
+        if line.startswith('case_id = '):
+            updated_lines.append(f'case_id = "{new_case_id}"')
+        else:
+            updated_lines.append(line)
+    
+    return '\n'.join(updated_lines)
+
+def get_proper_conversion_factor(original_units, csv_scale_factor):
+    """
+    Get proper conversion factor based on comprehensive_unit_conversion_reference.txt
+    Returns: (conversion_factor, target_units)
+    """
+    csv_factor = float(csv_scale_factor.replace('E', 'e'))
+    original_units = original_units.strip()
+    
+    # Carbon flux variables: CSV factor 3.15360E-02 -> use 86400 for lat_lon maps  
+    if abs(csv_factor - 3.15360E-02) < 1e-15:
+        return 86400.0, original_units.replace('/s', '/day')  # gC/m²/s to gC/m²/day
+    
+    # Nitrogen/Phosphorus flux: CSV factor 3.15360E+01 -> use 86400 for lat_lon maps
+    elif abs(csv_factor - 3.15360E+01) < 1e-10:
+        return 86400.0, original_units.replace('/s', '/day')  # gN/m²/s to gN/m²/day, gP/m²/s to gP/m²/day
+    
+    # Carbon state variables: CSV factor 1.00000E-09 -> use 1/1000 for lat_lon maps
+    elif abs(csv_factor - 1.00000E-09) < 1e-15:
+        return 1.0/1000.0, original_units.replace('gC', 'kgC')  # gC/m² to kgC/m²
+    
+    # Nitrogen/Phosphorus state: CSV factor 1.00000E-06 -> use 1.0 for lat_lon maps
+    elif abs(csv_factor - 1.00000E-06) < 1e-15:
+        return 1.0, original_units  # Keep gN/m², gP/m²
+    
+    # Water flux: CSV factor 86400.0 -> already correct for mm/s to mm/day
+    elif abs(csv_factor - 86400.0) < 1e-10:
+        return 86400.0, 'mm/day'  # mm/s to mm/day
+    
+    # No conversion needed: CSV factor 1.0
+    elif abs(csv_factor - 1.0) < 1e-10:
+        return 1.0, original_units
+    
+    # Unknown - use as-is with warning
+    else:
+        print(f"WARNING: Unknown conversion pattern for {original_units} with CSV factor {csv_factor}")
+        return 1.0, original_units
+
+def calculate_percentile_contours_from_data(data_array, var_name, conversion_factor):
+    """
+    Calculate 5th/95th percentile-based contour levels from actual netCDF data.
+    """
+    try:
+        print(f"  Calculating percentiles for {var_name} (conversion factor: {conversion_factor})")
+        
+        # Take temporal mean first to reduce to 2D (lat, lon)
+        if 'time' in data_array.dims:
+            data_2d = data_array.mean(dim='time', skipna=True)
+        else:
+            data_2d = data_array
+        
+        # Apply unit conversion
+        if abs(conversion_factor - 1.0) > 1e-10:
+            data_2d_converted = data_2d * conversion_factor
+            print(f"    Applied conversion factor {conversion_factor}")
+        else:
+            data_2d_converted = data_2d
+            print(f"    No conversion needed (factor = 1)")
+        
+        # Remove NaN values and flatten
+        valid_data = data_2d_converted.values.flatten()
+        valid_data = valid_data[~np.isnan(valid_data)]
+        
+        if len(valid_data) == 0:
+            print(f"    WARNING: No valid data for {var_name}")
+            return [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0]
+        
+        # Calculate percentiles
+        p5 = np.percentile(valid_data, 5)
+        p95 = np.percentile(valid_data, 95)
+        p25 = np.percentile(valid_data, 25) 
+        p75 = np.percentile(valid_data, 75)
+        median = np.percentile(valid_data, 50)
+        
+        # Generate 16 contour levels using 5th-95th percentile range
+        if abs(p95 - p5) < 1e-15:  # Nearly constant data
+            delta = max(abs(median) * 0.01, 1e-10)
+            levels = [median + (i-7.5) * delta/7.5 for i in range(16)]
+        else:
+            # Use 5th to 95th percentile range with some extension
+            min_level = p5
+            max_level = p95
+            
+            # Generate 16 levels spanning 5th to 95th percentiles
+            levels = []
+            for i in range(16):
+                frac = i / 15.0
+                level = min_level + frac * (max_level - min_level)
+                levels.append(level)
+        
+        # Round to appropriate precision
+        max_abs = max(abs(min(levels)), abs(max(levels)))
+        if max_abs < 1e-10:
+            precision = 15
+        elif max_abs < 1e-6:
+            precision = 10
+        elif max_abs < 1e-3:
+            precision = 8
+        elif max_abs < 1:
+            precision = 6
+        elif max_abs < 1000:
+            precision = 4
+        else:
+            precision = 2
+        
+        levels = [round(x, precision) for x in levels]
+        
+        print(f"    Data range: p5={p5:.4g}, median={median:.4g}, p95={p95:.4g}")
+        print(f"    Contour levels: [{levels[0]:.4g}, ..., {levels[-1]:.4g}]")
+        
+        return levels
+        
+    except Exception as e:
+        print(f"    ERROR calculating percentiles for {var_name}: {e}")
+        # Return default levels
+        return [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0]
+
+def generate_new_variable_section(var_name, csv_row, data_vars):
+    """Generate configuration section for a new variable from CSV using actual data."""
+    
+    group = csv_row['Group']
+    original_units = csv_row['Original Units'].strip()
+    csv_scale_factor = csv_row['Scale Factor']
+    long_name = csv_row['Long name'].strip()
+    
+    # Get proper conversion factor
+    conversion_factor, target_units = get_proper_conversion_factor(original_units, csv_scale_factor)
+    
+    # Calculate contour levels from actual data
+    if var_name in data_vars:
+        contour_levels = calculate_percentile_contours_from_data(data_vars[var_name], var_name, conversion_factor)
+    else:
+        print(f"  WARNING: {var_name} not found in netCDF data, using default levels")
+        # Use default levels based on conversion factor
+        if conversion_factor == 86400.0:  # Flux variables
+            contour_levels = [0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        elif conversion_factor == 1.0/1000.0:  # Carbon state
+            contour_levels = [0, 1, 2, 3, 4, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25]
+        else:  # Default
+            contour_levels = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0]
+    
+    contour_str = ",".join([f"{x:.6g}" for x in contour_levels])
+    
+    section_lines = [
+        "[#]",
+        'sets = ["lat_lon_land"]',
+        f'case_id = "{group}"',
+        f'variables = ["{var_name}"]',
+        'seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]',
+        'regions = ["global"]',
+        'test_colormap = "WhiteBlueGreenYellowRed.rgb"',
+        'reference_colormap = "WhiteBlueGreenYellowRed.rgb"',
+        'diff_colormap = "BrBG"',
+        f'contour_levels = [{contour_str}]'
+    ]
+    
+    # Add metadata comments
+    section_lines.extend([
+        f'# group: {group}',
+        f'# original_units: {original_units}',
+        f'# target_units: {target_units}',
+        f'# conversion_factor: {conversion_factor}',
+        f'# csv_scale_factor: {csv_scale_factor}',
+        f'# long_name: {long_name}',
+        f'# contours: 5th/95th percentiles from PI control data'
+    ])
+    
+    return '\n'.join(section_lines)
+
+def main():
+    """Main function to generate the land configuration file."""
+    
+    print("Generate Land Configuration File with Actual NetCDF Data")
+    print("=" * 60)
+    
+    # File paths
+    csv_path = "/tmp/zppy_land_fields.csv"
+    original_config_path = "/gpfs/fs1/home/ac.zhang40/e3sm_diags/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg"
+    netcdf_path = "/lcrc/group/e3sm2/ac.zhang40/E3SMv3/v3.LR.piControl_land_ilamb/post/lnd/native/clim/50yr/v3.LR.piControl_ANN_000101_005012_climo.nc"
+    output_path = "/gpfs/fs1/home/ac.zhang40/e3sm_diags/auxiliary_tools/debug/999-add-all-land-var/lat_lon_land_model_vs_model.cfg"
+    
+    # Read CSV data
+    csv_vars = read_csv_data(csv_path)
+    print(f"Loaded {len(csv_vars)} variables from CSV")
+    
+    # Parse original configuration
+    original_sections = parse_original_config(original_config_path)
+    original_vars = {var: section for var, section in original_sections}
+    print(f"Found {len(original_vars)} variables in original config")
+    
+    # Read netCDF data
+    print(f"Reading netCDF file: {netcdf_path}")
+    try:
+        ds = xr.open_dataset(netcdf_path, decode_times=False)
+        print(f"Successfully opened dataset with dimensions: {dict(ds.dims)}")
+        
+        # Get all data variables (exclude coordinate variables)
+        coord_vars = {'lon', 'lat', 'time', 'area', 'topo', 'landfrac', 'landmask', 'pftmask'}
+        data_vars = {}
+        for var_name, var in ds.data_vars.items():
+            if var_name not in coord_vars and 'time' in var.dims and len(var.dims) >= 2:
+                data_vars[var_name] = var
+        
+        print(f"Found {len(data_vars)} data variables in netCDF")
+        
+    except Exception as e:
+        print(f"ERROR reading netCDF file: {e}")
+        print("Continuing without netCDF data - will use default contour levels")
+        ds = None
+        data_vars = {}
+    
+    # Categorize variables
+    csv_var_names = set(csv_vars.keys())
+    original_var_names = set(original_vars.keys())
+    netcdf_var_names = set(data_vars.keys())
+    
+    new_vars = csv_var_names & netcdf_var_names - original_var_names  # New vars that exist in both CSV and netCDF
+    
+    print(f"Variables to keep from original: {len(original_var_names)}")
+    print(f"New variables to add: {len(new_vars)}")
+    
+    # Generate output
+    output_lines = []
+    
+    # Header
+    output_lines.extend([
+        "# ============================================================================",
+        "# COMPLETE ELM LAND CONFIGURATION WITH ACTUAL DATA",
+        "# ============================================================================",
+        "# Generated from:",
+        f"# - Original: {original_config_path}",
+        f"# - CSV data: {csv_path}",
+        f"# - NetCDF data: {netcdf_path}",
+        "# - Unit conversions: comprehensive_unit_conversion_reference.txt",
+        "#",
+        "# Structure:",
+        "# 1. Original variables (preserved settings + updated case_id with CSV group)",
+        "# 2. New variables from CSV (proper unit conversions + 5th/95th percentile contours)",
+        "# ============================================================================",
+        ""
+    ])
+    
+    # SECTION 1: Original variables with updated case_id
+    output_lines.extend([
+        "# ============================================================================",
+        "# ORIGINAL VARIABLES (settings preserved, case_id updated with CSV group)",
+        "# ============================================================================",
+        ""
+    ])
+    
+    for var_name in sorted(original_var_names):
+        if var_name in csv_vars:
+            # Update case_id with CSV group
+            group = csv_vars[var_name]['Group']
+            updated_section = update_case_id_in_section(original_vars[var_name], group)
+            output_lines.append(updated_section)
+            output_lines.append(f'# Updated case_id to: {group}')
+        else:
+            group = "Additional Variables"
+            updated_section = update_case_id_in_section(original_vars[var_name], group)
+            output_lines.append(updated_section)
+            output_lines.append('# Original variable (no CSV group info)')
+        
+        output_lines.append("")
+    
+    # SECTION 2: New variables from CSV with actual data
+    output_lines.extend([
+        "# ============================================================================", 
+        "# NEW VARIABLES FROM CSV (proper unit conversions + data-driven contours)",
+        "# ============================================================================",
+        ""
+    ])
+    
+    # Group new variables by category
+    vars_by_group = {}
+    for var_name in sorted(new_vars):
+        csv_row = csv_vars[var_name]
+        group = csv_row['Group']
+        if group not in vars_by_group:
+            vars_by_group[group] = []
+        vars_by_group[group].append((var_name, csv_row))
+    
+    for group_name in sorted(vars_by_group.keys()):
+        group_vars = vars_by_group[group_name]
+        output_lines.append(f"# {group_name.upper()} ({len(group_vars)} new variables)")
+        output_lines.append("# " + "="*60)
+        output_lines.append("")
+        
+        for var_name, csv_row in sorted(group_vars):
+            print(f"Processing new variable: {var_name}")
+            section = generate_new_variable_section(var_name, csv_row, data_vars)
+            output_lines.append(section)
+            output_lines.append("")
+    
+    # Write output file
+    with open(output_path, 'w') as f:
+        f.write('\n'.join(output_lines))
+    
+    # Close dataset if opened
+    if ds is not None:
+        ds.close()
+    
+    # Print summary
+    print("\n" + "="*60)
+    print("SUMMARY:")
+    print(f"- Original variables: {len(original_var_names)}")
+    print(f"- New variables: {len(new_vars)}")
+    print(f"- Total variables: {len(original_var_names) + len(new_vars)}")
+    print(f"- New variable groups: {len(vars_by_group)}")
+    print(f"\nOutput file: {output_path}")
+    print("="*60)
+
+if __name__ == "__main__":
+    main()

--- a/auxiliary_tools/debug/999-add-all-land-var/run_script_lat_lon_land.py
+++ b/auxiliary_tools/debug/999-add-all-land-var/run_script_lat_lon_land.py
@@ -1,0 +1,19 @@
+import os
+from e3sm_diags.parameter.lat_lon_land_parameter import LatLonLandParameter # Note the change.
+from e3sm_diags.run import runner
+
+param = LatLonLandParameter()
+param.test_data_path = '/lcrc/group/e3sm2/ac.zhang40/E3SMv3/v3.LR.piControl_land_ilamb/post/lnd/native/clim/50yr'
+param.test_name = 'v3.LR.piControl' 
+#param.short_test_name = 'alpha20_rrm_test'
+param.reference_data_path = '/lcrc/group/e3sm2/ac.zhang40/E3SMv3/v3.LR.piControl_land_ilamb/post/lnd/native/clim/50yr'
+param.ref_name = 'v3.LR.piControl' 
+
+param.run_type = 'model_vs_model'
+prefix = '/lcrc/group/e3sm/public_html/diagnostic_output/ac.zhang40/tests/999-all-land-var'
+param.seasons = ["ANN"]
+param.multiprocessing = True
+#param.num_workers = 16
+param.results_dir = os.path.join(prefix, 'lat_lon_test_land_model_vs_model')
+runner.sets_to_run = ['lat_lon_land']   # Note the change
+runner.run_diags([param])

--- a/e3sm_diags/derivations/derivations.py
+++ b/e3sm_diags/derivations/derivations.py
@@ -1264,6 +1264,490 @@ DERIVED_VARIABLES: DerivedVariablesMap = {
             ),
         ]
     ),
+    # ===== NEW ELM VARIABLES FROM CSV =====
+    "ACTUAL_IMMOB": OrderedDict(
+        [(("ACTUAL_IMMOB",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "ACTUAL_IMMOB_P": OrderedDict(
+        [(("ACTUAL_IMMOB_P",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "ADSORBTION_P": OrderedDict(
+        [(("ADSORBTION_P",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "AGNPP": OrderedDict(
+        [(("AGNPP",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "ALT": OrderedDict([(("ALT",), rename)]),
+    "ALTMAX": OrderedDict([(("ALTMAX",), rename)]),
+    "AR": OrderedDict(
+        [(("AR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "BCDEP": OrderedDict([(("BCDEP",), rename)]),
+    "BGNPP": OrderedDict(
+        [(("BGNPP",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "BIOCHEM_PMIN": OrderedDict(
+        [(("BIOCHEM_PMIN",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "BUILDHEAT": OrderedDict([(("BUILDHEAT",), rename)]),
+    "CH4PROD": OrderedDict(
+        [(("CH4PROD",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "COL_FIRE_CLOSS": OrderedDict(
+        [(("COL_FIRE_CLOSS",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "CWDC": OrderedDict(
+        [(("CWDC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "CWDN": OrderedDict([(("CWDN",), rename)]),
+    "CWDP": OrderedDict([(("CWDP",), rename)]),
+    "DEADCROOTC": OrderedDict(
+        [(("DEADCROOTC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "DEADCROOTN": OrderedDict([(("DEADCROOTN",), rename)]),
+    "DEADCROOTP": OrderedDict([(("DEADCROOTP",), rename)]),
+    "DEADSTEMC": OrderedDict(
+        [(("DEADSTEMC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "DEADSTEMN": OrderedDict([(("DEADSTEMN",), rename)]),
+    "DEADSTEMP": OrderedDict([(("DEADSTEMP",), rename)]),
+    "DEFICIT": OrderedDict([(("DEFICIT",), rename)]),
+    "DESORPTION_P": OrderedDict(
+        [(("DESORPTION_P",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "DISPVEGC": OrderedDict(
+        [(("DISPVEGC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "DISPVEGN": OrderedDict([(("DISPVEGN",), rename)]),
+    "DISPVEGP": OrderedDict([(("DISPVEGP",), rename)]),
+    "DSTDEP": OrderedDict([(("DSTDEP",), rename)]),
+    "DSTFLXT": OrderedDict([(("DSTFLXT",), rename)]),
+    "DWB": OrderedDict([(("DWB",), rename)]),
+    "DWT_CONV_CFLUX_GRC": OrderedDict(
+        [
+            (
+                ("DWT_CONV_CFLUX_GRC",),
+                lambda v: convert_units(v, target_units="g*/m^2/day"),
+            )
+        ]
+    ),
+    "DWT_CONV_NFLUX_GRC": OrderedDict(
+        [
+            (
+                ("DWT_CONV_NFLUX_GRC",),
+                lambda v: convert_units(v, target_units="mg*/m^2/day"),
+            )
+        ]
+    ),
+    "DWT_CONV_PFLUX_GRC": OrderedDict(
+        [
+            (
+                ("DWT_CONV_PFLUX_GRC",),
+                lambda v: convert_units(v, target_units="mg*/m^2/day"),
+            )
+        ]
+    ),
+    "DWT_SLASH_CFLUX": OrderedDict(
+        [(("DWT_SLASH_CFLUX",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "DWT_SLASH_NFLUX": OrderedDict(
+        [(("DWT_SLASH_NFLUX",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "DWT_SLASH_PFLUX": OrderedDict(
+        [(("DWT_SLASH_PFLUX",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "EFLX_DYNBAL": OrderedDict([(("EFLX_DYNBAL",), rename)]),
+    "EFLX_GRND_LAKE": OrderedDict([(("EFLX_GRND_LAKE",), rename)]),
+    "EFLX_LH_TOT_R": OrderedDict([(("EFLX_LH_TOT_R",), rename)]),
+    "EFLX_LH_TOT_U": OrderedDict([(("EFLX_LH_TOT_U",), rename)]),
+    "ELAI": OrderedDict([(("ELAI",), rename)]),
+    "ER": OrderedDict(
+        [(("ER",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "ERRH2O": OrderedDict([(("ERRH2O",), rename)]),
+    "ERRH2OSNO": OrderedDict([(("ERRH2OSNO",), rename)]),
+    "ERRSEB": OrderedDict([(("ERRSEB",), rename)]),
+    "ERRSOI": OrderedDict([(("ERRSOI",), rename)]),
+    "ERRSOL": OrderedDict([(("ERRSOL",), rename)]),
+    "ESAI": OrderedDict([(("ESAI",), rename)]),
+    "F_DENIT": OrderedDict(
+        [(("F_DENIT",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "F_NIT": OrderedDict(
+        [(("F_NIT",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "FCH4": OrderedDict(
+        [(("FCH4",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "FCH4TOCO2": OrderedDict(
+        [(("FCH4TOCO2",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "FCOV": OrderedDict([(("FCOV",), rename)]),
+    "FGR12": OrderedDict([(("FGR12",), rename)]),
+    "FGR_R": OrderedDict([(("FGR_R",), rename)]),
+    "FGR_U": OrderedDict([(("FGR_U",), rename)]),
+    "FH2OSFC": OrderedDict([(("FH2OSFC",), rename)]),
+    "FINUNDATED": OrderedDict([(("FINUNDATED",), rename)]),
+    "FIRA_R": OrderedDict([(("FIRA_R",), rename)]),
+    "FIRA_U": OrderedDict([(("FIRA_U",), rename)]),
+    "FIRE_R": OrderedDict([(("FIRE_R",), rename)]),
+    "FIRE_U": OrderedDict([(("FIRE_U",), rename)]),
+    "FPI": OrderedDict([(("FPI",), rename)]),
+    "FPI_P": OrderedDict([(("FPI_P",), rename)]),
+    "FPSN": OrderedDict([(("FPSN",), rename)]),
+    "FPSN_WC": OrderedDict([(("FPSN_WC",), rename)]),
+    "FPSN_WJ": OrderedDict([(("FPSN_WJ",), rename)]),
+    "FPSN_WP": OrderedDict([(("FPSN_WP",), rename)]),
+    "FROOTC": OrderedDict(
+        [(("FROOTC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "FROOTC_ALLOC": OrderedDict(
+        [(("FROOTC_ALLOC",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "FROOTN": OrderedDict([(("FROOTN",), rename)]),
+    "FROOTP": OrderedDict([(("FROOTP",), rename)]),
+    "FROST_TABLE": OrderedDict([(("FROST_TABLE",), rename)]),
+    "FSA_R": OrderedDict([(("FSA_R",), rename)]),
+    "FSA_U": OrderedDict([(("FSA_U",), rename)]),
+    "FSAT": OrderedDict([(("FSAT",), rename)]),
+    "FSDSND": OrderedDict([(("FSDSND",), rename)]),
+    "FSDSNDLN": OrderedDict([(("FSDSNDLN",), rename)]),
+    "FSDSNI": OrderedDict([(("FSDSNI",), rename)]),
+    "FSDSVD": OrderedDict([(("FSDSVD",), rename)]),
+    "FSDSVDLN": OrderedDict([(("FSDSVDLN",), rename)]),
+    "FSDSVI": OrderedDict([(("FSDSVI",), rename)]),
+    "FSDSVILN": OrderedDict([(("FSDSVILN",), rename)]),
+    "FSH_G": OrderedDict([(("FSH_G",), rename)]),
+    "FSH_NODYNLNDUSE": OrderedDict([(("FSH_NODYNLNDUSE",), rename)]),
+    "FSH_R": OrderedDict([(("FSH_R",), rename)]),
+    "FSH_U": OrderedDict([(("FSH_U",), rename)]),
+    "FSH_V": OrderedDict([(("FSH_V",), rename)]),
+    "FSM": OrderedDict([(("FSM",), rename)]),
+    "FSM_R": OrderedDict([(("FSM_R",), rename)]),
+    "FSM_U": OrderedDict([(("FSM_U",), rename)]),
+    "FSNO": OrderedDict([(("FSNO",), rename)]),
+    "FSNO_EFF": OrderedDict([(("FSNO_EFF",), rename)]),
+    "FSR": OrderedDict([(("FSR",), rename)]),
+    "FSRND": OrderedDict([(("FSRND",), rename)]),
+    "FSRNDLN": OrderedDict([(("FSRNDLN",), rename)]),
+    "FSRNI": OrderedDict([(("FSRNI",), rename)]),
+    "FSRVD": OrderedDict([(("FSRVD",), rename)]),
+    "FSRVDLN": OrderedDict([(("FSRVDLN",), rename)]),
+    "FSRVI": OrderedDict([(("FSRVI",), rename)]),
+    "GC_HEAT1": OrderedDict([(("GC_HEAT1",), rename)]),
+    "GC_ICE1": OrderedDict([(("GC_ICE1",), rename)]),
+    "GC_LIQ1": OrderedDict([(("GC_LIQ1",), rename)]),
+    "GR": OrderedDict(
+        [(("GR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "H2OCAN": OrderedDict([(("H2OCAN",), rename)]),
+    "H2OSFC": OrderedDict([(("H2OSFC",), rename)]),
+    "H2OSNO": OrderedDict([(("H2OSNO",), rename)]),
+    "H2OSNO_TOP": OrderedDict([(("H2OSNO_TOP",), rename)]),
+    "HC": OrderedDict([(("HC",), rename)]),
+    "HCSOI": OrderedDict([(("HCSOI",), rename)]),
+    "HEAT_FROM_AC": OrderedDict([(("HEAT_FROM_AC",), rename)]),
+    "HTOP": OrderedDict([(("HTOP",), rename)]),
+    "INT_SNOW": OrderedDict([(("INT_SNOW",), rename)]),
+    "LABILEP": OrderedDict([(("LABILEP",), rename)]),
+    "LAISHA": OrderedDict([(("LAISHA",), rename)]),
+    "LAISUN": OrderedDict([(("LAISUN",), rename)]),
+    "LAKEICETHICK": OrderedDict([(("LAKEICETHICK",), rename)]),
+    "LAND_USE_FLUX": OrderedDict(
+        [(("LAND_USE_FLUX",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "LEAFC_ALLOC": OrderedDict(
+        [(("LEAFC_ALLOC",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "LEAFN": OrderedDict([(("LEAFN",), rename)]),
+    "LEAFP": OrderedDict([(("LEAFP",), rename)]),
+    "LITFALL": OrderedDict(
+        [(("LITFALL",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "LITHR": OrderedDict(
+        [(("LITHR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "LITR1C": OrderedDict(
+        [(("LITR1C",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "LITR1N": OrderedDict([(("LITR1N",), rename)]),
+    "LITR1P": OrderedDict([(("LITR1P",), rename)]),
+    "LITR2C": OrderedDict(
+        [(("LITR2C",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "LITR2N": OrderedDict([(("LITR2N",), rename)]),
+    "LITR2P": OrderedDict([(("LITR2P",), rename)]),
+    "LITR3C": OrderedDict(
+        [(("LITR3C",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "LITR3N": OrderedDict([(("LITR3N",), rename)]),
+    "LITR3P": OrderedDict([(("LITR3P",), rename)]),
+    "LITTERC": OrderedDict(
+        [(("LITTERC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "LITTERC_HR": OrderedDict(
+        [(("LITTERC_HR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "LITTERC_LOSS": OrderedDict(
+        [(("LITTERC_LOSS",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "LIVECROOTC": OrderedDict(
+        [(("LIVECROOTC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "LIVECROOTN": OrderedDict([(("LIVECROOTN",), rename)]),
+    "LIVECROOTP": OrderedDict([(("LIVECROOTP",), rename)]),
+    "LIVESTEMC": OrderedDict(
+        [(("LIVESTEMC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "LIVESTEMN": OrderedDict([(("LIVESTEMN",), rename)]),
+    "LIVESTEMP": OrderedDict([(("LIVESTEMP",), rename)]),
+    "MR": OrderedDict(
+        [(("MR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "NEE": OrderedDict(
+        [(("NEE",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "NEP": OrderedDict(
+        [(("NEP",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "NET_NMIN": OrderedDict(
+        [(("NET_NMIN",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "NET_PMIN": OrderedDict(
+        [(("NET_PMIN",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "NFIRE": OrderedDict([(("NFIRE",), rename)]),
+    "NPOOL": OrderedDict([(("NPOOL",), rename)]),
+    "OCDEP": OrderedDict([(("OCDEP",), rename)]),
+    "OCCLP": OrderedDict([(("OCCLP",), rename)]),
+    "PARVEGLN": OrderedDict([(("PARVEGLN",), rename)]),
+    "PBOT": OrderedDict([(("PBOT",), rename)]),
+    "PCH4": OrderedDict([(("PCH4",), rename)]),
+    "PCO2": OrderedDict([(("PCO2",), rename)]),
+    "PDEP_TO_SMINP": OrderedDict(
+        [(("PDEP_TO_SMINP",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "PFT_FIRE_CLOSS": OrderedDict(
+        [(("PFT_FIRE_CLOSS",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "PFT_FIRE_NLOSS": OrderedDict(
+        [(("PFT_FIRE_NLOSS",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "PPOOL": OrderedDict([(("PPOOL",), rename)]),
+    "PRIMP": OrderedDict([(("PRIMP",), rename)]),
+    "PSNSHA": OrderedDict([(("PSNSHA",), rename)]),
+    "PSNSHADE_TO_CPOOL": OrderedDict(
+        [
+            (
+                ("PSNSHADE_TO_CPOOL",),
+                lambda v: convert_units(v, target_units="g*/m^2/day"),
+            )
+        ]
+    ),
+    "PSNSUN": OrderedDict([(("PSNSUN",), rename)]),
+    "PSNSUN_TO_CPOOL": OrderedDict(
+        [(("PSNSUN_TO_CPOOL",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "Q2M": OrderedDict([(("Q2M",), rename)]),
+    "QCHARGE": OrderedDict([(("QCHARGE",), rename)]),
+    "QDRAI_PERCH": OrderedDict([(("QDRAI_PERCH",), rename)]),
+    "QDRAI_XS": OrderedDict([(("QDRAI_XS",), rename)]),
+    "QDRIP": OrderedDict([(("QDRIP",), rename)]),
+    "QFLOOD": OrderedDict([(("QFLOOD",), rename)]),
+    "QFLX_ICE_DYNBAL": OrderedDict([(("QFLX_ICE_DYNBAL",), rename)]),
+    "QFLX_LIQ_DYNBAL": OrderedDict([(("QFLX_LIQ_DYNBAL",), rename)]),
+    "QH2OSFC": OrderedDict([(("QH2OSFC",), rename)]),
+    "QRUNOFF_NODYNLNDUSE": OrderedDict([(("QRUNOFF_NODYNLNDUSE",), rename)]),
+    "QRUNOFF_R": OrderedDict([(("QRUNOFF_R",), rename)]),
+    "QRUNOFF_U": OrderedDict([(("QRUNOFF_U",), rename)]),
+    "QSNOMELT": OrderedDict([(("QSNOMELT",), rename)]),
+    "QSNWCPICE": OrderedDict([(("QSNWCPICE",), rename)]),
+    "QSNWCPICE_NODYNLNDUSE": OrderedDict([(("QSNWCPICE_NODYNLNDUSE",), rename)]),
+    "RETRANSN": OrderedDict([(("RETRANSN",), rename)]),
+    "RETRANSP": OrderedDict([(("RETRANSP",), rename)]),
+    "RH2M_R": OrderedDict([(("RH2M_R",), rename)]),
+    "RH2M_U": OrderedDict([(("RH2M_U",), rename)]),
+    "RR": OrderedDict(
+        [(("RR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "SABG": OrderedDict([(("SABG",), rename)]),
+    "SABG_PEN": OrderedDict([(("SABG_PEN",), rename)]),
+    "SABV": OrderedDict([(("SABV",), rename)]),
+    "SECONDP": OrderedDict([(("SECONDP",), rename)]),
+    "SEEDC_GRC": OrderedDict(
+        [(("SEEDC_GRC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "SMIN_NH4": OrderedDict([(("SMIN_NH4",), rename)]),
+    "SMIN_NO3": OrderedDict([(("SMIN_NO3",), rename)]),
+    "SMIN_NO3_RUNOFF": OrderedDict(
+        [(("SMIN_NO3_RUNOFF",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "SMINN": OrderedDict([(("SMINN",), rename)]),
+    "SMINN_TO_NPOOL": OrderedDict(
+        [(("SMINN_TO_NPOOL",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "SMINP": OrderedDict([(("SMINP",), rename)]),
+    "SMINP_LEACHED": OrderedDict(
+        [(("SMINP_LEACHED",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "SMINP_TO_PPOOL": OrderedDict(
+        [(("SMINP_TO_PPOOL",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "SNOBCMCL": OrderedDict([(("SNOBCMCL",), rename)]),
+    "SNOBCMSL": OrderedDict([(("SNOBCMSL",), rename)]),
+    "SNODSTMCL": OrderedDict([(("SNODSTMCL",), rename)]),
+    "SNODSTMSL": OrderedDict([(("SNODSTMSL",), rename)]),
+    "SNOOCMCL": OrderedDict([(("SNOOCMCL",), rename)]),
+    "SNOOCMSL": OrderedDict([(("SNOOCMSL",), rename)]),
+    "SNOWDP": OrderedDict([(("SNOWDP",), rename)]),
+    "SNOWICE": OrderedDict([(("SNOWICE",), rename)]),
+    "SNOWLIQ": OrderedDict([(("SNOWLIQ",), rename)]),
+    "SNOW_DEPTH": OrderedDict([(("SNOW_DEPTH",), rename)]),
+    "SNOW_SINKS": OrderedDict([(("SNOW_SINKS",), rename)]),
+    "SNOW_SOURCES": OrderedDict([(("SNOW_SOURCES",), rename)]),
+    "SNOINTABS": OrderedDict([(("SNOINTABS",), rename)]),
+    "SOIL1C": OrderedDict(
+        [(("SOIL1C",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "SOIL1N": OrderedDict([(("SOIL1N",), rename)]),
+    "SOIL1P": OrderedDict([(("SOIL1P",), rename)]),
+    "SOIL2C": OrderedDict(
+        [(("SOIL2C",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "SOIL2N": OrderedDict([(("SOIL2N",), rename)]),
+    "SOIL2P": OrderedDict([(("SOIL2P",), rename)]),
+    "SOIL3C": OrderedDict(
+        [(("SOIL3C",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "SOIL3N": OrderedDict([(("SOIL3N",), rename)]),
+    "SOIL3P": OrderedDict([(("SOIL3P",), rename)]),
+    "SOIL4C": OrderedDict(
+        [(("SOIL4C",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "SOIL4N": OrderedDict([(("SOIL4N",), rename)]),
+    "SOIL4P": OrderedDict([(("SOIL4P",), rename)]),
+    "SOILC": OrderedDict(
+        [(("SOILC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "SOILC_HR": OrderedDict(
+        [(("SOILC_HR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "SOILC_LOSS": OrderedDict(
+        [(("SOILC_LOSS",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "SoilAlpha": OrderedDict([(("SoilAlpha",), rename)]),
+    "SoilAlpha_U": OrderedDict([(("SoilAlpha_U",), rename)]),
+    "SOLUTIONP": OrderedDict([(("SOLUTIONP",), rename)]),
+    "SOMHR": OrderedDict(
+        [(("SOMHR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "SOM_C_LEACHED": OrderedDict(
+        [(("SOM_C_LEACHED",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "STORVEGC": OrderedDict(
+        [(("STORVEGC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "STORVEGN": OrderedDict([(("STORVEGN",), rename)]),
+    "STORVEGP": OrderedDict([(("STORVEGP",), rename)]),
+    "SUPPLEMENT_TO_SMINN": OrderedDict(
+        [
+            (
+                ("SUPPLEMENT_TO_SMINN",),
+                lambda v: convert_units(v, target_units="mg*/m^2/day"),
+            )
+        ]
+    ),
+    "SUPPLEMENT_TO_SMINP": OrderedDict(
+        [
+            (
+                ("SUPPLEMENT_TO_SMINP",),
+                lambda v: convert_units(v, target_units="mg*/m^2/day"),
+            )
+        ]
+    ),
+    "SUPPLY": OrderedDict([(("SUPPLY",), rename)]),
+    "TBUILD": OrderedDict([(("TBUILD",), rename)]),
+    "TG_R": OrderedDict([(("TG_R",), rename)]),
+    "TG_U": OrderedDict([(("TG_U",), rename)]),
+    "TH2OSFC": OrderedDict([(("TH2OSFC",), rename)]),
+    "THBOT": OrderedDict([(("THBOT",), rename)]),
+    "TKE1": OrderedDict([(("TKE1",), rename)]),
+    "TOTCOLC": OrderedDict(
+        [(("TOTCOLC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TOTCOLN": OrderedDict([(("TOTCOLN",), rename)]),
+    "TOTCOLP": OrderedDict([(("TOTCOLP",), rename)]),
+    "TOTECOSYSC": OrderedDict(
+        [(("TOTECOSYSC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TOTECOSYSN": OrderedDict([(("TOTECOSYSN",), rename)]),
+    "TOTECOSYSP": OrderedDict([(("TOTECOSYSP",), rename)]),
+    "TOTLITC": OrderedDict(
+        [(("TOTLITC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TOTLITC_1m": OrderedDict(
+        [(("TOTLITC_1m",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TOTLITN": OrderedDict([(("TOTLITN",), rename)]),
+    "TOTLITP": OrderedDict([(("TOTLITP",), rename)]),
+    "TOTLITP_1m": OrderedDict([(("TOTLITP_1m",), rename)]),
+    "TOTPFTC": OrderedDict(
+        [(("TOTPFTC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TOTPFTN": OrderedDict([(("TOTPFTN",), rename)]),
+    "TOTPFTP": OrderedDict([(("TOTPFTP",), rename)]),
+    "TOTPRODC": OrderedDict(
+        [(("TOTPRODC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TOTSOMC_1m": OrderedDict(
+        [(("TOTSOMC_1m",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TOTSOMP_1m": OrderedDict([(("TOTSOMP_1m",), rename)]),
+    "TOTVEGC_ABG": OrderedDict(
+        [(("TOTVEGC_ABG",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "TREFMNAV_R": OrderedDict([(("TREFMNAV_R",), rename)]),
+    "TREFMNAV_U": OrderedDict([(("TREFMNAV_U",), rename)]),
+    "TREFMXAV_R": OrderedDict([(("TREFMXAV_R",), rename)]),
+    "TREFMXAV_U": OrderedDict([(("TREFMXAV_U",), rename)]),
+    "TSA_R": OrderedDict([(("TSA_R",), rename)]),
+    "TSA_U": OrderedDict([(("TSA_U",), rename)]),
+    "TSAI": OrderedDict([(("TSAI",), rename)]),
+    "TSOI_10CM": OrderedDict([(("TSOI_10CM",), rename)]),
+    "TV": OrderedDict([(("TV",), rename)]),
+    "TWS": OrderedDict([(("TWS",), rename)]),
+    "TWS_MONTH_BEGIN": OrderedDict([(("TWS_MONTH_BEGIN",), rename)]),
+    "TWS_MONTH_END": OrderedDict([(("TWS_MONTH_END",), rename)]),
+    "U10WITHGUSTS": OrderedDict([(("U10WITHGUSTS",), rename)]),
+    "URBAN_AC": OrderedDict([(("URBAN_AC",), rename)]),
+    "URBAN_HEAT": OrderedDict([(("URBAN_HEAT",), rename)]),
+    "VOLR": OrderedDict([(("VOLR",), rename)]),
+    "VOLRMCH": OrderedDict([(("VOLRMCH",), rename)]),
+    "WA": OrderedDict([(("WA",), rename)]),
+    "WASTEHEAT": OrderedDict([(("WASTEHEAT",), rename)]),
+    "WIND": OrderedDict([(("WIND",), rename)]),
+    "WOODC": OrderedDict(
+        [(("WOODC",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "WOODC_ALLOC": OrderedDict(
+        [(("WOODC_ALLOC",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "WOOD_HARVESTC": OrderedDict(
+        [(("WOOD_HARVESTC",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "WOOD_HARVESTN": OrderedDict(
+        [(("WOOD_HARVESTN",), lambda v: convert_units(v, target_units="mg*/m^2/day"))]
+    ),
+    "XR": OrderedDict(
+        [(("XR",), lambda v: convert_units(v, target_units="g*/m^2/day"))]
+    ),
+    "XSMRPOOL": OrderedDict(
+        [(("XSMRPOOL",), lambda v: convert_units(v, target_units="kgC/m^2"))]
+    ),
+    "ZBOT": OrderedDict([(("ZBOT",), rename)]),
+    "ZWT": OrderedDict([(("ZWT",), rename)]),
+    "ZWT_CH4_UNSAT": OrderedDict([(("ZWT_CH4_UNSAT",), rename)]),
+    "ZWT_PERCH": OrderedDict([(("ZWT_PERCH",), rename)]),
     # Ocean variables
     "tauuo": {("tauuo",): rename},
     "tos": {("tos",): rename},

--- a/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
@@ -1,6 +1,24 @@
+# ============================================================================
+# COMPLETE ELM LAND CONFIGURATION WITH ACTUAL DATA
+# ============================================================================
+# Generated from:
+# - Original: /gpfs/fs1/home/ac.zhang40/e3sm_diags/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
+# - CSV data: /tmp/zppy_land_fields.csv
+# - NetCDF data: /lcrc/group/e3sm2/ac.zhang40/E3SMv3/v3.LR.piControl_land_ilamb/post/lnd/native/clim/50yr/v3.LR.piControl_ANN_000101_005012_climo.nc
+# - Unit conversions: comprehensive_unit_conversion_reference.txt
+#
+# Structure:
+# 1. Original variables (preserved settings + updated case_id with CSV group)
+# 2. New variables from CSV (proper unit conversions + 5th/95th percentile contours)
+# ============================================================================
+
+# ============================================================================
+# ORIGINAL VARIABLES (settings preserved, case_id updated with CSV group)
+# ============================================================================
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Veg State"
 variables = ["BTRAN"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -9,9 +27,11 @@ reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,0.0667,0.133,0.2,0.267,0.333,0.4,0.467,0.533,0.6,0.667,0.733,0.8,0.867,0.933,1.0]
 
+# Updated case_id to: Veg State
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "C State"
 variables = ["CPOOL"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -20,9 +40,11 @@ reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,0.189,0.378,0.566,0.755,0.944,1.13,1.32,1.51,1.7,1.89,2.08,2.27,2.45,2.64,2.83]
 
+# Updated case_id to: C State
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "N Flux"
 variables = ["DENIT"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -31,9 +53,11 @@ reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,0.695,1.39,2.08,2.78,3.47,4.17,4.86,5.56,6.25,6.95,7.64,8.34,9.03,9.73,10.4]
 
+# Updated case_id to: N Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["EFLX_LH_TOT"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -41,9 +65,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [-7.56,2.17,11.9,21.6,31.4,41.1,50.9,60.6,70.3,80.1,89.8,99.5,109.0,119.0,129.0,138.0]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Fire"
 variables = ["FAREA_BURNED"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -51,9 +77,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,7.99e-1,1.6,2.4,3.2,4,4.79,5.59,6.39,7.19,7.99,8.79,9.59,10.4,11.2,12]
+# Updated case_id to: Fire
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["FCEV"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -61,9 +89,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [-2.345,0.596,3.54,6.48,9.42,12.4,15.3,18.2,21.2,24.1,27.1,30.0,32.9,35.9,38.8,41.8]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["FCTR"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -71,9 +101,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,5.91,11.8,17.7,23.6,29.5,35.4,41.3,47.2,53.2,59.1,65.0,70.9,76.8,82.7,88.6]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["FGEV"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -81,9 +113,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [-7.56,1.36,10.3,19.2,28.1,37.1,46.0,54.9,63.8,72.8,81.7,90.6,99.5,108.0,117.0,126.0]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["FGR"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -91,9 +125,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [-46.282,-40.5549,-34.8279,-29.1008,-23.3737,-17.6467,-11.9196,-6.193,-0.47,5.26,11.0,16.7,22.4,28.2,33.9,39.6]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["FIRA"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -101,9 +137,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [-1.917,7.78,17.5,27.2,36.9,46.6,56.3,66.0,75.7,85.4,95.1,105.0,114.0,124.0,134.0,144.0]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["FIRE"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -111,9 +149,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [97.7,126.0,155.0,183.0,212.0,240.0,269.0,297.0,326.0,355.0,383.0,412.0,440.0,469.0,497.0,526.0]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Energy Flux"
 variables = ["FLDS"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -121,9 +161,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [75.3,98.4,122.0,145.0,168.0,191.0,214.0,237.0,260.0,283.0,306.0,329.0,353.0,376.0,399.0,422.0]
+# Updated case_id to: Energy Flux
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Veg State"
 variables = ["FPG"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -131,9 +173,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0.642,0.666,0.689,0.713,0.737,0.761,0.785,0.809,0.833,0.857,0.881,0.904,0.928,0.952,0.976,1.0]
+# Updated case_id to: Veg State
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Veg State"
 variables = ["FPG_P"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -141,9 +185,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0.578,0.606,0.635,0.663,0.691,0.719,0.747,0.775,0.803,0.831,0.859,0.888,0.916,0.944,0.972,1.0]
+# Updated case_id to: Veg State
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Veg State"
 variables = ["FPI"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -151,9 +197,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0.0624,0.125,0.187,0.25,0.312,0.375,0.437,0.5,0.562,0.625,0.687,0.75,0.812,0.875,0.937,1.0]
+# Updated case_id to: Veg State
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Additional Variables"
 variables = ["FPI_P_vr"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -161,9 +209,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,0.0667,0.133,0.2,0.267,0.333,0.4,0.467,0.533,0.6,0.667,0.733,0.8,0.867,0.933,1.0]
+# Original variable (no CSV group info)
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Additional Variables"
 variables = ["FPI_vr"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -171,766 +221,11 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,0.0667,0.133,0.2,0.267,0.333,0.4,0.467,0.533,0.6,0.667,0.733,0.8,0.867,0.933,1.0]
+# Original variable (no CSV group info)
+
 [#]
 sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["FSA"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,18.2,36.4,54.6,72.8,91.0,109.0,127.0,146.0,164.0,182.0,200.0,218.0,237.0,255.0,273.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["FSAT"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0.000502,0.0231,0.0458,0.0684,0.0911,0.114,0.136,0.159,0.182,0.204,0.227,0.25,0.272,0.295,0.317,0.34]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["FSDS"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,25.4,50.8,76.2,102.0,127.0,152.0,178.0,203.0,229.0,254.0,279.0,305.0,330.0,356.0,381.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["FSH"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-44.4209,-32.942,-21.463,-9.984,1.49,13.0,24.5,35.9,47.4,58.9,70.4,81.8,93.3,105.0,116.0,128.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["FSNO"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.0667,0.133,0.2,0.267,0.333,0.4,0.467,0.533,0.6,0.667,0.733,0.8,0.867,0.933,1.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["FSR"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,21.1,42.3,63.4,84.5,106.0,127.0,148.0,169.0,190.0,211.0,233.0,254.0,275.0,296.0,317.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["GPP"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.588,1.18,1.76,2.35,2.94,3.53,4.12,4.71,5.29,5.88,6.47,7.06,7.65,8.24,8.82]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["GROSS_NMIN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,10.6,21.2,31.8,42.5,53.1,63.7,74.3,84.9,95.5,106.0,117.0,127.0,138.0,149.0,159.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["GROSS_PMIN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.303,0.605,0.908,1.21,1.51,1.82,2.12,2.42,2.72,3.03,3.33,3.63,3.94,4.24,4.54]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["H2OSNO"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,66.7,133.0,200.0,267.0,334.0,400.0,467.0,534.0,600.0,667.0,734.0,801.0,867.0,934.0,1000.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["H2OSOI"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [1.44e-06,0.0466,0.0931,0.14,0.186,0.233,0.279,0.326,0.373,0.419,0.466,0.512,0.559,0.605,0.652,0.699]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["HR"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.222,0.444,0.666,0.888,1.11,1.33,1.55,1.78,2.0,2.22,2.44,2.66,2.89,3.11,3.33]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["HR_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,1.81e-05,3.63e-05,5.44e-05,7.26e-05,9.07e-05,0.000109,0.000127,0.000145,0.000163,0.000181,0.0002,0.000218,0.000236,0.000254,0.000272]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["LABILEP_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,9.05,18.1,27.2,36.2,45.3,54.3,63.4,72.4,81.5,90.5,99.6,109.0,118.0,127.0,136.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["LEAFC"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.0228,0.0456,0.0683,0.0911,0.114,0.137,0.159,0.182,0.205,0.228,0.251,0.273,0.296,0.319,0.342]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["LEAFN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.774,1.55,2.32,3.1,3.87,4.64,5.42,6.19,6.97,7.74,8.51,9.29,10.1,10.8,11.6]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["LEAFP"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.0486,0.0972,0.146,0.194,0.243,0.292,0.34,0.389,0.438,0.486,0.535,0.583,0.632,0.681,0.729]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["NBP"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-2.873,-2.493,-2.112,-1.732,-1.352,-0.97,-0.59,-0.21,0.169,0.549,0.93,1.31,1.69,2.07,2.45,2.83]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["NDEP_TO_SMINN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0.00117,0.141,0.281,0.421,0.561,0.7,0.84,0.98,1.12,1.26,1.4,1.54,1.68,1.82,1.96,2.1]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["NFIX_TO_SMINN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.323,0.646,0.969,1.29,1.61,1.94,2.26,2.58,2.91,3.23,3.55,3.88,4.2,4.52,4.84]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["NPP"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-1.302,-0.92,-0.53,-0.14,0.241,0.627,1.01,1.4,1.78,2.17,2.56,2.94,3.33,3.71,4.1,4.48]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["PLANT_NDEMAND_COL"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,8.58,17.2,25.7,34.3,42.9,51.5,60.0,68.6,77.2,85.8,94.3,103.0,112.0,120.0,129.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["PLANT_PDEMAND_COL"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.477,0.955,1.43,1.91,2.39,2.86,3.34,3.82,4.3,4.77,5.25,5.73,6.2,6.68,7.16]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QDRAI"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.445,0.891,1.34,1.78,2.23,2.67,3.12,3.56,4.01,4.45,4.9,5.34,5.79,6.23,6.68]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QINFL"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-0.43,15.4,31.1,46.9,62.7,78.5,94.2,110.0,126.0,142.0,157.0,173.0,189.0,205.0,220.0,236.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QIRRIG_GRND"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QIRRIG_ORIG"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.267,0.534,0.801,1.07,1.33,1.6,1.87,2.14,2.4,2.67,2.94,3.2,3.47,3.74,4.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QIRRIG_REAL"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QIRRIG_SURF"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QIRRIG_WM"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-4.004,-3.737,-3.47,-3.203,-2.936,-2.669,-2.402,-2.135,-1.869,-1.602,-1.335,-1.068,-0.8,-0.53,-0.27,0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QOVER"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.195,0.391,0.586,0.782,0.977,1.17,1.37,1.56,1.76,1.95,2.15,2.35,2.54,2.74,2.93]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QRGWL"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-2.087,-1.719,-1.352,-0.98,-0.62,-0.25,0.118,0.485,0.853,1.22,1.59,1.95,2.32,2.69,3.06,3.42]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QRUNOFF"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-2.068,-1.238,-0.41,0.421,1.25,2.08,2.91,3.74,4.57,5.4,6.23,7.06,7.89,8.72,9.55,10.4]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QSOIL"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-0.23,0.0758,0.382,0.688,0.995,1.3,1.61,1.91,2.22,2.53,2.83,3.14,3.44,3.75,4.06,4.36]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QVEGE"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [-0.1,0.0206,0.122,0.224,0.325,0.427,0.529,0.63,0.732,0.833,0.935,1.04,1.14,1.24,1.34,1.44]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["QVEGT"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.204,0.408,0.612,0.816,1.02,1.22,1.43,1.63,1.84,2.04,2.24,2.45,2.65,2.86,3.06]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["RAIN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.96,1.92,2.88,3.84,4.8,5.76,6.72,7.68,8.64,9.6,10.6,11.5,12.5,13.4,14.4]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["RH2M"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [15.7,21.3,26.9,32.5,38.2,43.8,49.4,55.0,60.6,66.3,71.9,77.5,83.1,88.7,94.4,100.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMINN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,4.97,9.94,14.9,19.9,24.9,29.8,34.8,39.8,44.7,49.7,54.7,59.6,64.6,69.6,74.6]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMINN_TO_PLANT"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,4.75,9.49,14.2,19.0,23.7,28.5,33.2,38.0,42.7,47.5,52.2,57.0,61.7,66.5,71.2]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMINP"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,421.0,842.0,1260.0,1680.0,2100.0,2520.0,2950.0,3370.0,3790.0,4210.0,4630.0,5050.0,5470.0,5890.0,6310.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMINP_TO_PLANT"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.296,0.591,0.887,1.18,1.48,1.77,2.07,2.37,2.66,2.96,3.25,3.55,3.84,4.14,4.43]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMIN_NH4"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.158,0.316,0.475,0.633,0.791,0.949,1.11,1.27,1.42,1.58,1.74,1.9,2.06,2.21,2.37]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMIN_NH4_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.295,0.591,0.886,1.18,1.48,1.77,2.07,2.36,2.66,2.95,3.25,3.55,3.84,4.14,4.43]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMIN_NO3"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,4.96,9.92,14.9,19.8,24.8,29.8,34.7,39.7,44.7,49.6,54.6,59.5,64.5,69.5,74.4]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SMIN_NO3_LEACHED"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.0362,0.0724,0.109,0.145,0.181,0.217,0.253,0.289,0.326,0.362,0.398,0.434,0.47,0.507,0.543]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SNOW"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.234,0.468,0.702,0.936,1.17,1.4,1.64,1.87,2.11,2.34,2.57,2.81,3.04,3.28,3.51]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SNOWDP"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.155,0.311,0.466,0.621,0.777,0.932,1.09,1.24,1.4,1.55,1.71,1.86,2.02,2.17,2.33]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SNOWICE"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,66.7,133.0,200.0,267.0,334.0,400.0,467.0,534.0,600.0,667.0,734.0,801.0,867.0,934.0,1000.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SNOWLIQ"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,1.08,2.16,3.24,4.32,5.4,6.48,7.56,8.64,9.72,10.8,11.9,13.0,14.0,15.1,16.2]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SNOW_DEPTH"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.155,0.311,0.466,0.622,0.777,0.932,1.09,1.24,1.4,1.55,1.71,1.86,2.02,2.18,2.33]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL1C_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,12.4,24.8,37.3,49.7,62.1,74.5,86.9,99.3,112.0,124.0,137.0,149.0,161.0,174.0,186.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL1N_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,1.03,2.07,3.1,4.14,5.17,6.21,7.24,8.28,9.31,10.3,11.4,12.4,13.5,14.5,15.5]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL1P_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.0345,0.069,0.103,0.138,0.172,0.207,0.241,0.276,0.31,0.345,0.379,0.414,0.448,0.483,0.517]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL2C_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,110.0,220.0,330.0,440.0,550.0,660.0,770.0,880.0,990.0,1100.0,1210.0,1320.0,1430.0,1540.0,1650.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL2N_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,9.17,18.3,27.5,36.7,45.8,55.0,64.2,73.3,82.5,91.7,101.0,110.0,119.0,128.0,137.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL2P_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.306,0.611,0.917,1.22,1.53,1.83,2.14,2.44,2.75,3.06,3.36,3.67,3.97,4.28,4.58]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL3C_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,855.0,1710.0,2570.0,3420.0,4280.0,5130.0,5990.0,6840.0,7700.0,8550.0,9410.0,10300.0,11100.0,12000.0,12800.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL3N_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,85.5,171.0,257.0,342.0,428.0,513.0,599.0,684.0,770.0,855.0,941.0,1030.0,1110.0,1200.0,1280.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL3P_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,1.71,3.42,5.13,6.84,8.55,10.3,12.0,13.7,15.4,17.1,18.8,20.5,22.2,23.9,25.7]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL4C_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,3450.0,6890.0,10300.0,13800.0,17200.0,20700.0,24100.0,27600.0,31000.0,34500.0,37900.0,41400.0,44800.0,48300.0,51700.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL4N_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,345.0,689.0,1030.0,1380.0,1720.0,2070.0,2410.0,2760.0,3100.0,3450.0,3790.0,4140.0,4480.0,4830.0,5170.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOIL4P_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,6.89,13.8,20.7,27.6,34.5,41.3,48.2,55.1,62.0,68.9,75.8,82.7,89.6,96.5,103.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOILWATER_10CM"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [5.32,10.1,14.9,19.6,24.4,29.2,33.9,38.7,43.5,48.2,53.0,57.8,62.5,67.3,72.1,76.8]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SOLUTIONP_vr"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.0123,0.0247,0.037,0.0493,0.0617,0.074,0.0863,0.0987,0.111,0.123,0.136,0.148,0.16,0.173,0.185]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["SR"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.37,0.74,1.11,1.48,1.85,2.22,2.59,2.96,3.33,3.7,4.07,4.44,4.81,5.18,5.55]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TBOT"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [210.0,217.0,223.0,230.0,236.0,243.0,249.0,256.0,262.0,268.0,275.0,281.0,288.0,294.0,301.0,307.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TLAI"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,0.412,0.823,1.23,1.65,2.06,2.47,2.88,3.29,3.7,4.12,4.53,4.94,5.35,5.76,6.17]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TOTSOMC"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,7.38,14.8,22.1,29.5,36.9,44.3,51.6,59.0,66.4,73.8,81.2,88.5,95.9,103.0,111.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TOTSOMN"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,737.0,1470.0,2210.0,2950.0,3690.0,4420.0,5160.0,5900.0,6640.0,7370.0,8110.0,8850.0,9590.0,10300.0,11100.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TOTSOMP"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,14.8,29.6,44.3,59.1,73.9,88.7,103.0,118.0,133.0,148.0,163.0,177.0,192.0,207.0,222.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TOTVEGC"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [0,2.79,5.58,8.38,11.2,14.0,16.8,19.5,22.3,25.1,27.9,30.7,33.5,36.3,39.1,41.9]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TSA"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [207.0,213.0,220.0,227.0,233.0,240.0,247.0,254.0,260.0,267.0,274.0,281.0,287.0,294.0,301.0,307.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TSOI"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [238.0,243.0,248.0,253.0,257.0,262.0,267.0,272.0,276.0,281.0,286.0,291.0,295.0,300.0,305.0,310.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["TWS"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [1680.0,4470.0,7270.0,10100.0,12900.0,15700.0,18400.0,21200.0,24000.0,26800.0,29600.0,32400.0,35200.0,38000.0,40800.0,43600.0]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
-variables = ["ZWT"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [2.35,4.0,5.66,7.31,8.97,10.6,12.3,13.9,15.6,17.2,18.9,20.6,22.2,23.9,25.5,27.2]
-[#]
-sets = ["lat_lon_land"]
-case_id = "model_vs_model"
+case_id = "Additional Variables"
 variables = ["FP_UPTAKE"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
 regions = ["global"]
@@ -938,3 +233,6047 @@ test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [0,0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSA"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,18.2,36.4,54.6,72.8,91.0,109.0,127.0,146.0,164.0,182.0,200.0,218.0,237.0,255.0,273.0]
+# Updated case_id to: Energy Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["FSAT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.000502,0.0231,0.0458,0.0684,0.0911,0.114,0.136,0.159,0.182,0.204,0.227,0.25,0.272,0.295,0.317,0.34]
+# Updated case_id to: Physical State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,25.4,50.8,76.2,102.0,127.0,152.0,178.0,203.0,229.0,254.0,279.0,305.0,330.0,356.0,381.0]
+# Updated case_id to: Energy Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSH"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-44.4209,-32.942,-21.463,-9.984,1.49,13.0,24.5,35.9,47.4,58.9,70.4,81.8,93.3,105.0,116.0,128.0]
+# Updated case_id to: Energy Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["FSNO"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0667,0.133,0.2,0.267,0.333,0.4,0.467,0.533,0.6,0.667,0.733,0.8,0.867,0.933,1.0]
+# Updated case_id to: Physical State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,21.1,42.3,63.4,84.5,106.0,127.0,148.0,169.0,190.0,211.0,233.0,254.0,275.0,296.0,317.0]
+# Updated case_id to: Energy Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["GPP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.588,1.18,1.76,2.35,2.94,3.53,4.12,4.71,5.29,5.88,6.47,7.06,7.65,8.24,8.82]
+# Updated case_id to: C Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["GROSS_NMIN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,10.6,21.2,31.8,42.5,53.1,63.7,74.3,84.9,95.5,106.0,117.0,127.0,138.0,149.0,159.0]
+# Updated case_id to: N Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["GROSS_PMIN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.303,0.605,0.908,1.21,1.51,1.82,2.12,2.42,2.72,3.03,3.33,3.63,3.94,4.24,4.54]
+# Updated case_id to: P Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["H2OSNO"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,66.7,133.0,200.0,267.0,334.0,400.0,467.0,534.0,600.0,667.0,734.0,801.0,867.0,934.0,1000.0]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["H2OSOI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [1.44e-06,0.0466,0.0931,0.14,0.186,0.233,0.279,0.326,0.373,0.419,0.466,0.512,0.559,0.605,0.652,0.699]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["HR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.222,0.444,0.666,0.888,1.11,1.33,1.55,1.78,2.0,2.22,2.44,2.66,2.89,3.11,3.33]
+# Updated case_id to: C Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["HR_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.81e-05,3.63e-05,5.44e-05,7.26e-05,9.07e-05,0.000109,0.000127,0.000145,0.000163,0.000181,0.0002,0.000218,0.000236,0.000254,0.000272]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["LABILEP_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,9.05,18.1,27.2,36.2,45.3,54.3,63.4,72.4,81.5,90.5,99.6,109.0,118.0,127.0,136.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["LEAFC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0228,0.0456,0.0683,0.0911,0.114,0.137,0.159,0.182,0.205,0.228,0.251,0.273,0.296,0.319,0.342]
+# Updated case_id to: C State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["LEAFN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.774,1.55,2.32,3.1,3.87,4.64,5.42,6.19,6.97,7.74,8.51,9.29,10.1,10.8,11.6]
+# Updated case_id to: N State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["LEAFP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0486,0.0972,0.146,0.194,0.243,0.292,0.34,0.389,0.438,0.486,0.535,0.583,0.632,0.681,0.729]
+# Updated case_id to: P State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["NBP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-2.873,-2.493,-2.112,-1.732,-1.352,-0.97,-0.59,-0.21,0.169,0.549,0.93,1.31,1.69,2.07,2.45,2.83]
+# Updated case_id to: C Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["NDEP_TO_SMINN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.00117,0.141,0.281,0.421,0.561,0.7,0.84,0.98,1.12,1.26,1.4,1.54,1.68,1.82,1.96,2.1]
+# Updated case_id to: N Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["NFIX_TO_SMINN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.323,0.646,0.969,1.29,1.61,1.94,2.26,2.58,2.91,3.23,3.55,3.88,4.2,4.52,4.84]
+# Updated case_id to: N Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["NPP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1.302,-0.92,-0.53,-0.14,0.241,0.627,1.01,1.4,1.78,2.17,2.56,2.94,3.33,3.71,4.1,4.48]
+# Updated case_id to: C Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["PLANT_NDEMAND_COL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,8.58,17.2,25.7,34.3,42.9,51.5,60.0,68.6,77.2,85.8,94.3,103.0,112.0,120.0,129.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["PLANT_PDEMAND_COL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.477,0.955,1.43,1.91,2.39,2.86,3.34,3.82,4.3,4.77,5.25,5.73,6.2,6.68,7.16]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QDRAI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.445,0.891,1.34,1.78,2.23,2.67,3.12,3.56,4.01,4.45,4.9,5.34,5.79,6.23,6.68]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QINFL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.43,15.4,31.1,46.9,62.7,78.5,94.2,110.0,126.0,142.0,157.0,173.0,189.0,205.0,220.0,236.0]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QIRRIG_GRND"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QIRRIG_ORIG"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.267,0.534,0.801,1.07,1.33,1.6,1.87,2.14,2.4,2.67,2.94,3.2,3.47,3.74,4.0]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QIRRIG_REAL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QIRRIG_SURF"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QIRRIG_WM"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-4.004,-3.737,-3.47,-3.203,-2.936,-2.669,-2.402,-2.135,-1.869,-1.602,-1.335,-1.068,-0.8,-0.53,-0.27,0]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QOVER"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.195,0.391,0.586,0.782,0.977,1.17,1.37,1.56,1.76,1.95,2.15,2.35,2.54,2.74,2.93]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QRGWL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-2.087,-1.719,-1.352,-0.98,-0.62,-0.25,0.118,0.485,0.853,1.22,1.59,1.95,2.32,2.69,3.06,3.42]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QRUNOFF"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-2.068,-1.238,-0.41,0.421,1.25,2.08,2.91,3.74,4.57,5.4,6.23,7.06,7.89,8.72,9.55,10.4]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QSOIL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.23,0.0758,0.382,0.688,0.995,1.3,1.61,1.91,2.22,2.53,2.83,3.14,3.44,3.75,4.06,4.36]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QVEGE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.1,0.0206,0.122,0.224,0.325,0.427,0.529,0.63,0.732,0.833,0.935,1.04,1.14,1.24,1.34,1.44]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QVEGT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.204,0.408,0.612,0.816,1.02,1.22,1.43,1.63,1.84,2.04,2.24,2.45,2.65,2.86,3.06]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["RAIN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.96,1.92,2.88,3.84,4.8,5.76,6.72,7.68,8.64,9.6,10.6,11.5,12.5,13.4,14.4]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["RH2M"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [15.7,21.3,26.9,32.5,38.2,43.8,49.4,55.0,60.6,66.3,71.9,77.5,83.1,88.7,94.4,100.0]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["SMINN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.97,9.94,14.9,19.9,24.9,29.8,34.8,39.8,44.7,49.7,54.7,59.6,64.6,69.6,74.6]
+# Updated case_id to: N State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["SMINN_TO_PLANT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.75,9.49,14.2,19.0,23.7,28.5,33.2,38.0,42.7,47.5,52.2,57.0,61.7,66.5,71.2]
+# Updated case_id to: N Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["SMINP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,421.0,842.0,1260.0,1680.0,2100.0,2520.0,2950.0,3370.0,3790.0,4210.0,4630.0,5050.0,5470.0,5890.0,6310.0]
+# Updated case_id to: P State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["SMINP_TO_PLANT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.296,0.591,0.887,1.18,1.48,1.77,2.07,2.37,2.66,2.96,3.25,3.55,3.84,4.14,4.43]
+# Updated case_id to: P Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["SMIN_NH4"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.158,0.316,0.475,0.633,0.791,0.949,1.11,1.27,1.42,1.58,1.74,1.9,2.06,2.21,2.37]
+# Updated case_id to: N State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SMIN_NH4_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.295,0.591,0.886,1.18,1.48,1.77,2.07,2.36,2.66,2.95,3.25,3.55,3.84,4.14,4.43]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["SMIN_NO3"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.96,9.92,14.9,19.8,24.8,29.8,34.7,39.7,44.7,49.6,54.6,59.5,64.5,69.5,74.4]
+# Updated case_id to: N State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["SMIN_NO3_LEACHED"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0362,0.0724,0.109,0.145,0.181,0.217,0.253,0.289,0.326,0.362,0.398,0.434,0.47,0.507,0.543]
+# Updated case_id to: N Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["SNOW"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.234,0.468,0.702,0.936,1.17,1.4,1.64,1.87,2.11,2.34,2.57,2.81,3.04,3.28,3.51]
+# Updated case_id to: H2O Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["SNOWDP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.155,0.311,0.466,0.621,0.777,0.932,1.09,1.24,1.4,1.55,1.71,1.86,2.02,2.17,2.33]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["SNOWICE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,66.7,133.0,200.0,267.0,334.0,400.0,467.0,534.0,600.0,667.0,734.0,801.0,867.0,934.0,1000.0]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["SNOWLIQ"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.08,2.16,3.24,4.32,5.4,6.48,7.56,8.64,9.72,10.8,11.9,13.0,14.0,15.1,16.2]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["SNOW_DEPTH"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.155,0.311,0.466,0.622,0.777,0.932,1.09,1.24,1.4,1.55,1.71,1.86,2.02,2.18,2.33]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL1C_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,12.4,24.8,37.3,49.7,62.1,74.5,86.9,99.3,112.0,124.0,137.0,149.0,161.0,174.0,186.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL1N_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.03,2.07,3.1,4.14,5.17,6.21,7.24,8.28,9.31,10.3,11.4,12.4,13.5,14.5,15.5]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL1P_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0345,0.069,0.103,0.138,0.172,0.207,0.241,0.276,0.31,0.345,0.379,0.414,0.448,0.483,0.517]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL2C_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,110.0,220.0,330.0,440.0,550.0,660.0,770.0,880.0,990.0,1100.0,1210.0,1320.0,1430.0,1540.0,1650.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL2N_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,9.17,18.3,27.5,36.7,45.8,55.0,64.2,73.3,82.5,91.7,101.0,110.0,119.0,128.0,137.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL2P_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.306,0.611,0.917,1.22,1.53,1.83,2.14,2.44,2.75,3.06,3.36,3.67,3.97,4.28,4.58]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL3C_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,855.0,1710.0,2570.0,3420.0,4280.0,5130.0,5990.0,6840.0,7700.0,8550.0,9410.0,10300.0,11100.0,12000.0,12800.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL3N_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,85.5,171.0,257.0,342.0,428.0,513.0,599.0,684.0,770.0,855.0,941.0,1030.0,1110.0,1200.0,1280.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL3P_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.71,3.42,5.13,6.84,8.55,10.3,12.0,13.7,15.4,17.1,18.8,20.5,22.2,23.9,25.7]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL4C_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,3450.0,6890.0,10300.0,13800.0,17200.0,20700.0,24100.0,27600.0,31000.0,34500.0,37900.0,41400.0,44800.0,48300.0,51700.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL4N_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,345.0,689.0,1030.0,1380.0,1720.0,2070.0,2410.0,2760.0,3100.0,3450.0,3790.0,4140.0,4480.0,4830.0,5170.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOIL4P_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,6.89,13.8,20.7,27.6,34.5,41.3,48.2,55.1,62.0,68.9,75.8,82.7,89.6,96.5,103.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["SOILWATER_10CM"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [5.32,10.1,14.9,19.6,24.4,29.2,33.9,38.7,43.5,48.2,53.0,57.8,62.5,67.3,72.1,76.8]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["SOLUTIONP_vr"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0123,0.0247,0.037,0.0493,0.0617,0.074,0.0863,0.0987,0.111,0.123,0.136,0.148,0.16,0.173,0.185]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["SR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.37,0.74,1.11,1.48,1.85,2.22,2.59,2.96,3.33,3.7,4.07,4.44,4.81,5.18,5.55]
+# Updated case_id to: C Flux
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TBOT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [210.0,217.0,223.0,230.0,236.0,243.0,249.0,256.0,262.0,268.0,275.0,281.0,288.0,294.0,301.0,307.0]
+# Updated case_id to: Energy State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["TLAI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.412,0.823,1.23,1.65,2.06,2.47,2.88,3.29,3.7,4.12,4.53,4.94,5.35,5.76,6.17]
+# Updated case_id to: Veg State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTSOMC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,7.38,14.8,22.1,29.5,36.9,44.3,51.6,59.0,66.4,73.8,81.2,88.5,95.9,103.0,111.0]
+# Updated case_id to: C State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["TOTSOMN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,737.0,1470.0,2210.0,2950.0,3690.0,4420.0,5160.0,5900.0,6640.0,7370.0,8110.0,8850.0,9590.0,10300.0,11100.0]
+# Updated case_id to: N State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTSOMP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,14.8,29.6,44.3,59.1,73.9,88.7,103.0,118.0,133.0,148.0,163.0,177.0,192.0,207.0,222.0]
+# Updated case_id to: P State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTVEGC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2.79,5.58,8.38,11.2,14.0,16.8,19.5,22.3,25.1,27.9,30.7,33.5,36.3,39.1,41.9]
+# Updated case_id to: C State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TSA"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [207.0,213.0,220.0,227.0,233.0,240.0,247.0,254.0,260.0,267.0,274.0,281.0,287.0,294.0,301.0,307.0]
+# Updated case_id to: Energy State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Additional Variables"
+variables = ["TSOI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [238.0,243.0,248.0,253.0,257.0,262.0,267.0,272.0,276.0,281.0,286.0,291.0,295.0,300.0,305.0,310.0]
+# Original variable (no CSV group info)
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["TWS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [1680.0,4470.0,7270.0,10100.0,12900.0,15700.0,18400.0,21200.0,24000.0,26800.0,29600.0,32400.0,35200.0,38000.0,40800.0,43600.0]
+# Updated case_id to: H2O State
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["ZWT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [2.35,4.0,5.66,7.31,8.97,10.6,12.3,13.9,15.6,17.2,18.9,20.6,22.2,23.9,25.5,27.2]
+# Updated case_id to: Physical State
+
+# ============================================================================
+# NEW VARIABLES FROM CSV (proper unit conversions + data-driven contours)
+# ============================================================================
+
+# AEROSOL FLUX (4 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol Flux"
+variables = ["BCDEP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,6.6e-14,1.32e-13,1.98e-13,2.63e-13,3.29e-13,3.95e-13,4.61e-13,5.26e-13,5.92e-13,6.58e-13,7.24e-13,7.9e-13,8.55e-13,9.21e-13,9.87e-13]
+# group: Aerosol Flux
+# original_units: kg/m^2/s
+# target_units: kg/m^2/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total black carbon deposition (dry+wet) from atmosphere
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol Flux"
+variables = ["DSTDEP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2e-10,4e-10,5e-10,7e-10,9e-10,1.1e-09,1.3e-09,1.5e-09,1.6e-09,1.8e-09,2e-09,2.2e-09,2.4e-09,2.5e-09,2.7e-09]
+# group: Aerosol Flux
+# original_units: kg/m^2/s
+# target_units: kg/m^2/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total dust deposition (dry+wet) from atmosphere
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol Flux"
+variables = ["DSTFLXT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.2e-09,8.5e-09,1.27e-08,1.7e-08,2.12e-08,2.54e-08,2.97e-08,3.39e-08,3.82e-08,4.24e-08,4.66e-08,5.09e-08,5.51e-08,5.94e-08,6.36e-08]
+# group: Aerosol Flux
+# original_units: kg/m2/s
+# target_units: kg/m2/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total surface dust emission
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol Flux"
+variables = ["OCDEP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [8e-15,1.969e-12,3.93e-12,5.891e-12,7.852e-12,9.813e-12,1.1774e-11,1.3735e-11,1.5696e-11,1.7657e-11,1.9618e-11,2.1579e-11,2.354e-11,2.5501e-11,2.7462e-11,2.9423e-11]
+# group: Aerosol Flux
+# original_units: kg/m^2/s
+# target_units: kg/m^2/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total OC deposition (dry+wet) from atmosphere
+# contours: 5th/95th percentiles from PI control data
+
+# AEROSOL STATE (6 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol State"
+variables = ["SNOBCMCL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.8e-07,3.6e-07,5.3e-07,7.1e-07,8.9e-07,1.07e-06,1.25e-06,1.42e-06,1.6e-06,1.78e-06,1.96e-06,2.14e-06,2.32e-06,2.49e-06,2.67e-06]
+# group: Aerosol State
+# original_units: kg/m2
+# target_units: kg/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: mass of black carbon in snow column
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol State"
+variables = ["SNOBCMSL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.2e-09,8.4e-09,1.26e-08,1.68e-08,2.1e-08,2.52e-08,2.94e-08,3.36e-08,3.78e-08,4.2e-08,4.62e-08,5.04e-08,5.46e-08,5.88e-08,6.3e-08]
+# group: Aerosol State
+# original_units: kg/m2
+# target_units: kg/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: mass of black carbon in top snow layer
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol State"
+variables = ["SNODSTMCL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000277,0.000553,0.00083,0.001107,0.001383,0.00166,0.001936,0.002213,0.00249,0.002766,0.003043,0.00332,0.003596,0.003873,0.00415]
+# group: Aerosol State
+# original_units: kg/m2
+# target_units: kg/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: mass of dust in snow column
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol State"
+variables = ["SNODSTMSL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,3.35e-06,6.69e-06,1.004e-05,1.338e-05,1.673e-05,2.007e-05,2.342e-05,2.677e-05,3.011e-05,3.346e-05,3.68e-05,4.015e-05,4.35e-05,4.684e-05,5.019e-05]
+# group: Aerosol State
+# original_units: kg/m2
+# target_units: kg/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: mass of dust in top snow layer
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol State"
+variables = ["SNOOCMCL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.92e-06,9.85e-06,1.477e-05,1.97e-05,2.462e-05,2.955e-05,3.447e-05,3.94e-05,4.432e-05,4.925e-05,5.417e-05,5.909e-05,6.402e-05,6.894e-05,7.387e-05]
+# group: Aerosol State
+# original_units: kg/m2
+# target_units: kg/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: mass of OC in snow column
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Aerosol State"
+variables = ["SNOOCMSL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.4e-07,2.7e-07,4.1e-07,5.4e-07,6.8e-07,8.1e-07,9.5e-07,1.08e-06,1.22e-06,1.36e-06,1.49e-06,1.63e-06,1.76e-06,1.9e-06,2.03e-06]
+# group: Aerosol State
+# original_units: kg/m2
+# target_units: kg/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: mass of OC in top snow layer
+# contours: 5th/95th percentiles from PI control data
+
+# C FLUX (36 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["AGNPP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.087,0.1739,0.2609,0.3478,0.4348,0.5217,0.6087,0.6956,0.7826,0.8695,0.9565,1.0434,1.1304,1.2173,1.3043]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: aboveground NPP
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["AR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.3046,0.6091,0.9137,1.2183,1.5229,1.8274,2.132,2.4366,2.7412,3.0457,3.3503,3.6549,3.9595,4.264,4.5686]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: autotrophic respiration (maintenance + growth)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["BGNPP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.066216,0.132431,0.198647,0.264863,0.331078,0.397294,0.46351,0.529725,0.595941,0.662157,0.728372,0.794588,0.860804,0.927019,0.993235]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: belowground NPP
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["CH4PROD"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000328,0.000656,0.000985,0.001313,0.001641,0.001969,0.002297,0.002625,0.002954,0.003282,0.00361,0.003938,0.004266,0.004595,0.004923]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: gridcell total production of CH4
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["DWT_CONV_CFLUX_GRC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: land conversion C flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["DWT_SLASH_CFLUX"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: slash C flux to litter and CWD due to land use
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["ER"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.4503,0.9006,1.351,1.8013,2.2516,2.7019,3.1522,3.6026,4.0529,4.5032,4.9535,5.4038,5.8542,6.3045,6.7548]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: total ecosystem respiration (autotrophic + heterotrophic)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["FCH4"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-3.6e-07,-1.6e-07,5e-08,2.5e-07,4.5e-07,6.5e-07,8.6e-07,1.06e-06,1.26e-06,1.46e-06,1.67e-06,1.87e-06,2.07e-06,2.27e-06,2.48e-06,2.68e-06]
+# group: C Flux
+# original_units: kgC/m2/s
+# target_units: kgC/m2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: gridcell surface CH4 flux to atmosphere (+ to atm)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["FCH4TOCO2"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000145,0.000291,0.000436,0.000582,0.000727,0.000872,0.001018,0.001163,0.001309,0.001454,0.001599,0.001745,0.00189,0.002036,0.002181]
+# group: C Flux
+# original_units: gC/m2/s
+# target_units: gC/m2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: gridcell oxidation of CH4 to CO2
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["FPSN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.4394,0.8788,1.3182,1.7576,2.197,2.6364,3.0758,3.5152,3.9546,4.394,4.8334,5.2728,5.7122,6.1516,6.591]
+# group: C Flux
+# original_units: umol/m2s
+# target_units: umol/m2s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: photosynthesis
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["FPSN_WC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.198,0.396,0.594,0.792,0.99,1.188,1.386,1.584,1.782,1.98,2.178,2.376,2.574,2.772,2.97]
+# group: C Flux
+# original_units: umol/m2s
+# target_units: umol/m2s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: Rubisco-limited photosynthesis
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["FPSN_WJ"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2444,0.4889,0.7333,0.9778,1.2222,1.4666,1.7111,1.9555,2.2,2.4444,2.6888,2.9333,3.1777,3.4222,3.6666]
+# group: C Flux
+# original_units: umol/m2s
+# target_units: umol/m2s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: RuBP-limited photosynthesis
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["FPSN_WP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.013992,0.027984,0.041976,0.055968,0.06996,0.083952,0.097944,0.111936,0.125928,0.13992,0.153912,0.167904,0.181896,0.195888,0.20988]
+# group: C Flux
+# original_units: umol/m2s
+# target_units: umol/m2s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: product-limited photosynthesis
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["FROOTC_ALLOC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.052333,0.104667,0.157,0.209334,0.261667,0.314,0.366334,0.418667,0.471001,0.523334,0.575667,0.628001,0.680334,0.732668,0.785001]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: fine root C allocation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["GR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.046637,0.093275,0.139912,0.186549,0.233187,0.279824,0.326461,0.373098,0.419736,0.466373,0.51301,0.559648,0.606285,0.652922,0.69956]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: total growth respiration
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["LAND_USE_FLUX"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: total C emitted from land cover conversion and wood product pools
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["LEAFC_ALLOC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.044444,0.088887,0.133331,0.177774,0.222218,0.266661,0.311105,0.355549,0.399992,0.444436,0.488879,0.533323,0.577766,0.62221,0.666654]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: leaf C allocation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["LITFALL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1544,0.3088,0.4631,0.6175,0.7719,0.9263,1.0806,1.235,1.3894,1.5438,1.6981,1.8525,2.0069,2.1613,2.3156]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: litterfall (leaves and fine roots)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["LITHR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0717,0.1434,0.2151,0.2867,0.3584,0.4301,0.5018,0.5735,0.6452,0.7169,0.7885,0.8602,0.9319,1.0036,1.0753]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: litter heterotrophic respiration
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["LITTERC_HR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0717,0.1434,0.2151,0.2867,0.3584,0.4301,0.5018,0.5735,0.6452,0.7169,0.7885,0.8602,0.9319,1.0036,1.0753]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: litter C heterotrophic respiration
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["LITTERC_LOSS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1569,0.3138,0.4707,0.6276,0.7845,0.9414,1.0983,1.2552,1.4121,1.569,1.7259,1.8828,2.0397,2.1966,2.3536]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: litter C loss
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["MR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1699,0.3398,0.5097,0.6795,0.8494,1.0193,1.1892,1.3591,1.529,1.6988,1.8687,2.0386,2.2085,2.3784,2.5483]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: maintenance respiration
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["NEE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.017931,-0.015485,-0.013039,-0.010594,-0.008148,-0.005702,-0.003257,-0.000811,0.001635,0.00408,0.006526,0.008972,0.011417,0.013863,0.016309,0.018754]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: net ecosystem exchange of carbon (positive for source)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["NEP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.0075,0.018356,0.044213,0.070069,0.095925,0.121782,0.147638,0.173494,0.199351,0.225207,0.251063,0.27692,0.302776,0.328632,0.354489,0.380345]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: net ecosystem production (no fire/landuse/harvest flux: positive for sink
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["PSNSHA"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0863,0.1726,0.2589,0.3452,0.4314,0.5177,0.604,0.6903,0.7766,0.8629,0.9492,1.0355,1.1217,1.208,1.2943]
+# group: C Flux
+# original_units: umolCO2/m^2/s
+# target_units: umolCO2/m^2/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: shaded leaf photosynthesis
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["PSNSHADE_TO_CPOOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.232,0.464,0.696,0.928,1.16,1.3921,1.6241,1.8561,2.0881,2.3201,2.5521,2.7841,3.0161,3.2481,3.4801]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: C fixation from shaded canopy
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["PSNSUN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2429,0.4857,0.7286,0.9714,1.2143,1.4572,1.7,1.9429,2.1858,2.4286,2.6715,2.9143,3.1572,3.4001,3.6429]
+# group: C Flux
+# original_units: umolCO2/m^2/s
+# target_units: umolCO2/m^2/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: sunlit leaf photosynthesis
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["PSNSUN_TO_CPOOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2379,0.4759,0.7138,0.9518,1.1897,1.4276,1.6656,1.9035,2.1415,2.3794,2.6173,2.8553,3.0932,3.3312,3.5691]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: C fixation from sunlit canopy
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["RR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1171,0.2341,0.3512,0.4682,0.5853,0.7024,0.8194,0.9365,1.0536,1.1706,1.2877,1.4047,1.5218,1.6389,1.7559]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: root respiration (fine root MR + total root GR)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["SOILC_HR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0853,0.1706,0.2558,0.3411,0.4264,0.5117,0.5969,0.6822,0.7675,0.8528,0.9381,1.0233,1.1086,1.1939,1.2792]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: soil C heterotrophic respiration
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["SOILC_LOSS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0853,0.1706,0.2558,0.3411,0.4264,0.5117,0.5969,0.6822,0.7675,0.8528,0.9381,1.0233,1.1086,1.1939,1.2792]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: soil C loss
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["SOMHR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0853,0.1706,0.2558,0.3411,0.4264,0.5117,0.5969,0.6822,0.7675,0.8528,0.9381,1.0233,1.1086,1.1939,1.2792]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: soil organic matter heterotrophic respiration
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["SOM_C_LEACHED"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: total flux of C from SOM pools due to leaching
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["WOODC_ALLOC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.058776,0.117552,0.176328,0.235103,0.293879,0.352655,0.411431,0.470207,0.528983,0.587759,0.646534,0.70531,0.764086,0.822862,0.881638]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: wood C allocation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["WOOD_HARVESTC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: wood harvest C (to product pools)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C Flux"
+variables = ["XR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1013,0.2025,0.3038,0.405,0.5063,0.6075,0.7088,0.8101,0.9113,1.0126,1.1138,1.2151,1.3163,1.4176,1.5189]
+# group: C Flux
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: total excess respiration
+# contours: 5th/95th percentiles from PI control data
+
+# C STATE (28 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["CWDC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2419,0.4838,0.7256,0.9675,1.2094,1.4513,1.6932,1.9351,2.1769,2.4188,2.6607,2.9026,3.1445,3.3864,3.6282]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: coarse woody debris C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["DEADCROOTC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2333,0.4666,0.6999,0.9332,1.1665,1.3998,1.6331,1.8664,2.0997,2.333,2.5663,2.7996,3.0329,3.2662,3.4995]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: dead coarse root C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["DEADSTEMC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.7638,1.5275,2.2913,3.0551,3.8188,4.5826,5.3464,6.1101,6.8739,7.6377,8.4015,9.1652,9.929,10.6928,11.4565]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: dead stem C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["DISPVEGC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.0305,2.0609,3.0914,4.1219,5.1523,6.1828,7.2132,8.2437,9.2742,10.3046,11.3351,12.3656,13.396,14.4265,15.4569]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: displayed vegetation carbon (excluding storage and cpool)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["FROOTC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.017621,0.035242,0.052863,0.070484,0.088105,0.105726,0.123347,0.140968,0.158589,0.17621,0.193831,0.211452,0.229073,0.246694,0.264315]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: fine root C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["LITR1C"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.00152,0.003039,0.004559,0.006079,0.007598,0.009118,0.010638,0.012157,0.013677,0.015196,0.016716,0.018236,0.019755,0.021275,0.022795]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: LITR1 C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["LITR2C"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.008949,0.017898,0.026847,0.035797,0.044746,0.053695,0.062644,0.071593,0.080542,0.089491,0.09844,0.10739,0.116339,0.125288,0.134237]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: LITR2 C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["LITR3C"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.016716,0.033431,0.050147,0.066862,0.083578,0.100293,0.117009,0.133724,0.15044,0.167155,0.183871,0.200586,0.217302,0.234017,0.250733]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: LITR3 C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["LITTERC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.026348,0.052697,0.079045,0.105394,0.131742,0.15809,0.184439,0.210787,0.237136,0.263484,0.289832,0.316181,0.342529,0.368878,0.395226]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: litter C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["LIVECROOTC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000688,0.001375,0.002063,0.002751,0.003438,0.004126,0.004813,0.005501,0.006189,0.006876,0.007564,0.008252,0.008939,0.009627,0.010315]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: live coarse root C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["LIVESTEMC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.002289,0.004578,0.006867,0.009156,0.011444,0.013733,0.016022,0.018311,0.0206,0.022889,0.025178,0.027467,0.029755,0.032044,0.034333]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: live stem C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["SEEDC_GRC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: pool for seeding new PFTs via dynamic landcover
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["SOIL1C"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.001829,0.003657,0.005486,0.007314,0.009143,0.010971,0.0128,0.014628,0.016457,0.018285,0.020114,0.021943,0.023771,0.0256,0.027428]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: SOIL1 C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["SOIL2C"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.020614,0.041228,0.061841,0.082455,0.103069,0.123683,0.144296,0.16491,0.185524,0.206138,0.226752,0.247365,0.267979,0.288593,0.309207]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: SOIL2 C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["SOIL3C"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2413,0.4827,0.724,0.9654,1.2067,1.4481,1.6894,1.9308,2.1721,2.4135,2.6548,2.8961,3.1375,3.3788,3.6202]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: SOIL3 C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["SOIL4C"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,3.0858,6.1717,9.2575,12.3434,15.4292,18.5151,21.6009,24.6868,27.7726,30.8585,33.9443,37.0302,40.116,43.2019,46.2877]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: SOIL4 C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["SOILC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,3.3061,6.6121,9.9182,13.2242,16.5303,19.8363,23.1424,26.4484,29.7545,33.0605,36.3666,39.6726,42.9787,46.2848,49.5908]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: soil C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["STORVEGC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1371,0.2742,0.4113,0.5484,0.6855,0.8227,0.9598,1.0969,1.234,1.3711,1.5082,1.6453,1.7824,1.9195,2.0566]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: stored vegetation carbon (excluding cpool)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTCOLC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.314,8.628,12.9419,17.2559,21.5699,25.8839,30.1978,34.5118,38.8258,43.1398,47.4537,51.7677,56.0817,60.3957,64.7096]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total column-level C (no product pools)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTECOSYSC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.3171,8.6343,12.9514,17.2685,21.5857,25.9028,30.2199,34.537,38.8542,43.1713,47.4884,51.8056,56.1227,60.4398,64.757]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total ecosystem C (no product pools)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTLITC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.026348,0.052697,0.079045,0.105394,0.131742,0.15809,0.184439,0.210787,0.237136,0.263484,0.289832,0.316181,0.342529,0.368878,0.395226]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total litter carbon
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTLITC_1m"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.020601,0.041203,0.061804,0.082405,0.103007,0.123608,0.144209,0.16481,0.185412,0.206013,0.226614,0.247216,0.267817,0.288418,0.30902]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total litter C to 1 meter
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTPFTC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.1055,2.2111,3.3166,4.4221,5.5276,6.6332,7.7387,8.8442,9.9497,11.0553,12.1608,13.2663,14.3718,15.4774,16.5829]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total PFT-level C (with cpool)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTPRODC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total wood product C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTSOMC_1m"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.5784,3.1568,4.7353,6.3137,7.8921,9.4705,11.0489,12.6274,14.2058,15.7842,17.3626,18.941,20.5195,22.0979,23.6763]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total soil organic matter C to 1 meter
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["TOTVEGC_ABG"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.8022,1.6043,2.4065,3.2087,4.0108,4.813,5.6152,6.4173,7.2195,8.0217,8.8238,9.626,10.4281,11.2303,12.0325]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: total aboveground vegetation C (no cpool)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["WOODC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.0005,2.0011,3.0016,4.0022,5.0027,6.0032,7.0038,8.0043,9.0049,10.0054,11.006,12.0065,13.007,14.0076,15.0081]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: wood C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "C State"
+variables = ["XSMRPOOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.095189,-0.088843,-0.082497,-0.076151,-0.069805,-0.063459,-0.057114,-0.050768,-0.044422,-0.038076,-0.03173,-0.025384,-0.019038,-0.012692,-0.006346,0]
+# group: C State
+# original_units: gC/m^2
+# target_units: kgC/m^2
+# conversion_factor: 0.001
+# csv_scale_factor: 1.00000E-09
+# long_name: temporary photosynthate C pool
+# contours: 5th/95th percentiles from PI control data
+
+# ENERGY FLUX (34 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["EFLX_DYNBAL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: dynamic land cover change conversion energy flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["EFLX_GRND_LAKE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-117.193,-111.478,-105.762,-100.047,-94.3316,-88.6163,-82.9009,-77.1855,-71.4702,-65.7548,-60.0394,-54.324,-48.6087,-42.8933,-37.1779,-31.4626]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: net heat flux into lake/snow surface (excluding light transmission)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["EFLX_LH_TOT_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [3.104,10.2745,17.445,24.6154,31.7859,38.9564,46.1269,53.2973,60.4678,67.6383,74.8088,81.9793,89.1497,96.3202,103.491,110.661]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural total evaporation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["ERRSEB"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-2e-14,-1.8e-14,-1.7e-14,-1.6e-14,-1.4e-14,-1.3e-14,-1.2e-14,-1e-14,-9e-15,-8e-15,-7e-15,-5e-15,-4e-15,-3e-15,-1e-15,0]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: surface energy conservation error
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["ERRSOI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-4e-10,-3e-10,-3e-10,-2e-10,-2e-10,-1e-10,-0,0,1e-10,1e-10,2e-10,3e-10,3e-10,4e-10,4e-10,5e-10]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: soil/lake energy conservation error
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["ERRSOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: solar radiation conservation error
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FGR12"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.081875,-0.062274,-0.042673,-0.023072,-0.003471,0.01613,0.035731,0.055332,0.074933,0.094534,0.114135,0.133736,0.153337,0.172938,0.192539,0.21214]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: heat flux between soil layers 1 and 2
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FGR_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.0658,0.1651,0.396,0.6269,0.8577,1.0886,1.3195,1.5504,1.7813,2.0121,2.243,2.4739,2.7048,2.9357,3.1665,3.3974]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural heat flux into soil/snow including snow melt
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FIRA_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [28.3482,34.0122,39.6762,45.3402,51.0043,56.6683,62.3323,67.9963,73.6604,79.3244,84.9884,90.6524,96.3165,101.98,107.645,113.309]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural net longwave radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FIRE_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [243.782,258.902,274.022,289.142,304.262,319.382,334.502,349.622,364.742,379.862,394.981,410.101,425.221,440.341,455.461,470.581]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural emitted longwave radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSA_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [31.469,43.8814,56.2938,68.7061,81.1185,93.5309,105.943,118.356,130.768,143.18,155.593,168.005,180.417,192.83,205.242,217.654]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural absorbed solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDSND"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [18.6959,24.7371,30.7784,36.8196,42.8609,48.9021,54.9434,60.9846,67.0258,73.0671,79.1083,85.1496,91.1908,97.2321,103.273,109.315]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct nir incident solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDSNDLN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [50.8818,72.3081,93.7344,115.161,136.587,158.013,179.44,200.866,222.292,243.718,265.145,286.571,307.997,329.423,350.85,372.276]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct nir incident solar radiation at local noon
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDSNI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [6.5678,8.3529,10.138,11.9231,13.7083,15.4934,17.2785,19.0636,20.8488,22.6339,24.419,26.2042,27.9893,29.7744,31.5595,33.3447]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: diffuse nir incident solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDSVD"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [12.6554,17.9931,23.3308,28.6686,34.0063,39.344,44.6818,50.0195,55.3572,60.6949,66.0327,71.3704,76.7081,82.0459,87.3836,92.7213]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct vis incident solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDSVDLN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [36.3162,55.8621,75.4081,94.954,114.5,134.046,153.592,173.138,192.684,212.23,231.775,251.321,270.867,290.413,309.959,329.505]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct vis incident solar radiation at local noon
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDSVI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [19.8219,21.8463,23.8706,25.895,27.9194,29.9438,31.9681,33.9925,36.0169,38.0412,40.0656,42.09,44.1143,46.1387,48.1631,50.1875]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: diffuse vis incident solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSDSVILN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [24.2093,32.5931,40.9769,49.3607,57.7445,66.1283,74.5121,82.8959,91.2797,99.6635,108.047,116.431,124.815,133.199,141.582,149.966]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: diffuse vis incident solar radiation at local noon
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSH_G"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-21.15,-15.8639,-10.5778,-5.2918,-0.0057,5.2804,10.5665,15.8525,21.1386,26.4247,31.7107,36.9968,42.2829,47.5689,52.855,58.1411]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: sensible heat from ground
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSH_NODYNLNDUSE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-21.107,-15.0385,-8.97,-2.9016,3.1669,9.2353,15.3038,21.3723,27.4407,33.5092,39.5776,45.6461,51.7146,57.783,63.8515,69.92]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: sensible heat not including correction for land use change
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSH_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-7.7181,-2.2403,3.2376,8.7154,14.1932,19.6711,25.1489,30.6267,36.1046,41.5824,47.0602,52.5381,58.0159,63.4937,68.9716,74.4494]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural sensible heat
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSH_V"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2.6547,5.3095,7.9642,10.619,13.2737,15.9285,18.5832,21.238,23.8927,26.5475,29.2022,31.857,34.5117,37.1665,39.8212]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: sensible heat from veg
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSM"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.3302,0.6603,0.9905,1.3207,1.6508,1.981,2.3112,2.6413,2.9715,3.3017,3.6318,3.962,4.2922,4.6223,4.9525]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: snow melt heat flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSM_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.3569,0.7137,1.0706,1.4275,1.7843,2.1412,2.498,2.8549,3.2118,3.5686,3.9255,4.2823,4.6392,4.9961,5.3529]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural snow melt heat flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSRND"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [5.3938,8.2885,11.1832,14.0779,16.9727,19.8674,22.7621,25.6568,28.5515,31.4463,34.341,37.2357,40.1304,43.0251,45.9199,48.8146]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct nir reflected solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSRNDLN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [15.0786,22.0946,29.1105,36.1265,43.1425,50.1584,57.1744,64.1904,71.2063,78.2223,85.2383,92.2542,99.2702,106.286,113.302,120.318]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct nir reflected solar radiation at local noon
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSRNI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [3.6774,4.3474,5.0173,5.6873,6.3572,7.0272,7.6971,8.3671,9.037,9.707,10.377,11.0469,11.7169,12.3868,13.0568,13.7267]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: diffuse nir reflected solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSRVD"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [1.7372,4.5482,7.3591,10.1701,12.9811,15.792,18.603,21.414,24.2249,27.0359,29.8469,32.6578,35.4688,38.2798,41.0907,43.9017]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct vis reflected solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSRVDLN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [5.8429,11.952,18.0612,24.1703,30.2794,36.3885,42.4976,48.6068,54.7159,60.825,66.9341,73.0433,79.1524,85.2615,91.3706,97.4798]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: direct vis reflected solar radiation at local noon
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["FSRVI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [2.4222,4.4329,6.4436,8.4543,10.465,12.4757,14.4865,16.4972,18.5079,20.5186,22.5293,24.54,26.5507,28.5615,30.5722,32.5829]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: diffuse vis reflected solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["PARVEGLN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,22.5888,45.1775,67.7663,90.355,112.944,135.533,158.121,180.71,203.299,225.888,248.476,271.065,293.654,316.243,338.831]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: absorbed par by vegetation at local noon
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["SABG"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [12.2534,22.9562,33.659,44.3618,55.0646,65.7673,76.4701,87.1729,97.8757,108.578,119.281,129.984,140.687,151.39,162.092,172.795]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: solar rad absorbed by ground
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["SABG_PEN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.5931,1.1862,1.7793,2.3724,2.9655,3.5587,4.1518,4.7449,5.338,5.9311,6.5242,7.1173,7.7104,8.3035,8.8966]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural solar rad penetrating top soil or snow layer
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy Flux"
+variables = ["SABV"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,11.106,22.212,33.3179,44.4239,55.5299,66.6359,77.7418,88.8478,99.9538,111.06,122.166,133.272,144.378,155.484,166.59]
+# group: Energy Flux
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: solar rad absorbed by veg
+# contours: 5th/95th percentiles from PI control data
+
+# ENERGY STATE (14 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["GC_HEAT1"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-4.34286e+09,-3.92992e+09,-3.51699e+09,-3.10406e+09,-2.69113e+09,-2.2782e+09,-1.86526e+09,-1.45233e+09,-1.0394e+09,-6.26469e+08,-2.13537e+08,1.99395e+08,6.12327e+08,1.02526e+09,1.43819e+09,1.85112e+09]
+# group: Energy State
+# original_units: J/m^2
+# target_units: J/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: initial gridcell total heat content
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["HC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [14035.8,14504.8,14973.9,15443,15912,16381.1,16850.2,17319.2,17788.3,18257.4,18726.4,19195.5,19664.6,20133.7,20602.7,21071.8]
+# group: Energy State
+# original_units: MJ/m2
+# target_units: MJ/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: heat content of soil/snow/lake
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["HCSOI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [13420.5,13604.9,13789.3,13973.8,14158.2,14342.7,14527.1,14711.5,14896,15080.4,15264.8,15449.3,15633.7,15818.2,16002.6,16187]
+# group: Energy State
+# original_units: MJ/m2
+# target_units: MJ/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: soil heat content
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TG"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [220.488,225.897,231.307,236.716,242.126,247.536,252.945,258.355,263.765,269.174,274.584,279.994,285.403,290.813,296.223,301.632]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: ground temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TG_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [254.716,257.89,261.065,264.239,267.414,270.588,273.763,276.937,280.112,283.286,286.461,289.635,292.809,295.984,299.158,302.333]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural ground temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TH2OSFC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [221.339,226.683,232.027,237.37,242.714,248.058,253.402,258.746,264.09,269.434,274.778,280.122,285.466,290.81,296.154,301.498]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: surface water temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["THBOT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [223.519,228.578,233.637,238.696,243.755,248.814,253.872,258.931,263.99,269.049,274.108,279.167,284.226,289.285,294.344,299.403]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: atmospheric air potential temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TREFMNAV"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [220.769,225.74,230.712,235.683,240.654,245.625,250.596,255.568,260.539,265.51,270.481,275.452,280.423,285.395,290.366,295.337]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: daily minimum of average 2-m temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TREFMNAV_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [253.295,256.136,258.977,261.818,264.659,267.5,270.341,273.182,276.023,278.864,281.704,284.545,287.386,290.227,293.068,295.909]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural daily minimum of average 2-m temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TREFMXAV"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [223.89,229.237,234.584,239.931,245.278,250.625,255.972,261.319,266.665,272.012,277.359,282.706,288.053,293.4,298.747,304.094]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: daily maximum of average 2-m temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TREFMXAV_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [258.24,261.343,264.445,267.548,270.65,273.753,276.855,279.957,283.06,286.162,289.265,292.367,295.47,298.572,301.675,304.777]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural daily maximum of average 2-m temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TSA_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [255.774,258.699,261.624,264.549,267.474,270.399,273.324,276.249,279.174,282.099,285.024,287.949,290.874,293.799,296.724,299.649]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural 2m air temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TSOI_10CM"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [221.336,226.688,232.041,237.393,242.745,248.097,253.449,258.801,264.154,269.506,274.858,280.21,285.562,290.914,296.266,301.619]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: soil temperature in top 10cm of soil
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Energy State"
+variables = ["TV"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [223.434,228.554,233.673,238.792,243.911,249.03,254.15,259.269,264.388,269.507,274.626,279.746,284.865,289.984,295.103,300.222]
+# group: Energy State
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: vegetation temperature
+# contours: 5th/95th percentiles from PI control data
+
+# FIRE (3 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Fire"
+variables = ["COL_FIRE_CLOSS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.019088,0.038177,0.057265,0.076354,0.095442,0.114531,0.133619,0.152708,0.171796,0.190885,0.209973,0.229062,0.24815,0.267238,0.286327]
+# group: Fire
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: total column-level fire C loss (non-peat and non-conversion)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Fire"
+variables = ["NFIRE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4e-10,7e-10,1.1e-09,1.4e-09,1.8e-09,2.2e-09,2.5e-09,2.9e-09,3.3e-09,3.6e-09,4e-09,4.3e-09,4.7e-09,5.1e-09,5.4e-09]
+# group: Fire
+# original_units: counts/km2/sec
+# target_units: counts/km2/sec
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: fire counts valid only in Reg.C
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Fire"
+variables = ["PFT_FIRE_CLOSS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.017303,0.034605,0.051908,0.06921,0.086513,0.103815,0.121118,0.13842,0.155723,0.173025,0.190328,0.207631,0.224933,0.242236,0.259538]
+# group: Fire
+# original_units: gC/m^2/s
+# target_units: gC/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E-02
+# long_name: total PFT-level fire C loss (non-peat and non-conversion)
+# contours: 5th/95th percentiles from PI control data
+
+# H2O FLUX (19 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["DEFICIT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: runoff supply deficit
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["DWB"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.007955,-0.006808,-0.005661,-0.004514,-0.003367,-0.00222,-0.001073,7.4e-05,0.001221,0.002368,0.003515,0.004662,0.005809,0.006956,0.008103,0.00925]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: net change in total water mass
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QCHARGE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.0126,0.1154,0.2434,0.3714,0.4994,0.6274,0.7555,0.8835,1.0115,1.1395,1.2675,1.3955,1.5235,1.6515,1.7795,1.9075]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: aquifer recharge rate (vegetated landunits only)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QDRAI_PERCH"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,6.7e-07,1.34e-06,2.01e-06,2.68e-06,3.35e-06,4.02e-06,4.69e-06,5.36e-06,6.03e-06,6.7e-06,7.37e-06,8.04e-06,8.71e-06,9.38e-06,1.005e-05]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: perched water table drainage
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QDRAI_XS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.569e-05,3.139e-05,4.708e-05,6.278e-05,7.847e-05,9.417e-05,0.00010986,0.00012556,0.00014125,0.00015695,0.00017264,0.00018833,0.00020403,0.00021972,0.00023542]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: saturation excess drainage
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QDRIP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.0756,0.4134,0.7511,1.0888,1.4266,1.7643,2.102,2.4398,2.7775,3.1152,3.453,3.7907,4.1284,4.4662,4.8039,5.1416]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: throughfall
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QFLOOD"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: runoff from river flooding
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QFLX_ICE_DYNBAL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: ice dynamic land cover change conversion runoff flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QFLX_LIQ_DYNBAL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: liq dynamic land cover change conversion runoff flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QH2OSFC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.031633,0.063265,0.094898,0.12653,0.158163,0.189795,0.221428,0.25306,0.284693,0.316325,0.347958,0.37959,0.411223,0.442855,0.474488]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: surface water runoff
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QINTR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0769,0.1538,0.2307,0.3076,0.3844,0.4613,0.5382,0.6151,0.692,0.7689,0.8458,0.9227,0.9996,1.0764,1.1533]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: interception
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QRUNOFF_NODYNLNDUSE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1739,0.3479,0.5218,0.6957,0.8697,1.0436,1.2175,1.3915,1.5654,1.7393,1.9133,2.0872,2.2611,2.4351,2.609]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: total liquid runoff (does not include QSNWCPICE) not including correction for land use change
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QRUNOFF_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.0004,0.2085,0.4166,0.6247,0.8328,1.0409,1.249,1.4571,1.6652,1.8733,2.0814,2.2895,2.4977,2.7058,2.9139,3.122]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: rural total runoff
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QSNOMELT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0675,0.1349,0.2024,0.2698,0.3373,0.4047,0.4722,0.5397,0.6071,0.6746,0.742,0.8095,0.8769,0.9444,1.0119]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: snow melt
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QSNWCPICE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.037797,0.075594,0.113391,0.151188,0.188986,0.226783,0.26458,0.302377,0.340174,0.377971,0.415768,0.453565,0.491363,0.52916,0.566957]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: excess snowfall due to snow capping
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["QSNWCPICE_NODYNLNDUSE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.037797,0.075594,0.113391,0.151188,0.188986,0.226783,0.26458,0.302377,0.340174,0.377971,0.415768,0.453565,0.491363,0.52916,0.566957]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: excess snowfall due to snow capping not including correction for land use change
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["SNOW_SINKS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0843,0.1686,0.253,0.3373,0.4216,0.5059,0.5903,0.6746,0.7589,0.8432,0.9276,1.0119,1.0962,1.1805,1.2649]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: snow sinks (liquid water)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["SNOW_SOURCES"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0849,0.1698,0.2547,0.3395,0.4244,0.5093,0.5942,0.6791,0.764,0.8489,0.9337,1.0186,1.1035,1.1884,1.2733]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: snow sources (liquid water)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O Flux"
+variables = ["SUPPLY"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: H2O Flux
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: runoff supply for land use
+# contours: 5th/95th percentiles from PI control data
+
+# H2O STATE (16 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["ERRH2O"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-2.1e-14,-1.6e-14,-1.2e-14,-8e-15,-4e-15,0,5e-15,9e-15,1.3e-14,1.7e-14,2.1e-14,2.5e-14,3e-14,3.4e-14,3.8e-14,4.2e-14]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total water conservation error
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["ERRH2OSNO"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: imbalance in snow depth (liquid water)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["GC_ICE1"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2640.58,5281.15,7921.73,10562.3,13202.9,15843.5,18484,21124.6,23765.2,26405.8,29046.3,31686.9,34327.5,36968.1,39608.6]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: initial gridcell total ice content
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["GC_LIQ1"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [2150.95,2443.12,2735.29,3027.46,3319.64,3611.81,3903.98,4196.16,4488.33,4780.5,5072.68,5364.85,5657.02,5949.2,6241.37,6533.54]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: initial gridcell total liq content
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["H2OCAN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.007395,0.01479,0.022186,0.029581,0.036976,0.044371,0.051767,0.059162,0.066557,0.073952,0.081348,0.088743,0.096138,0.103533,0.110929]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: intercepted water
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["H2OSFC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.403,0.806,1.209,1.612,2.015,2.418,2.821,3.224,3.627,4.03,4.433,4.836,5.2389,5.6419,6.0449]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: surface water depth
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["H2OSNO_TOP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2085,0.417,0.6255,0.834,1.0425,1.251,1.4595,1.668,1.8765,2.085,2.2935,2.502,2.7105,2.919,3.1275]
+# group: H2O State
+# original_units: kg/m2
+# target_units: kg/m2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: mass of snow in top snow layer
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["INT_SNOW"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,90053.2,180106,270160,360213,450266,540319,630373,720426,810479,900532,990586,1.08064e+06,1.17069e+06,1.26075e+06,1.3508e+06]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: accumulated SWE (vegetated landunits only)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["Q2M"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.00011,0.001138,0.002166,0.003195,0.004223,0.005251,0.006279,0.007307,0.008336,0.009364,0.010392,0.01142,0.012448,0.013476,0.014505,0.015533]
+# group: H2O State
+# original_units: kg/kg
+# target_units: kg/kg
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: 2m specific humidity
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["QBOT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.000119,0.001131,0.002144,0.003156,0.004168,0.00518,0.006193,0.007205,0.008217,0.009229,0.010242,0.011254,0.012266,0.013278,0.014291,0.015303]
+# group: H2O State
+# original_units: kg/kg
+# target_units: kg/kg
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: atmospheric specific humidity
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["RH2M_R"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [35.9806,39.9658,43.951,47.9362,51.9215,55.9067,59.8919,63.8771,67.8623,71.8475,75.8328,79.818,83.8032,87.7884,91.7736,95.7588]
+# group: H2O State
+# original_units: %
+# target_units: %
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: rural 2m relative humidity
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["TWS_MONTH_BEGIN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [2104.67,4871.6,7638.53,10405.5,13172.4,15939.3,18706.3,21473.2,24240.1,27007.1,29774,32540.9,35307.8,38074.8,40841.7,43608.6]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total water storage at the beginning of a month
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["TWS_MONTH_END"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [2104.76,4871.69,7638.61,10405.5,13172.5,15939.4,18706.3,21473.2,24240.2,27007.1,29774,32540.9,35307.9,38074.8,40841.7,43608.6]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total water storage at the end of a month
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["VOLR"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.66097e+06,9.32194e+06,1.39829e+07,1.86439e+07,2.33048e+07,2.79658e+07,3.26268e+07,3.72878e+07,4.19487e+07,4.66097e+07,5.12707e+07,5.59316e+07,6.05926e+07,6.52536e+07,6.99145e+07]
+# group: H2O State
+# original_units: m3
+# target_units: m3
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: river channel total water storage
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["VOLRMCH"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,3.95691e+06,7.91381e+06,1.18707e+07,1.58276e+07,1.97845e+07,2.37414e+07,2.76983e+07,3.16553e+07,3.56122e+07,3.95691e+07,4.3526e+07,4.74829e+07,5.14398e+07,5.53967e+07,5.93536e+07]
+# group: H2O State
+# original_units: m3
+# target_units: m3
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: river channel main channel water storage
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "H2O State"
+variables = ["WA"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [1017.55,1283.5,1549.45,1815.4,2081.36,2347.31,2613.26,2879.21,3145.17,3411.12,3677.07,3943.02,4208.97,4474.93,4740.88,5006.83]
+# group: H2O State
+# original_units: mm
+# target_units: mm
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: water in the unconfined aquifer (vegetated landunits only)
+# contours: 5th/95th percentiles from PI control data
+
+# N FLUX (11 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["ACTUAL_IMMOB"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.005095,0.01019,0.015285,0.02038,0.025476,0.030571,0.035666,0.040761,0.045856,0.050951,0.056046,0.061141,0.066236,0.071331,0.076427]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: actual N immobilization
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["DWT_CONV_NFLUX_GRC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: land conversion N flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["DWT_SLASH_NFLUX"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: slash N flux to litter and CWD due to land use
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["F_DENIT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000278,0.000556,0.000834,0.001113,0.001391,0.001669,0.001947,0.002225,0.002503,0.002781,0.00306,0.003338,0.003616,0.003894,0.004172]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: denitrification flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["F_NIT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000321,0.000642,0.000962,0.001283,0.001604,0.001925,0.002246,0.002566,0.002887,0.003208,0.003529,0.00385,0.00417,0.004491,0.004812]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: nitrification flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["NET_NMIN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.00245,0.004899,0.007349,0.009799,0.012248,0.014698,0.017147,0.019597,0.022047,0.024496,0.026946,0.029396,0.031845,0.034295,0.036744]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: net rate of N mineralization
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["PFT_FIRE_NLOSS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000154,0.000307,0.000461,0.000615,0.000768,0.000922,0.001075,0.001229,0.001383,0.001536,0.00169,0.001844,0.001997,0.002151,0.002304]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: total pft-level fire N loss
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["SMINN_TO_NPOOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.002484,0.004967,0.007451,0.009935,0.012418,0.014902,0.017385,0.019869,0.022353,0.024836,0.02732,0.029804,0.032287,0.034771,0.037254]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: deployment of soil mineral N uptake
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["SMIN_NO3_RUNOFF"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,4.03e-05,8.06e-05,0.0001209,0.0001612,0.0002015,0.0002418,0.0002821,0.0003224,0.0003627,0.000403,0.0004433,0.0004836,0.0005239,0.0005642,0.0006045]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: soil NO3 pool loss to runoff
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["SUPPLEMENT_TO_SMINN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: supplemental N supply
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N Flux"
+variables = ["WOOD_HARVESTN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: N Flux
+# original_units: gN/m^2/s
+# target_units: gN/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: wood harvest N (to product pools)
+# contours: 5th/95th percentiles from PI control data
+
+# N STATE (22 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["CWDN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.4963,0.9926,1.4889,1.9852,2.4815,2.9778,3.4741,3.9703,4.4666,4.9629,5.4592,5.9555,6.4518,6.9481,7.4444]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: coarse woody debris N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["DEADCROOTN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.4666,0.9332,1.3998,1.8664,2.333,2.7996,3.2662,3.7328,4.1994,4.666,5.1326,5.5992,6.0658,6.5324,6.999]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: dead coarse root N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["DEADSTEMN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.5275,3.0551,4.5826,6.1101,7.6377,9.1652,10.6928,12.2203,13.7478,15.2754,16.8029,18.3304,19.858,21.3855,22.9131]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: dead stem N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["DISPVEGN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2.9715,5.943,8.9145,11.886,14.8575,17.829,20.8005,23.772,26.7435,29.715,32.6864,35.6579,38.6294,41.6009,44.5724]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: displayed vegetation nitrogen
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["FROOTN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.4195,0.8391,1.2586,1.6782,2.0977,2.5173,2.9368,3.3564,3.7759,4.1955,4.615,5.0346,5.4541,5.8737,6.2932]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: fine root N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["LITR1N"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.027873,0.055747,0.08362,0.111494,0.139367,0.16724,0.195114,0.222987,0.250861,0.278734,0.306607,0.334481,0.362354,0.390228,0.418101]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: LITR1 N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["LITR2N"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1569,0.3139,0.4708,0.6277,0.7847,0.9416,1.0985,1.2555,1.4124,1.5693,1.7263,1.8832,2.0401,2.1971,2.354]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: LITR2 N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["LITR3N"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.297,0.5941,0.8911,1.1881,1.4852,1.7822,2.0792,2.3762,2.6733,2.9703,3.2673,3.5644,3.8614,4.1584,4.4555]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: LITR3 N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["LIVECROOTN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.013753,0.027505,0.041258,0.055011,0.068764,0.082516,0.096269,0.110022,0.123774,0.137527,0.15128,0.165033,0.178785,0.192538,0.206291]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: live coarse root N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["LIVESTEMN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.045778,0.091555,0.137333,0.183111,0.228888,0.274666,0.320444,0.366221,0.411999,0.457777,0.503554,0.549332,0.59511,0.640887,0.686665]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: live stem N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["NPOOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2.5025,5.005,7.5076,10.0101,12.5126,15.0151,17.5176,20.0202,22.5227,25.0252,27.5277,30.0302,32.5327,35.0353,37.5378]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: temporary plant N pool
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["RETRANSN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.5539,1.1077,1.6616,2.2155,2.7694,3.3232,3.8771,4.431,4.9848,5.5387,6.0926,6.6465,7.2003,7.7542,8.3081]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: plant pool of retranslocated N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["SOIL1N"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1524,0.3048,0.4571,0.6095,0.7619,0.9143,1.0667,1.219,1.3714,1.5238,1.6762,1.8285,1.9809,2.1333,2.2857]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL1 N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["SOIL2N"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.7178,3.4356,5.1534,6.8713,8.5891,10.3069,12.0247,13.7425,15.4603,17.1781,18.896,20.6138,22.3316,24.0494,25.7672]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL2 N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["SOIL3N"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,24.1346,48.2692,72.4037,96.5383,120.673,144.807,168.942,193.077,217.211,241.346,265.48,289.615,313.75,337.884,362.019]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL3 N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["SOIL4N"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,308.58,617.17,925.75,1234.34,1542.92,1851.51,2160.09,2468.68,2777.26,3085.85,3394.43,3703.02,4011.6,4320.19,4628.77]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL4 N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["STORVEGN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,3.9779,7.9559,11.9338,15.9118,19.8897,23.8677,27.8456,31.8236,35.8015,39.7795,43.7574,47.7353,51.7133,55.6912,59.6692]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: stored vegetation nitrogen
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["TOTCOLN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,333.4,666.81,1000.21,1333.61,1667.02,2000.42,2333.82,2667.23,3000.63,3334.03,3667.44,4000.84,4334.24,4667.65,5001.05]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total column-level N (no product pools)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["TOTECOSYSN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,333.34,666.67,1000.01,1333.35,1666.68,2000.02,2333.36,2666.7,3000.03,3333.37,3666.71,4000.04,4333.38,4666.72,5000.05]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total ecosystem N (no product pools)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["TOTLITN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.4741,0.9482,1.4223,1.8964,2.3705,2.8446,3.3187,3.7928,4.2669,4.7411,5.2152,5.6893,6.1634,6.6375,7.1116]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total litter N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["TOTPFTN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,6.9265,13.8529,20.7794,27.7058,34.6323,41.5587,48.4852,55.4116,62.3381,69.2645,76.191,83.1175,90.0439,96.9704,103.897]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total PFT-level N
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "N State"
+variables = ["TOTVEGN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,6.9265,13.8529,20.7794,27.7058,34.6323,41.5587,48.4852,55.4116,62.3381,69.2645,76.191,83.1174,90.0439,96.9704,103.897]
+# group: N State
+# original_units: gN/m^2
+# target_units: gN/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total vegetation N
+# contours: 5th/95th percentiles from PI control data
+
+# P FLUX (12 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["ACTUAL_IMMOB_P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,8.6e-05,0.000172,0.000258,0.000344,0.00043,0.000516,0.000602,0.000688,0.000774,0.00086,0.000946,0.001032,0.001118,0.001203,0.001289]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: actual P immobilization
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["ADSORBTION_P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1.355e-05,-1.234e-05,-1.114e-05,-9.94e-06,-8.73e-06,-7.53e-06,-6.33e-06,-5.12e-06,-3.92e-06,-2.72e-06,-1.51e-06,-3.1e-07,8.9e-07,2.1e-06,3.3e-06,4.5e-06]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: adsorb P flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["BIOCHEM_PMIN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,8.1e-09,1.61e-08,2.42e-08,3.23e-08,4.04e-08,4.84e-08,5.65e-08,6.46e-08,7.26e-08,8.07e-08,8.88e-08,9.69e-08,1.049e-07,1.13e-07,1.211e-07]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: biochemical rate of P mineralization
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["DESORPTION_P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-7.2e-09,-6.3e-09,-5.4e-09,-4.6e-09,-3.7e-09,-2.8e-09,-2e-09,-1.1e-09,-2e-10,6e-10,1.5e-09,2.4e-09,3.2e-09,4.1e-09,5e-09,5.8e-09]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: desorp P flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["DWT_CONV_PFLUX_GRC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: land conversion P flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["DWT_SLASH_PFLUX"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: slash P flux to litter and CWD due to land use
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["NET_PMIN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000132,0.000263,0.000395,0.000526,0.000658,0.000789,0.000921,0.001052,0.001184,0.001315,0.001447,0.001578,0.00171,0.001842,0.001973]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: net rate of P mineralization
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["PDEP_TO_SMINP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [1e-08,3.14e-06,6.27e-06,9.4e-06,1.253e-05,1.566e-05,1.879e-05,2.192e-05,2.505e-05,2.818e-05,3.131e-05,3.444e-05,3.757e-05,4.07e-05,4.383e-05,4.696e-05]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: atmospheric P deposition to soil mineral P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["RETRANSP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2495.31,4990.61,7485.92,9981.22,12476.5,14971.8,17467.1,19962.4,22457.7,24953.1,27448.4,29943.7,32439,34934.3,37429.6]
+# group: P Flux
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: plant pool of retranslocated P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["SMINP_LEACHED"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.01e-06,2.03e-06,3.04e-06,4.05e-06,5.07e-06,6.08e-06,7.1e-06,8.11e-06,9.12e-06,1.014e-05,1.115e-05,1.216e-05,1.318e-05,1.419e-05,1.52e-05]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: soil mineral P pool loss to leaching
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["SMINP_TO_PPOOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000135,0.000271,0.000406,0.000541,0.000677,0.000812,0.000947,0.001083,0.001218,0.001353,0.001489,0.001624,0.001759,0.001895,0.00203]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: deployment of soil mineral P uptake
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P Flux"
+variables = ["SUPPLEMENT_TO_SMINP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: P Flux
+# original_units: gP/m^2/s
+# target_units: gP/m^2/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 3.15360E+01
+# long_name: supplemental P supply
+# contours: 5th/95th percentiles from PI control data
+
+# P STATE (28 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["CWDP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.08,0.1601,0.2401,0.3201,0.4001,0.4802,0.5602,0.6402,0.7203,0.8003,0.8803,0.9604,1.0404,1.1204,1.2004]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: coarse woody debris P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["DEADCROOTP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0778,0.1555,0.2333,0.3111,0.3888,0.4666,0.5444,0.6221,0.6999,0.7777,0.8554,0.9332,1.011,1.0887,1.1665]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: dead coarse root P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["DEADSTEMP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2546,0.5092,0.7638,1.0184,1.2729,1.5275,1.7821,2.0367,2.2913,2.5459,2.8005,3.0551,3.3097,3.5643,3.8188]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: dead stem P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["DISPVEGP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.3787,0.7573,1.136,1.5147,1.8934,2.272,2.6507,3.0294,3.408,3.7867,4.1654,4.5441,4.9227,5.3014,5.6801]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: displayed vegetation phosphorus
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["FROOTP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.017621,0.035242,0.052863,0.070484,0.088105,0.105726,0.123347,0.140968,0.158589,0.17621,0.193831,0.211452,0.229073,0.246694,0.264315]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: fine root P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["LABILEP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,6.6408,13.2816,19.9223,26.5631,33.2039,39.8447,46.4854,53.1262,59.767,66.4078,73.0486,79.6893,86.3301,92.9709,99.6117]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: soil labile P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["LITR1P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0667,0.1333,0.2,0.2667,0.3333,0.4,0.4667,0.5333,0.6,0.6667,0.7333,0.8,0.8667,0.9333,1]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: LITR1 P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["LITR2P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.01025,0.0205,0.03075,0.041,0.051251,0.061501,0.071751,0.082001,0.092251,0.102501,0.112751,0.123001,0.133252,0.143502,0.153752]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: LITR2 P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["LITR3P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.018569,0.037138,0.055707,0.074276,0.092845,0.111414,0.129983,0.148552,0.167121,0.18569,0.204259,0.222828,0.241397,0.259966,0.278535]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: LITR3 P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["LIVECROOTP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000229,0.000458,0.000688,0.000917,0.001146,0.001375,0.001604,0.001834,0.002063,0.002292,0.002521,0.002751,0.00298,0.003209,0.003438]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: live coarse root P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["LIVESTEMP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.000763,0.001526,0.002289,0.003052,0.003815,0.004578,0.005341,0.006104,0.006867,0.00763,0.008393,0.009156,0.009918,0.010681,0.011444]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: live stem P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["OCCLP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,102.48,204.96,307.44,409.92,512.4,614.87,717.35,819.83,922.31,1024.79,1127.27,1229.75,1332.23,1434.71,1537.19]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: soil occluded P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["PPOOL"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1361,0.2722,0.4083,0.5444,0.6805,0.8166,0.9527,1.0888,1.2248,1.3609,1.497,1.6331,1.7692,1.9053,2.0414]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: temporary plant P pool
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["PRIMP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.3122,0.6243,0.9365,1.2486,1.5608,1.8729,2.1851,2.4973,2.8094,3.1216,3.4337,3.7459,4.0581,4.3702,4.6824]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: soil primary P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["SECONDP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,151.89,303.78,455.67,607.56,759.45,911.34,1063.24,1215.13,1367.02,1518.91,1670.8,1822.69,1974.58,2126.47,2278.36]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: soil secondary P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["SOIL1P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.00507,0.01014,0.015211,0.020281,0.025351,0.030421,0.035491,0.040562,0.045632,0.050702,0.055772,0.060842,0.065913,0.070983,0.076053]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL1 P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["SOIL2P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.056987,0.113974,0.17096,0.227947,0.284934,0.341921,0.398908,0.455895,0.512881,0.569868,0.626855,0.683842,0.740829,0.797816,0.854802]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL2 P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["SOIL3P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.4818,0.9636,1.4455,1.9273,2.4091,2.8909,3.3727,3.8546,4.3364,4.8182,5.3,5.7818,6.2637,6.7455,7.2273]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL3 P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["SOIL4P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,6.1716,12.3433,18.5149,24.6865,30.8582,37.0298,43.2014,49.373,55.5447,61.7163,67.8879,74.0596,80.2312,86.4028,92.5745]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: SOIL4 P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["SOLUTIONP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.006299,0.012599,0.018898,0.025198,0.031497,0.037797,0.044096,0.050396,0.056695,0.062995,0.069294,0.075594,0.081893,0.088193,0.094492]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: soil solution P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["STORVEGP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2146,0.4291,0.6437,0.8582,1.0728,1.2874,1.5019,1.7165,1.931,2.1456,2.3601,2.5747,2.7893,3.0038,3.2184]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: stored vegetation phosphorus
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTCOLP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,160.52,321.04,481.57,642.09,802.61,963.13,1123.66,1284.18,1444.7,1605.22,1765.74,1926.27,2086.79,2247.31,2407.83]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total column-level P (no product pools)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTECOSYSP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,232.12,464.24,696.36,928.48,1160.59,1392.71,1624.83,1856.95,2089.07,2321.19,2553.31,2785.43,3017.55,3249.66,3481.78]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total ecosystem P (no product pools)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTLITP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0667,0.1333,0.2,0.2667,0.3333,0.4,0.4667,0.5333,0.6,0.6667,0.7333,0.8,0.8667,0.9333,1]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total litter P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTLITP_1m"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.053189,0.106377,0.159566,0.212755,0.265943,0.319132,0.372321,0.42551,0.478698,0.531887,0.585076,0.638264,0.691453,0.744642,0.79783]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total litter P to 1 meter
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTPFTP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.5844,1.1687,1.7531,2.3375,2.9218,3.5062,4.0906,4.675,5.2593,5.8437,6.4281,7.0124,7.5968,8.1812,8.7655]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total PFT-level P
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTSOMP_1m"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,3.159,6.3181,9.4771,12.6361,15.7952,18.9542,22.1132,25.2723,28.4313,31.5903,34.7493,37.9084,41.0674,44.2264,47.3855]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total soil organic matter P to 1 meter
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "P State"
+variables = ["TOTVEGP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.5844,1.1687,1.7531,2.3375,2.9218,3.5062,4.0906,4.6749,5.2593,5.8437,6.4281,7.0124,7.5968,8.1812,8.7655]
+# group: P State
+# original_units: gP/m^2
+# target_units: gP/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E-06
+# long_name: total vegetation P
+# contours: 5th/95th percentiles from PI control data
+
+# PHYSICAL STATE (14 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["ALT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.024,2.3676,4.7112,7.0547,9.3983,11.7419,14.0855,16.429,18.7726,21.1162,23.4598,25.8033,28.1469,30.4905,32.834,35.1776]
+# group: Physical State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: current active layer thickness
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["ALTMAX"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.1107,2.4485,4.7863,7.1241,9.4619,11.7997,14.1375,16.4753,18.8131,21.1508,23.4886,25.8264,28.1642,30.502,32.8398,35.1776]
+# group: Physical State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: maximum annual active layer thickness
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["FCOV"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.001487,0.015274,0.02906,0.042846,0.056633,0.070419,0.084205,0.097992,0.111778,0.125564,0.13935,0.153137,0.166923,0.180709,0.194496,0.208282]
+# group: Physical State
+# original_units: proportion
+# target_units: proportion
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: fractional impermeable area
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["FH2OSFC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.001672,0.003345,0.005017,0.006689,0.008361,0.010034,0.011706,0.013378,0.01505,0.016723,0.018395,0.020067,0.02174,0.023412,0.025084]
+# group: Physical State
+# original_units: proportion
+# target_units: proportion
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: fraction of ground covered by surface water
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["FINUNDATED"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.002083,0.004167,0.00625,0.008333,0.010416,0.0125,0.014583,0.016666,0.018749,0.020833,0.022916,0.024999,0.027082,0.029166,0.031249]
+# group: Physical State
+# original_units: proportion
+# target_units: proportion
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: fractional inundated area of vegetated columns
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["FROST_TABLE"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.0311,0.22,0.4089,0.5978,0.7867,0.9756,1.1645,1.3534,1.5423,1.7312,1.9201,2.109,2.2979,2.4868,2.6757,2.8646]
+# group: Physical State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: frost table depth (vegetated landunits only)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["FSNO_EFF"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.0667,0.1333,0.2,0.2667,0.3333,0.4,0.4667,0.5333,0.6,0.6667,0.7333,0.8,0.8667,0.9333,1]
+# group: Physical State
+# original_units: proportion
+# target_units: proportion
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: effective fraction of ground covered by snow
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["LAKEICETHICK"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.020618,0.041235,0.061853,0.08247,0.103088,0.123705,0.144323,0.16494,0.185558,0.206176,0.226793,0.247411,0.268028,0.288646,0.309263]
+# group: Physical State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: thickness of lake ice (including physical expansion on freezing)
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["SNOINTABS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.01209,0.02418,0.03627,0.04836,0.06045,0.07254,0.08463,0.09672,0.10881,0.1209,0.13299,0.14508,0.15717,0.16926,0.18135]
+# group: Physical State
+# original_units: %
+# target_units: %
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: percent of incoming solar absorbed by lower snow layers
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["SoilAlpha"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.54305,0.573514,0.603977,0.63444,0.664903,0.695366,0.725829,0.756292,0.786755,0.817219,0.847682,0.878145,0.908608,0.939071,0.969534,0.999997]
+# group: Physical State
+# original_units: unitless
+# target_units: unitless
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: factor limiting ground evap
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["TKE1"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [129.664,150.739,171.814,192.888,213.963,235.038,256.112,277.187,298.262,319.337,340.411,361.486,382.561,403.635,424.71,445.785]
+# group: Physical State
+# original_units: W/(mK)
+# target_units: W/(mK)
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: top lake level eddy thermal conductivity
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["ZBOT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [8.6859,8.9912,9.2964,9.6016,9.9069,10.2121,10.5173,10.8226,11.1278,11.4331,11.7383,12.0435,12.3488,12.654,12.9592,13.2645]
+# group: Physical State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: atmospheric reference height
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["ZWT_CH4_UNSAT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.0825,0.3305,0.5784,0.8264,1.0743,1.3223,1.5703,1.8182,2.0662,2.3141,2.5621,2.81,3.058,3.306,3.5539,3.8019]
+# group: Physical State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: depth of water table for methane production used in non-inundated area
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Physical State"
+variables = ["ZWT_PERCH"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.0167,0.2066,0.3964,0.5863,0.7761,0.966,1.1559,1.3457,1.5356,1.7254,1.9153,2.1052,2.295,2.4849,2.6747,2.8646]
+# group: Physical State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: perched water table depth (vegetated landunits only)
+# contours: 5th/95th percentiles from PI control data
+
+# PRESSURE (3 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Pressure"
+variables = ["PBOT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [64313.4,66738.6,69163.9,71589.1,74014.4,76439.6,78864.8,81290.1,83715.3,86140.6,88565.8,90991,93416.3,95841.5,98266.8,100692]
+# group: Pressure
+# original_units: Pa
+# target_units: Pa
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: atmospheric pressure
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Pressure"
+variables = ["PCH4"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.109333,0.113456,0.117579,0.121701,0.125824,0.129947,0.13407,0.138193,0.142316,0.146439,0.150562,0.154685,0.158808,0.162931,0.167054,0.171176]
+# group: Pressure
+# original_units: Pa
+# target_units: Pa
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: atmospheric partial pressure of CH4
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Pressure"
+variables = ["PCO2"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [18.2854,18.9749,19.6645,20.354,21.0435,21.7331,22.4226,23.1122,23.8017,24.4912,25.1808,25.8703,26.5598,27.2494,27.9389,28.6285]
+# group: Pressure
+# original_units: Pa
+# target_units: Pa
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: atmospheric partial pressure of CO2
+# contours: 5th/95th percentiles from PI control data
+
+# URBAN (20 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["BUILDHEAT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.000493,0.007037,0.014568,0.022098,0.029629,0.037159,0.04469,0.05222,0.059751,0.067281,0.074812,0.082342,0.089873,0.097403,0.104934,0.112464]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: heat flux from urban building interior to walls and roof
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["EFLX_LH_TOT_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [9.2251,14.1344,19.0437,23.953,28.8623,33.7716,38.6809,43.5902,48.4995,53.4088,58.3181,63.2274,68.1367,73.046,77.9553,82.8646]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban total evaporation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["FGR_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-47.0509,-40.9319,-34.813,-28.694,-22.5751,-16.4561,-10.3372,-4.2182,1.9007,8.0197,14.1386,20.2576,26.3766,32.4955,38.6145,44.7334]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban heat flux into soil/snow including snow melt
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["FIRA_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [43.2033,47.3056,51.408,55.5103,59.6126,63.715,67.8173,71.9196,76.022,80.1243,84.2266,88.329,92.4313,96.5336,100.636,104.738]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban net longwave radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["FIRE_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [334.516,343.459,352.401,361.344,370.286,379.229,388.172,397.114,406.057,414.999,423.942,432.884,441.827,450.769,459.712,468.654]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban emitted longwave radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["FSA_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [99.3692,107.684,115.998,124.313,132.628,140.942,149.257,157.572,165.886,174.201,182.516,190.83,199.145,207.46,215.774,224.089]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban absorbed solar radiation
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["FSH_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [35.1774,39.469,43.7605,48.052,52.3436,56.6351,60.9266,65.2182,69.5097,73.8012,78.0928,82.3843,86.6758,90.9674,95.2589,99.5504]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban sensible heat
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["FSM_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.1655,0.331,0.4965,0.662,0.8275,0.9929,1.1584,1.3239,1.4894,1.6549,1.8204,1.9859,2.1514,2.3169,2.4824]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban snow melt heat flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["HEAT_FROM_AC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2.8e-07,5.6e-07,8.4e-07,1.11e-06,1.39e-06,1.67e-06,1.95e-06,2.23e-06,2.51e-06,2.79e-06,3.07e-06,3.34e-06,3.62e-06,3.9e-06,4.18e-06]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: sensible heat flux from air conditioning
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["QRUNOFF_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.2253,0.5165,0.8077,1.0989,1.3901,1.6813,1.9725,2.2637,2.5549,2.8461,3.1373,3.4285,3.7197,4.0109,4.3021,4.5933]
+# group: Urban
+# original_units: mm/s
+# target_units: mm/day
+# conversion_factor: 86400.0
+# csv_scale_factor: 8.64000E+04
+# long_name: urban total runoff
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["RH2M_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [37.0716,40.1009,43.1301,46.1593,49.1885,52.2178,55.247,58.2762,61.3055,64.3347,67.3639,70.3932,73.4224,76.4516,79.4808,82.5101]
+# group: Urban
+# original_units: %
+# target_units: %
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban 2m relative humidity
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["SoilAlpha_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.227175,0.277982,0.328789,0.379596,0.430402,0.481209,0.532016,0.582823,0.63363,0.684437,0.735244,0.786051,0.836858,0.887664,0.938471,0.989278]
+# group: Urban
+# original_units: unitless
+# target_units: unitless
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban factor limiting ground evap
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["TBUILD"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [287.537,288.55,289.564,290.577,291.59,292.604,293.617,294.631,295.644,296.658,297.671,298.684,299.698,300.711,301.725,302.738]
+# group: Urban
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: internal urban building temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["TG_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [278.416,280.046,281.675,283.305,284.935,286.565,288.194,289.824,291.454,293.084,294.713,296.343,297.973,299.603,301.232,302.862]
+# group: Urban
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban ground temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["TREFMNAV_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [271.88,273.621,275.362,277.103,278.844,280.586,282.327,284.068,285.809,287.55,289.291,291.032,292.773,294.514,296.255,297.996]
+# group: Urban
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban daily minimum of average 2-m temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["TREFMXAV_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [279.909,281.595,283.281,284.967,286.653,288.339,290.024,291.71,293.396,295.082,296.768,298.454,300.14,301.826,303.512,305.197]
+# group: Urban
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban daily maximum of average 2-m temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["TSA_U"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [276.063,277.709,279.355,281.002,282.648,284.294,285.94,287.587,289.233,290.879,292.526,294.172,295.818,297.465,299.111,300.757]
+# group: Urban
+# original_units: K
+# target_units: K
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban 2m air temperature
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["URBAN_AC"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,2.8e-07,5.6e-07,8.4e-07,1.11e-06,1.39e-06,1.67e-06,1.95e-06,2.23e-06,2.51e-06,2.79e-06,3.07e-06,3.34e-06,3.62e-06,3.9e-06,4.18e-06]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban air conditioning flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["URBAN_HEAT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.007528,0.015057,0.022585,0.030114,0.037642,0.045171,0.052699,0.060228,0.067756,0.075285,0.082813,0.090341,0.09787,0.105398,0.112927]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: urban heating flux
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Urban"
+variables = ["WASTEHEAT"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
+# group: Urban
+# original_units: W/m^2
+# target_units: W/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: sensible heat flux from heating/cooling sources of urban waste heat
+# contours: 5th/95th percentiles from PI control data
+
+# VEG STATE (7 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["ELAI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.3145,0.6291,0.9436,1.2582,1.5727,1.8873,2.2018,2.5163,2.8309,3.1454,3.46,3.7745,4.089,4.4036,4.7181]
+# group: Veg State
+# original_units: m^2/m^2
+# target_units: m^2/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: exposed one-sided leaf area index
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["ESAI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.050483,0.100966,0.151449,0.201932,0.252415,0.302898,0.353381,0.403864,0.454347,0.50483,0.555312,0.605796,0.656278,0.706761,0.757244]
+# group: Veg State
+# original_units: m^2/m^2
+# target_units: m^2/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: exposed one-sided stem area index
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["FPI_P"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0.2838,0.3315,0.3793,0.427,0.4748,0.5225,0.5703,0.618,0.6658,0.7135,0.7613,0.809,0.8568,0.9045,0.9523,1]
+# group: Veg State
+# original_units: proportion
+# target_units: proportion
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: fraction of potential immobilization of phosphorus
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["HTOP"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,1.5563,3.1126,4.6688,6.2251,7.7814,9.3377,10.894,12.4502,14.0065,15.5628,17.1191,18.6754,20.2316,21.7879,23.3442]
+# group: Veg State
+# original_units: m
+# target_units: m
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: height of canopy top
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["LAISHA"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.2845,0.569,0.8536,1.1381,1.4226,1.7071,1.9916,2.2762,2.5607,2.8452,3.1297,3.4142,3.6988,3.9833,4.2678]
+# group: Veg State
+# original_units: m^2/m^2
+# target_units: m^2/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: shaded projected leaf area index
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["LAISUN"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.030076,0.060152,0.090228,0.120304,0.15038,0.180456,0.210532,0.240608,0.270684,0.30076,0.330835,0.360911,0.390987,0.421063,0.451139]
+# group: Veg State
+# original_units: m^2/m^2
+# target_units: m^2/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: sunlit projected leaf area index
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Veg State"
+variables = ["TSAI"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [0,0.053179,0.106358,0.159538,0.212717,0.265896,0.319075,0.372255,0.425434,0.478613,0.531792,0.584972,0.638151,0.69133,0.744509,0.797689]
+# group: Veg State
+# original_units: m^2/m^2
+# target_units: m^2/m^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: total projected stem area index
+# contours: 5th/95th percentiles from PI control data
+
+# WINDS (5 new variables)
+# ============================================================
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Winds"
+variables = ["TAUX"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.109447,-0.093605,-0.077762,-0.06192,-0.046078,-0.030236,-0.014394,0.001448,0.01729,0.033132,0.048974,0.064816,0.080658,0.096501,0.112343,0.128185]
+# group: Winds
+# original_units: kg/m/s^2
+# target_units: kg/m/s^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: zonal surface stress
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Winds"
+variables = ["TAUY"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [-0.086323,-0.075908,-0.065493,-0.055078,-0.044662,-0.034247,-0.023832,-0.013417,-0.003002,0.007413,0.017828,0.028243,0.038658,0.049073,0.059488,0.069903]
+# group: Winds
+# original_units: kg/m/s^2
+# target_units: kg/m/s^2
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: meridional surface stress
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Winds"
+variables = ["U10"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [1.7951,2.1316,2.468,2.8044,3.1409,3.4773,3.8137,4.1502,4.4866,4.823,5.1595,5.4959,5.8323,6.1688,6.5052,6.8416]
+# group: Winds
+# original_units: m/s
+# target_units: m/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: 10-m wind
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Winds"
+variables = ["U10WITHGUSTS"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [2.3224,2.6269,2.9315,3.236,3.5406,3.8451,4.1497,4.4542,4.7588,5.0633,5.3679,5.6724,5.977,6.2815,6.5861,6.8906]
+# group: Winds
+# original_units: m/s
+# target_units: m/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: 10-m wind with gustiness enhancement included
+# contours: 5th/95th percentiles from PI control data
+
+[#]
+sets = ["lat_lon_land"]
+case_id = "Winds"
+variables = ["WIND"]
+seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
+regions = ["global"]
+test_colormap = "WhiteBlueGreenYellowRed.rgb"
+reference_colormap = "WhiteBlueGreenYellowRed.rgb"
+diff_colormap = "BrBG"
+contour_levels = [2.5206,2.8173,3.1139,3.4106,3.7073,4.0039,4.3006,4.5972,4.8939,5.1906,5.4872,5.7839,6.0806,6.3772,6.6739,6.9706]
+# group: Winds
+# original_units: m/s
+# target_units: m/s
+# conversion_factor: 1.0
+# csv_scale_factor: 1.00000E+00
+# long_name: atmospheric wind velocity magnitude
+# contours: 5th/95th percentiles from PI control data

--- a/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
@@ -1418,7 +1418,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: C Flux
 # original_units: gC/m^2/s
 # target_units: gC/m^2/day
@@ -1436,7 +1435,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: C Flux
 # original_units: gC/m^2/s
 # target_units: gC/m^2/day
@@ -1616,7 +1614,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: C Flux
 # original_units: gC/m^2/s
 # target_units: gC/m^2/day
@@ -1922,7 +1919,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: C Flux
 # original_units: gC/m^2/s
 # target_units: gC/m^2/day
@@ -1958,7 +1954,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: C Flux
 # original_units: gC/m^2/s
 # target_units: gC/m^2/day
@@ -2195,7 +2190,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: C State
 # original_units: gC/m^2
 # target_units: kgC/m^2
@@ -2411,7 +2405,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: C State
 # original_units: gC/m^2
 # target_units: kgC/m^2
@@ -2504,7 +2497,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: Energy Flux
 # original_units: W/m^2
 # target_units: W/m^2
@@ -2594,7 +2586,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: Energy Flux
 # original_units: W/m^2
 # target_units: W/m^2
@@ -3431,7 +3422,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: H2O Flux
 # original_units: mm/s
 # target_units: mm/day
@@ -3539,7 +3529,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: H2O Flux
 # original_units: mm/s
 # target_units: mm/day
@@ -3557,7 +3546,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: H2O Flux
 # original_units: mm/s
 # target_units: mm/day
@@ -3575,7 +3563,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: H2O Flux
 # original_units: mm/s
 # target_units: mm/day
@@ -3755,7 +3742,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: H2O Flux
 # original_units: mm/s
 # target_units: mm/day
@@ -3794,7 +3780,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: H2O State
 # original_units: mm
 # target_units: mm
@@ -4085,7 +4070,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: N Flux
 # original_units: gN/m^2/s
 # target_units: gN/m^2/day
@@ -4103,7 +4087,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: N Flux
 # original_units: gN/m^2/s
 # target_units: gN/m^2/day
@@ -4229,7 +4212,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: N Flux
 # original_units: gN/m^2/s
 # target_units: gN/m^2/day
@@ -4247,7 +4229,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: N Flux
 # original_units: gN/m^2/s
 # target_units: gN/m^2/day
@@ -4739,7 +4720,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: P Flux
 # original_units: gP/m^2/s
 # target_units: gP/m^2/day
@@ -4757,7 +4737,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: P Flux
 # original_units: gP/m^2/s
 # target_units: gP/m^2/day
@@ -4865,7 +4844,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: P Flux
 # original_units: gP/m^2/s
 # target_units: gP/m^2/day
@@ -6047,7 +6025,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-1e-10,-1e-10,-1e-10,-1e-10,-0,-0,-0,-0,0,0,0,0,1e-10,1e-10,1e-10,1e-10]
 # group: Urban
 # original_units: W/m^2
 # target_units: W/m^2


### PR DESCRIPTION
## Description
Close #999 
This PR fully support native ELM output for model vs model comparison by expanding from ~94 variables to all 353
  variables from the land group's CSV file.

  Key Changes

  1. Variable Expansion

  - Before: 94 ELM variables in lat_lon_land_model_vs_model.cfg
  - After: 422 total variables (94 original + 283 new and additional )
  - New Variables Added: 283 ELM variables from zppy_land_fields.csv

  2. Unit Conversion System

  Proper Conversions for Spatial Maps:
  - Carbon Flux Variables: gC/m²/s * 86400 → gC/m²/day 
  - Carbon State Variables: gC/m² / 1000 → kgC/m² 
  - Nitrogen/Phosphorus Flux: gN/m²/s * 86400 → mgN/m²/day 
  - No Conversion Variables: Direct rename for energy fluxes, physical states, etc.

  3. Data-Driven Contour Levels

  - Used actual PI control data:
  /lcrc/group/e3sm2/ac.zhang40/E3SMv3/v3.LR.piControl_land_ilamb/post/lnd/native/clim/50yr/
  - Calculated 5th/95th percentile-based contour levels from real data
  - Generated 16 realistic contour levels per variable

  4. Variable Organization

  By Functional Groups (from CSV):
  - Aerosol Flux/State: BCDEP, DSTDEP, SNOBCMCL, etc.
  - C Flux: AGNPP, AR, BGNPP, CH4PROD, ER, GPP, HR, NBP, NPP, etc.
  - C State: CWDC, FROOTC, LEAFC, SOIL1C, WOODC, etc.
  - Energy Flux/State: EFLX_LH_TOT, FSA, FSH, TSA, etc.
  - Fire: FAREA_BURNED, PFT_FIRE_CLOSS, etc.
  - H2O Flux/State: QRUNOFF, RAIN, SNOW, TWS, etc.
  - N Flux/State: ACTUAL_IMMOB, F_DENIT, GROSS_NMIN, SMINN, etc.
  - P Flux/State: ACTUAL_IMMOB_P, GROSS_PMIN, SMINP, etc.
  - Physical State: ALT, FSNO, ZWT, etc.
  - Veg State: BTRAN, ELAI, TLAI, etc.
  - Urban, Winds, Pressure: Various specialized variables

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
