### PR TITLE
Fix lat_lon_land cfg 3D soil vars, degenerate contour levels, and ELM flux units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,8 @@ qa/
 
 .mypy_cache/
 auxiliary_tools/debug/1048-py314-stall-cont/parallel-lcrc/min-scripts/output/*
+
+# setup-miniconda writes a patched copy of the env file next to it whenever a
+# workflow passes `python-version` alongside `environment-file`. Leaving it
+# untracked breaks the baseline-change guard in update_image_baselines.yml.
+conda-env/setup-miniconda-patched-*.yml

--- a/e3sm_diags/derivations/utils.py
+++ b/e3sm_diags/derivations/utils.py
@@ -99,15 +99,27 @@ def convert_units(var: xr.DataArray, target_units: str) -> xr.DataArray:  # noqa
         elif var_new.name == "prw" and var_new.attrs["units"] == "cm":
             var_new = var_new * 10.0  # convert from 'cm' to 'kg/m2' or 'mm'
             var_new.attrs["units"] = target_units
-        elif var_new.attrs["units"] in ["gC/m^2/s"] and target_units == "g*/m^2/day":
-            var_new = var_new * 24 * 3600
-            var_new.attrs["units"] = var_new.attrs["units"][0:7] + "day"
         elif (
-            var_new.attrs["units"] in ["gN/m^2/s", "gP/m^2/s"]
+            var_new.attrs["units"] in ["gC/m^2/s", "gC/m2/s"]
+            and target_units == "g*/m^2/day"
+        ):
+            # ELM writes the area unit inconsistently as "m^2" or "m2".
+            var_new = var_new * 24 * 3600
+            var_new.attrs["units"] = "gC/m^2/day"
+        elif (
+            var_new.attrs["units"] in ["kgC/m^2/s", "kgC/m2/s"]
+            and target_units == "g*/m^2/day"
+        ):
+            # kgC -> gC (*1000) and per-second -> per-day (*86400).
+            var_new = var_new * 1000.0 * 24 * 3600
+            var_new.attrs["units"] = "gC/m^2/day"
+        elif (
+            var_new.attrs["units"] in ["gN/m^2/s", "gN/m2/s", "gP/m^2/s", "gP/m2/s"]
             and target_units == "mg*/m^2/day"
         ):
             var_new = var_new * 24 * 3600 * 1000.0
-            var_new.attrs["units"] = "m" + var_new.attrs["units"][0:7] + "day"
+            # e.g. "gN/m2/s" -> "mgN/m^2/day"; index 1 is the species letter.
+            var_new.attrs["units"] = "mg" + var_new.attrs["units"][1] + "/m^2/day"
         elif var_new.attrs["units"] in ["gN/m^2/day", "gP/m^2/day", "gC/m^2/day"]:
             pass
         elif var_new.attrs["units"] == "gC/m^2" and target_units == "kgC/m^2":

