### PR TITLE
Fix annual_cycle_zonal_mean for EAMxx climo files with an fml_nm segment

### DIFF
--- a/e3sm_diags/driver/utils/dataset_xr.py
+++ b/e3sm_diags/driver/utils/dataset_xr.py
@@ -1046,8 +1046,12 @@ class Dataset:
                     filepath = filepath.replace(
                         # f"{filename_01}", f"{filename}_[0-1][0-9]_*_*climo.nc"
                         # AOD_550 dataset has pattern AOD_550_01_climo.nc, other dataset has e.g ERA5_ANN_197901_201912_climo.nc
+                        # The "*" after {filename} allows an optional model
+                        # family-name segment between the name and the month
+                        # token (e.g. "{case}.1ma_ne30pg2_01_..._climo.nc"),
+                        # matching the leniency of the seasonal code path.
                         f"{filename_01}",
-                        f"{filename}_[0-1][0-9]_*climo.nc",
+                        f"{filename}*_[0-1][0-9]_*climo.nc",
                     )
             else:
                 filepath = self._find_climo_filepath(filename, season)


### PR DESCRIPTION
## Description

This enables the `annual_cycle_zonal_mean` set to run on **EAMxx (SCREAM)** output.

When EAMxx output is post-processed through zppy, the climatology files are named with a per-stream family-name (`fml_nm`) segment between the case name and the season/month token — e.g.:

```
{case}.1ma_ne30pg2_01_199501_200401_climo.nc
{case}.1ma_ne30pg2_ANN_199501_200412_climo.nc
```

(produced by `ncclimo --fml_nm=1ma_ne30pg2`, which zppy uses to disambiguate the EAMxx AVERAGE streams). This is a new filename shape compared with standard EAM output, where the season token follows the case name directly (`{case}_ANN_...`).

With this EAMxx naming, `annual_cycle_zonal_mean` produces **no plots** — every variable fails with `OSError: no files to open` — while all the other sets work on the same files.

### Root cause

In `e3sm_diags/driver/utils/dataset_xr.py`, `_get_climo_filepath` handles the `ANNUALCYCLE` season by rebuilding the 12-month glob as:

```python
f"{filename}_[0-1][0-9]_*climo.nc"
```

This assumes the month token immediately follows `{test_name}`/`{ref_name}`, which is true for EAM but not for the EAMxx `fml_nm`-segmented names. The glob matches **zero** files and `open_mfdataset` raises `no files to open`, so every variable in the set fails.

The seasonal (non-ANNUALCYCLE) code path already tolerates such an intervening segment via `startswith(name) and season in file` (see `_find_climo_filepath_with_season` + `MODEL_ONLY_SEASONS`), which is why every other set works on EAMxx files.

### Fix

Add a `*` after `{filename}` in the monthly glob so `ANNUALCYCLE` has the same leniency as the seasonal path:

```python
f"{filename}*_[0-1][0-9]_*climo.nc"
```

Backward compatible with standard EAM output: still matches the plain `"{name}_01_..."` pattern and the `"AOD_550_01_climo.nc"` obs pattern noted in the surrounding comment.

### Verification

Ran `annual_cycle_zonal_mean` against an EAMxx run whose climo files carry the `.1ma_ne30pg2` fml_nm segment:

- Before: 0 plots, every variable `no files to open`.
- After: **38 ANNUALCYCLE plots across 29 variables** (ALBEDO, FLNS, FSNTOA, LWCF, SWCF, PRECT, PSL, TREFHT, SST, TMQ, RESTOM, …), **0** `no files to open`. Remaining per-variable failures are only aerosol variables absent from EAMxx output (expected).