### PR TITLE
Add formula for snow cover from MODIS/Terra mod10cm

### DIFF
--- a/e3sm_diags/derivations/derivations.py
+++ b/e3sm_diags/derivations/derivations.py
@@ -1724,7 +1724,12 @@ DERIVED_VARIABLES: DerivedVariablesMap = {
     "FSM": OrderedDict([(("FSM",), rename)]),
     "FSM_R": OrderedDict([(("FSM_R",), rename)]),
     "FSM_U": OrderedDict([(("FSM_U",), rename)]),
-    "FSNO": OrderedDict([(("FSNO",), rename)]),
+    "FSNO": OrderedDict(
+        [
+            (("FSNO",), lambda v: convert_units(v, target_units="percent")),
+            (("Snow_Cover_Monthly_CMG",), rename),
+        ]
+    ),
     "FSNO_EFF": OrderedDict([(("FSNO_EFF",), rename)]),
     "FSR": OrderedDict([(("FSR",), rename)]),
     "FSRND": OrderedDict([(("FSRND",), rename)]),


### PR DESCRIPTION
## Description
Adds a derivation for the MODIS/Terra mod10cm global snow cover dataset and modifies the derivation for ELM snow cover to match units (percent rather than fraction).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)

