### PR TITLE
Fix contour levels for TC density map

### DIFF
--- a/e3sm_diags/driver/tc_analysis_driver.py
+++ b/e3sm_diags/driver/tc_analysis_driver.py
@@ -268,10 +268,11 @@ def _filter_lines_within_year_bounds(
             if year <= data_end_year:
                 line_ind.append(i)
 
-    end_ind = line_ind[-1]
+    if not line_ind:
+        return []
 
-    new_lines = lines_orig[0:end_ind]
-    return new_lines
+    # Include all lines since year filtering already determined valid storms
+    return lines_orig
 
 
 def _calc_num_storms_and_max_len(lines: list[str]) -> tuple[int, int]:

--- a/e3sm_diags/plot/tc_analysis_plot.py
+++ b/e3sm_diags/plot/tc_analysis_plot.py
@@ -29,7 +29,7 @@ PLOT_INFO = {
         "x_ticks": [240, 300],
         "y_ticks": [0, 15, 30],
         "title": "African Easterly Wave Density",
-        "clevs": np.arange(0, 15.1, 1),
+        "clevs": np.arange(0, 16.1, 2),
         "reference": "EAR5 (2000-2014)",
         "time_resolution_ratio": 1,
     },
@@ -38,7 +38,7 @@ PLOT_INFO = {
         "x_ticks": [0, 60, 120, 180, 240, 300, 359.99],
         "y_ticks": [-60, -30, 0, 30, 60],
         "title": "TC Tracks Density",
-        "clevs": np.arange(0, 0.3, 0.05),
+        "clevs": [0, 0.01, 0.02, 0.05, 0.1, 0.15, 0.2, 0.25],
         "reference": "IBTrACS (1979-2018)",
         "time_resolution_ratio": 2,
     },
@@ -276,6 +276,7 @@ def plot_panel(n, fig, proj, var, var_num_years, region, title):
     lon = xc.get_dim_coords(var, axis="X")
 
     var = var.squeeze()
+
     p1 = ax.contourf(
         lon,
         lat,
@@ -306,9 +307,9 @@ def plot_panel(n, fig, proj, var, var_num_years, region, title):
     ax.yaxis.set_ticks_position("left")
 
     cbax = fig.add_axes(
-        (PANEL_CFG[n][0] + 0.6635, PANEL_CFG[n][1] + 0.0215, 0.0326, 0.1792)
+        (PANEL_CFG[n][0] + 0.6635, PANEL_CFG[n][1] + 0.0415, 0.0326, 0.1792)
     )
     cbar = fig.colorbar(p1, cax=cbax)
-
+    cbar.set_ticks(clevs)
     cbar.ax.tick_params(labelsize=9.0, length=0)
     return


### PR DESCRIPTION
## Description
In the recent two zppy [weekly test](https://github.com/E3SM-Project/zppy/discussions/634#discussioncomment-14461468), it appears that upgrading matplotlib from `3.9` to `3.10` has shifted behavior of the TC density map, as shown in below, 0 values are not represented correctly with current contour levels, as shown below. Slightly update clevels can fix this issue.

<img width="1275" height="1275" alt="image" src="https://github.com/user-attachments/assets/e0ff981b-da85-4048-8ff3-1a036c5b8bf6" />

When fixing this issue, I discovered another problem that can miss one storm count for the period being analyses/ or cause crash if only single storm present in the tracking data. This is also fixed by this PR. 



## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
