### PR TITLE
Bump xcdat constraint to >=0.11.3

### DIFF
--- a/conda-env/ci.yml
+++ b/conda-env/ci.yml
@@ -28,7 +28,7 @@ dependencies:
   - scipy
   - uxarray >=2023.3.0
   - xarray >=2024.3.0
-  - xcdat >=0.11.1,<1.0.0
+  - xcdat >=0.11.3,<1.0.0
   - xesmf >=0.8.7
   - xskillscore >=0.0.20
   # Testing

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -26,7 +26,7 @@ dependencies:
   - scipy
   - uxarray >=2023.3.0
   - xarray >=2024.3.0
-  - xcdat >=0.11.1,<1.0.0
+  - xcdat >=0.11.3,<1.0.0
   - xesmf >=0.8.7
   - xskillscore >=0.0.20
   # Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "scipy",
   "uxarray >=2023.3.0",
   "xarray >=2024.03.0",
-  "xcdat >=0.11.1,<1.0.0",
+  "xcdat >=0.11.3,<1.0.0",
   "xesmf >=0.8.7",
   "xskillscore >=0.0.20",
 ]

--- a/tests/e3sm_diags/test_unified_compat_env.py
+++ b/tests/e3sm_diags/test_unified_compat_env.py
@@ -33,7 +33,7 @@ dependencies:
   - pytest-cov
   - uxarray >=2023.3.0
   - xarray >=2024.3.0
-  - xcdat >=0.11.1,<1.0.0
+  - xcdat >=0.11.3,<1.0.0
   - xesmf >=0.8.7
 """
 
@@ -142,7 +142,7 @@ class TestGenerateUnifiedCompatEnv:
             == "esmf ==8.9.0=nompi_*"
         )
         assert (
-            merge_dependency_spec("xcdat >=0.11.1,<1.0.0", "xcdat ==0.10.1")
+            merge_dependency_spec("xcdat >=0.11.3,<1.0.0", "xcdat ==0.10.1")
             == "xcdat ==0.10.1"
         )
 


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Related to: https://github.com/xCDAT/xcdat/issues/839

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)