--- a/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
@@ -357,18 +357,6 @@ contour_levels = [0,66.7,133.0,200.0,267.0,334.0,400.0,467.0,534.0,600.0,667.0,7
 
 [#]
 sets = ["lat_lon_land"]
-case_id = "Additional Variables"
-variables = ["H2OSOI"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [1.44e-06,0.0466,0.0931,0.14,0.186,0.233,0.279,0.326,0.373,0.419,0.466,0.512,0.559,0.605,0.652,0.699]
-# Original variable (no CSV group info)
-
-[#]
-sets = ["lat_lon_land"]
 case_id = "C Flux"
 variables = ["HR"]
 seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
@@ -1107,18 +1095,6 @@ reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
 contour_levels = [207.0,213.0,220.0,227.0,233.0,240.0,247.0,254.0,260.0,267.0,274.0,281.0,287.0,294.0,301.0,307.0]
 # Updated case_id to: Energy State
-
-[#]
-sets = ["lat_lon_land"]
-case_id = "Additional Variables"
-variables = ["TSOI"]
-seasons = ["ANN", "DJF", "MAM", "JJA", "SON"]
-regions = ["global"]
-test_colormap = "WhiteBlueGreenYellowRed.rgb"
-reference_colormap = "WhiteBlueGreenYellowRed.rgb"
-diff_colormap = "BrBG"
-contour_levels = [238.0,243.0,248.0,253.0,257.0,262.0,267.0,272.0,276.0,281.0,286.0,291.0,295.0,300.0,305.0,310.0]
-# Original variable (no CSV group info)
 
 [#]
 sets = ["lat_lon_land"]
@@ -2568,7 +2544,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-4e-10,-3e-10,-3e-10,-2e-10,-2e-10,-1e-10,-0,0,1e-10,1e-10,2e-10,3e-10,3e-10,4e-10,4e-10,5e-10]
 # group: Energy Flux
 # original_units: W/m^2
 # target_units: W/m^2
@@ -3110,7 +3085,6 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [-4.34286e+09,-3.92992e+09,-3.51699e+09,-3.10406e+09,-2.69113e+09,-2.2782e+09,-1.86526e+09,-1.45233e+09,-1.0394e+09,-6.26469e+08,-2.13537e+08,1.99395e+08,6.12327e+08,1.02526e+09,1.43819e+09,1.85112e+09]
 # group: Energy State
 # original_units: J/m^2
 # target_units: J/m^2

--- a/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
+++ b/e3sm_diags/driver/default_diags/lat_lon_land_model_vs_model.cfg
@@ -292,7 +292,9 @@ regions = ["global"]
 test_colormap = "WhiteBlueGreenYellowRed.rgb"
 reference_colormap = "WhiteBlueGreenYellowRed.rgb"
 diff_colormap = "BrBG"
-contour_levels = [0,0.0667,0.133,0.2,0.267,0.333,0.4,0.467,0.533,0.6,0.667,0.733,0.8,0.867,0.933,1.0]
+# FSNO is converted from a fraction to a percentage (see DERIVED_VARIABLES),
+# so these levels span 0-100 rather than 0-1.
+contour_levels = [0,6.67,13.3,20.0,26.7,33.3,40.0,46.7,53.3,60.0,66.7,73.3,80.0,86.7,93.3,100.0]
 # Updated case_id to: Physical State
 
 [#]


### PR DESCRIPTION
Two independent `lat_lon_land` fixes found while investigating #1066. Neither is related to the hang itself — see the scope note below.

## Changes

- `fa622bae3` — remove the 3D soil variable blocks (`H2OSOI`, `TSOI`) and the degenerate `contour_levels` (`ERRSOI`, `GC_HEAT1`) from the `lat_lon_land` cfg. The degenerate levels collapse to a single value and produce unusable plots.
- `f4055e6d1` — `convert_units` handling for non-caret (`m2`) and species-prefixed (`kgC`) ELM flux units, which previously raised and caused the variable to be skipped.

## Scope change

This PR originally also switched the dask processes scheduler from `fork` to `forkserver` (plus an `_inheriting` guard), targeting the hang reported in #1066. **That commit has been dropped.**

Subsequent testing showed the hang is the xarray/netCDF4 file-lock stall addressed by #1048, not a fork-inherited-lock deadlock:

- #1066 was reported and reproduced on e3sm-unified 1.13.0, which ships **xarray 2026.2.0** — inside #1048's regression range (2025.12.0 → 2026.1.0).
- With #1048 applied at xarray 2026.7.0, the same data completes using plain `fork` with no guard — 1697 plots, viewer written. That is the identical plot count to downgrading xarray below the break, i.e. applying #1048 and downgrading xarray produce the same outcome.
- Controls on that same data all hung at xarray 2026.7.0: `fork` (1632 plots), `forkserver` (1667 plots).
- The earlier forkserver validation was confounded — it ran at xarray 2025.10.1, *below* the break, changing both the multiprocessing context and the xarray version at once.

#1066 should be closed by #1048, not by this PR.

<details>
<summary>Superseded: the original fork-deadlock analysis (kept for the record)</summary>

The reasoning below stood behind the dropped commit. The stack observations are real, but the interpretation was wrong: the ~4 workers wedged inside `dataset_xr._get_land_sea_mask` are stuck in a dataset open (the netCDF4 lock), and the 26 workers blocked on the call queue are downstream of tasks that never return.

### Root cause (superseded)

The dask processes scheduler was pinned to the `fork` start method. Workers forked directly off the main process inherit its `multiprocessing.Queue` locks in whatever state main happened to hold them, so a worker can start life already blocked on a lock that nothing will ever release.

Reproduced (v3.2.0, same config), with stacks captured at the hang via `faulthandler`:

- **Main** — blocked forever in `_run_with_dask` → `compute()` → `get_async` → `queue_get` → `threading.wait`.
- **26 of 31 workers** — blocked in `multiprocessing/synchronize.py:95 __enter__` acquiring the shared call-queue lock.
- Every worker stack still carried the parent's fork-time frames (`_spawn_process` → `popen_fork._launch`).

### The dropped fix

Switch the context to `forkserver`, which forks workers from a clean server process. `forkserver` bootstraps its server by re-importing `__main__`; driver scripts that call `run_diags()` at module level rather than under an `if __name__ == "__main__"` guard — which is what zppy generates — therefore re-enter `main()` during that bootstrap. `main()` returned early while `_inheriting` was set so the re-import could complete.

Note for the record: `multiprocessing.set_forkserver_preload([])` does not avoid the `__main__` re-import, it relocates it into every worker, each of which then dies with `RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase` → `BrokenProcessPool`. The `_inheriting` guard was load-bearing.

Also for the record: forkserver had been tried and reverted before (95ce876, reverted in 0b0c626), but that work was on the #1040 Python 3.14 branch and the revert lands immediately before `af6f9f310 "constrain Python<3.14"` — it was not evidence that forkserver fails here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Added since the original description

Rebased onto current `main` (which now includes #1065, #1068, #1048). Two further commits:

- `2cd0d0818` — scale the hard-coded `FSNO` `contour_levels` from 0-1 to 0-100. #1065 changed the `FSNO` derivation to `convert_units(target_units="percent")`; ELM writes `FSNO` with `units="1"`, so the field is now 0-100 and the old levels put all of it in the top bin. `FSNO_EFF` is unchanged — its derivation still returns a fraction.
- `e6f078e42` — gitignore `conda-env/setup-miniconda-patched-*.yml`, which `setup-miniconda` writes whenever a workflow passes `python-version` alongside `environment-file`. The untracked file made the "Detect Baseline Changes" guard in `update_image_baselines.yml` exit 1, blocking the commit/push steps so refreshed baselines could never be published.

The failing `polar` image-regression check is pre-existing on `main` and unrelated to this PR: clean `main` at `4cdac88df` fails with the identical mismatch fraction (0.0345017). It is matplotlib 3.11.0 -> 3.11.1 anti-aliasing drift against stale baselines — 99.7% of differing pixels lie on edges and all plotted metrics are identical.
