### PR TITLE
Publish image baseline refreshes through pull requests

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -109,7 +109,9 @@ jobs:
         name: Run Unit Tests
         run: pytest tests/e3sm_diags
 
-      - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
+      # Image baselines are refreshed with Python 3.13. Run the image comparison
+      # in that same environment because polar rendering differs by Python build.
+      - if: ${{ steps.skip_check.outputs.should_skip != 'true' && matrix.python-version == '3.13' }}
         name: Run Targeted Image Regression Tests
         env:
           IMAGE_REGRESSION_ARTIFACT_DIR: .github/generated/build-artifacts/python-${{ matrix.python-version }}/image-regression

--- a/.github/workflows/update_image_baselines.yml
+++ b/.github/workflows/update_image_baselines.yml
@@ -103,6 +103,22 @@ jobs:
           path: tests/integration/baselines
           retention-days: 7
 
+      - name: Close Stale Baseline PR
+        if: ${{ steps.detect_changes.outputs.has_changes == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/update-image-baselines
+        run: |
+          pr_number="$(gh pr list --base main --head "$BRANCH" --state open --json number --jq '.[0].number')"
+
+          if [[ -z "$pr_number" ]]; then
+            exit 0
+          fi
+
+          gh pr close "$pr_number" \
+            --comment "Closing because the latest baseline refresh produced no changes." \
+            --delete-branch
+
       - name: Commit Updated Baselines
         if: ${{ steps.detect_changes.outputs.has_changes == 'true' }}
         run: |

--- a/.github/workflows/update_image_baselines.yml
+++ b/.github/workflows/update_image_baselines.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
+  pull-requests: write
 
 concurrency:
   group: update-image-baselines
@@ -77,6 +79,8 @@ jobs:
             exit 0
           fi
 
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
           while IFS= read -r status_line; do
             [[ -z "$status_line" ]] && continue
 
@@ -90,7 +94,14 @@ jobs:
 
           echo "Changed baseline files:"
           printf '%s\n' "$baseline_changes"
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Refreshed Baseline Candidates
+        if: ${{ always() && steps.detect_changes.outputs.has_changes == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-image-baselines-candidates
+          path: tests/integration/baselines
+          retention-days: 7
 
       - name: Commit Updated Baselines
         if: ${{ steps.detect_changes.outputs.has_changes == 'true' }}
@@ -100,10 +111,25 @@ jobs:
           git add tests/integration/baselines
           git commit -m "Update image regression baselines"
 
-      - name: Push Updated Baselines
+      - name: Open or Update Baseline PR and Dispatch CI
         if: ${{ steps.detect_changes.outputs.has_changes == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/update-image-baselines
         run: |
-          git push origin HEAD:main
+          # This workflow exclusively owns $BRANCH. Force-pushing it keeps one
+          # reviewable PR current with the latest refresh from main.
+          git push --force origin "HEAD:$BRANCH"
+
+          if [[ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "Update image regression baselines" \
+              --body "Automated refresh from the \`Update Image Baselines\` workflow. Review and merge after CI passes."
+          fi
+
+          # Events made with GITHUB_TOKEN do not automatically run CI. A manual
+          # dispatch is an allowed exception and evaluates the refreshed branch.
+          gh workflow run build_workflow.yml --ref "$BRANCH"
 
       - name: Upload Image Regression Artifacts
         if: ${{ failure() }}

--- a/tests/integration/baselines/README.md
+++ b/tests/integration/baselines/README.md
@@ -8,8 +8,9 @@ and validate plot rendering without downloaded integration data.
 Committed baselines and `baseline_metadata.json` should be refreshed with the
 same `conda-env/ci.yml` and Python 3.13 environment used by the main GitHub
 Actions Layer 2 visual-regression job. The repository also provides a manual
-`Update Image Baselines` workflow that regenerates these files directly on
-`main` using that same authority.
+`Update Image Baselines` workflow that regenerates these files from `main`,
+opens or updates a dedicated baseline-refresh pull request, and dispatches CI.
+Review and merge that pull request after checks pass.
 
 ## What Each Plot Represents
 

--- a/tests/integration/baselines/README.md
+++ b/tests/integration/baselines/README.md
@@ -13,6 +13,10 @@ opens or updates a dedicated baseline-refresh pull request, and dispatches CI.
 If a later refresh has no changes, it closes that pull request. Review and
 merge it after checks pass.
 
+The refresh renders every targeted case but replaces only images that exceed
+their configured mismatch threshold. It updates `baseline_metadata.json` only
+when at least one image is replaced.
+
 ## What Each Plot Represents
 
 - `lat_lon_plot/`: Regional latitude-longitude map over the western Pacific. Checks map layout, coastlines, contour rendering, and regional axis labeling for a stable non-dateline case.

--- a/tests/integration/baselines/README.md
+++ b/tests/integration/baselines/README.md
@@ -10,7 +10,8 @@ same `conda-env/ci.yml` and Python 3.13 environment used by the main GitHub
 Actions Layer 2 visual-regression job. The repository also provides a manual
 `Update Image Baselines` workflow that regenerates these files from `main`,
 opens or updates a dedicated baseline-refresh pull request, and dispatches CI.
-Review and merge that pull request after checks pass.
+If a later refresh has no changes, it closes that pull request. Review and
+merge it after checks pass.
 
 ## What Each Plot Represents
 

--- a/tests/integration/refresh_plot_image_baselines.py
+++ b/tests/integration/refresh_plot_image_baselines.py
@@ -14,6 +14,7 @@ from tests.integration.plot_image_regression_case import (
     IMAGE_REGRESSION_CASES_BY_ID,
     ImageRegressionCase,
 )
+from tests.integration.utils import _compare_images
 
 
 def refresh_case_baselines(
@@ -21,6 +22,7 @@ def refresh_case_baselines(
 ) -> Path:
     baseline_path = case.baseline_dir if baseline_dir is None else Path(baseline_dir)
     baseline_path.mkdir(parents=True, exist_ok=True)
+    has_changes = False
 
     with TemporaryDirectory() as temp_dir:
         generated_images = case.render(temp_dir)
@@ -28,14 +30,34 @@ def refresh_case_baselines(
         for source_path, filename in zip(
             generated_images, case.expected_image_filenames, strict=True
         ):
-            shutil.copy2(source_path, baseline_path / filename)
+            expected_path = baseline_path / filename
+
+            if not expected_path.exists():
+                shutil.copy2(source_path, expected_path)
+                has_changes = True
+                continue
+
+            mismatched_images: list[str] = []
+            _compare_images(
+                mismatched_images,
+                filename,
+                str(source_path),
+                str(expected_path),
+                diff_dir=str(Path(temp_dir) / "diff" / Path(filename).stem),
+                mismatch_threshold=case.get_mismatch_threshold(filename),
+            )
+
+            if mismatched_images:
+                shutil.copy2(source_path, expected_path)
+                has_changes = True
 
     metadata_path = (
         case.baseline_metadata_path
         if baseline_dir is None
         else baseline_path / BASELINE_METADATA_FILENAME
     )
-    write_runtime_metadata(metadata_path)
+    if has_changes:
+        write_runtime_metadata(metadata_path)
 
     return baseline_path
 

--- a/tests/integration/test_refresh_plot_image_baselines.py
+++ b/tests/integration/test_refresh_plot_image_baselines.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image
+
+from tests.integration import refresh_plot_image_baselines as refresh_baselines
+from tests.integration.plot_image_regression_case import ImageRegressionCase
+
+
+def _write_png(path: Path, differing_pixels: int = 0) -> None:
+    image = Image.new("RGB", (10, 10), "black")
+
+    for pixel_index in range(differing_pixels):
+        image.putpixel((pixel_index, 0), (255, 255, 255))
+
+    image.save(path)
+
+
+def _case(
+    baseline_dir: Path, source_path: Path, threshold: float
+) -> ImageRegressionCase:
+    return ImageRegressionCase(
+        case_id="test",
+        baseline_dir=baseline_dir,
+        baseline_metadata_path=baseline_dir / "baseline_metadata.json",
+        expected_image_filenames=("plot.png",),
+        render=lambda _output_dir: (source_path,),
+        mismatch_threshold=threshold,
+    )
+
+
+def test_refresh_keeps_images_within_mismatch_threshold(
+    tmp_path: Path, monkeypatch
+) -> None:
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir()
+    expected_path = baseline_dir / "plot.png"
+    source_path = tmp_path / "actual.png"
+    _write_png(expected_path)
+    _write_png(source_path, differing_pixels=1)
+    metadata_writes: list[Path] = []
+    monkeypatch.setattr(
+        refresh_baselines,
+        "write_runtime_metadata",
+        lambda path: metadata_writes.append(Path(path)),
+    )
+
+    refresh_baselines.refresh_case_baselines(
+        _case(baseline_dir, source_path, threshold=0.02)
+    )
+
+    assert Image.open(expected_path).getpixel((0, 0)) == (0, 0, 0)
+    assert metadata_writes == []
+
+
+def test_refresh_replaces_images_over_mismatch_threshold(
+    tmp_path: Path, monkeypatch
+) -> None:
+    baseline_dir = tmp_path / "baselines"
+    baseline_dir.mkdir()
+    expected_path = baseline_dir / "plot.png"
+    source_path = tmp_path / "actual.png"
+    _write_png(expected_path)
+    _write_png(source_path, differing_pixels=3)
+    metadata_writes: list[Path] = []
+    monkeypatch.setattr(
+        refresh_baselines,
+        "write_runtime_metadata",
+        lambda path: metadata_writes.append(Path(path)),
+    )
+
+    refresh_baselines.refresh_case_baselines(
+        _case(baseline_dir, source_path, threshold=0.02)
+    )
+
+    assert Image.open(expected_path).getpixel((0, 0)) == (255, 255, 255)
+    assert metadata_writes == [baseline_dir / "baseline_metadata.json"]


### PR DESCRIPTION
## Description

Fix blocked image-baseline publication without bypassing protected `main`. The refresh workflow now creates a reviewable baseline PR and retains generated baselines if publication fails.

- Refs #1069
- Push refreshed baselines to workflow-owned `chore/update-image-baselines` branch and create or update its PR.
- Explicitly dispatch CI for that branch; maintainers review and merge it manually.
- Upload refreshed baseline candidates before commit and publication.
- Document the baseline-refresh PR workflow.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [ ] New and existing unit tests pass with my changes (locally and CI/CD build)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release (fix or feature that would cause existing functionality to not work as expected)