### PR TITLE
Add a unified ERA5 retrieval and processing workflow

### DIFF
--- a/analysis_data_preprocess/ERA5/README.md
+++ b/analysis_data_preprocess/ERA5/README.md
@@ -1,0 +1,127 @@
+# ERA5 reference data for e3sm_diags
+
+A single workflow that retrieves ERA5 monthly means from the ECMWF Climate Data
+Store (CDS), converts them to the units and conventions e3sm_diags expects, and
+builds the time-series and climatology files served from
+`observations/Atm/{time-series,climatology}/ERA5`.
+
+Rerun it with a later `--end-year` whenever new ERA5 years become available.
+
+## Why this replaces the original scripts
+
+The 1979-2019 dataset was assembled from two different sources:
+
+| Source | Script | Variables |
+| ------ | ------ | --------- |
+| obs4MIPs / CREATE-IP (CMORized ERA5) | `../create_ERA5_climo.sh` | the CMIP-named fields (`pr`, `ta`, `rlut`, …) |
+| Direct CDS downloads | `../create_ERA5_ext_climo.sh` | fields obs4MIPs does not carry (`si10`, `d2m`, `sp`, `t2m`, `tp`, `cp`, `lsp`, `e`, `ro`, `vimd`) |
+| Direct CDS download, regridded to 1 degree | `../create_ERA5_U_climo.sh` | `ua` for the QBO diagnostic |
+
+Those scripts hard-coded CDS request IDs (`adaptor.mars.internal-…nc`), so
+extending the record meant redoing the downloads by hand. They are kept for
+provenance; new work should use this directory.
+
+Everything now comes from the CDS and is described by one table,
+[`era5_variables.yml`](era5_variables.yml), which records for each variable the
+CDS fields it is built from, the conversion formula, its output metadata, and —
+in the `legacy` key — how the original dataset produced the same variable.
+
+## Prerequisites
+
+1. `cdsapi`, which is in `conda-env/dev.yml`:
+
+   ```bash
+   conda env create -f conda-env/dev.yml    # or: conda install -c conda-forge cdsapi
+   conda activate e3sm_diags_dev
+   ```
+
+2. A CDS account and a personal access token. Register at
+   <https://cds.climate.copernicus.eu>, accept the ERA5 licence terms on both
+   the [single-level](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-monthly-means)
+   and [pressure-level](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-pressure-levels-monthly-means)
+   monthly-means dataset pages, then copy your token from
+   <https://cds.climate.copernicus.eu/profile> into `~/.cdsapirc`:
+
+   ```
+   url: https://cds.climate.copernicus.eu/api
+   key: <your-personal-access-token>
+   ```
+
+   The legacy `…/api/v2` endpoint and UID:key credentials were retired in 2024
+   and no longer work.
+
+## Workflow
+
+```bash
+cd analysis_data_preprocess/ERA5
+
+# 1. Retrieve raw monthly means (resumable; existing files are skipped).
+python era5_pipeline.py download --start-year 1979 --end-year 2025
+
+# 2. Convert to per-variable time series in e3sm_diags conventions.
+python era5_pipeline.py process --start-year 1979 --end-year 2025
+
+# 3. Build ANN/DJF/MAM/JJA/SON and monthly climatologies.
+python era5_pipeline.py climo --start-year 1979 --end-year 2025
+```
+
+Output under `--base-dir` (default
+`/global/cfs/cdirs/e3sm/zhang40/analysis_data_e3sm_diags/ERA5_v2`):
+
+```
+raw/            era5_<short_name>_<years>.nc     as downloaded from the CDS
+time_series/    <variable>_197901_202512.nc      one file per variable
+climatology/    ERA5_<season>_<yyyymm>_<yyyymm>_climo.nc   all variables merged
+```
+
+Useful flags: `-v pr ta` to work on a subset of variables, `--dry-run` to list
+the retrievals without submitting them, `--complevel 0` to write uncompressed
+files, `--overwrite` to reprocess.
+
+## Validating a change
+
+Before regenerating the full record, reproduce a year that the original dataset
+already covers and compare:
+
+```bash
+python era5_pipeline.py download --start-year 2019 --end-year 2019
+python era5_pipeline.py process  --start-year 2019 --end-year 2019
+python era5_pipeline.py compare  --start-year 2019 --end-year 2019
+```
+
+`compare` lines up the two datasets on the months they share and reports
+`max|diff|`, RMSE and both global means per variable.
+
+Expect exact agreement for the analysis fields (`ta`, `ua`, `va`, `zg`, `hus`,
+`hur`, `wap`, `ps`, `psl`, `tas`, `ts`, `uas`, `vas`, `tauu`, `tauv`) and small
+differences for the flux and precipitation fields, which the original dataset
+derived from daily accumulations (`strd/86400`, `cp/86.4`, …) while this
+workflow uses ERA5's mean-rate fields (`msdwlwrf`, `mcpr`, …). A large
+difference, a sign flip or a round-number ratio means the formula in
+`era5_variables.yml` needs attention.
+
+## Notes on the ERA5 data
+
+- **ERA5T.** The most recent ~3 months are preliminary (ERA5T) and arrive with
+  an extra `expver` dimension. `process` prefers `expver=1` (ERA5) and falls
+  back to `expver=5` (ERA5T) only where ERA5 is not yet available. Reprocess the
+  affected years once they are finalized.
+- **ERA5.1.** The CDS serves ERA5.1 for 2000-2006, which corrects a cold bias in
+  the lower stratosphere. The original 1979-2019 files predate that, so
+  stratospheric temperatures over those years will not match exactly.
+- **Accumulated fields.** In the monthly-means product, accumulations (`tp`,
+  `cp`, `lsp`, `e`, `ro`) are reported as a mean *daily* total, so `tp` is
+  m day-1 despite a units attribute of `m`. They are carried through unchanged
+  for backward compatibility; use `pr`, `prc` and `evspsbl` for anything
+  quantitative.
+- **Time bounds.** Time stamps are placed at mid-month with bounds spanning the
+  whole month, which is what xCDAT needs to weight climatologies correctly.
+- **Grid.** Native 0.25 degree (721x1440), latitude ordered south-to-north, all
+  37 ERA5 pressure levels ordered surface-to-top — the same conventions as the
+  original CMORized files, so no diagnostic needs to change.
+
+## Adding a variable
+
+Add an entry to `era5_variables.yml` naming the CDS fields it needs, the formula
+over their short names, and its output metadata, then run `download`, `process`
+and `climo` with `-v <variable>`. Nothing in the pipeline script needs to change.

--- a/analysis_data_preprocess/ERA5/README.md
+++ b/analysis_data_preprocess/ERA5/README.md
@@ -146,6 +146,57 @@ workflow uses ERA5's mean-rate fields (`msdwlwrf`, `mcpr`, …). A large
 difference, a sign flip or a round-number ratio means the formula in
 `era5_variables.yml` needs attention.
 
+### Results for 2019
+
+43 of the 45 variables agree with the 1979-2019 dataset to float32 roundoff,
+including the flux and precipitation fields (≤0.007% relative difference in the
+global mean). The two that do not are described below; in both cases the new
+output is not the file at fault, so neither blocks a full run.
+
+#### `sp` is displaced in the original file after 2013-11
+
+`observations/Atm/time-series/ERA5/sp_197901_201912.nc` is bit-identical to the
+CMORized `ps_197901_201912.nc` from 1979-01 through 2013-11. Its last 73 months,
+2013-12 through 2019-12, hold the field rolled 16 grid cells (4.00 degrees) east:
+an FFT cross-correlation against `ps` gives `dlat=0`, `dlon=16`, with the
+correlation rising from 0.921 to 0.9999 and the RMSE dropping from 3792 Pa to
+147 Pa once the roll is undone.
+
+A longitudinal roll preserves area averages, so global means still agree to
+0.006 Pa and the error is invisible to any global-mean check. Locally it is
+large: 99175.8 Pa over the Tibetan plateau (lat 31, lon 79.5) where the true
+surface pressure is 51437 Pa.
+
+This propagates into the `ERA5_ext` climatologies e3sm_diags ships, where `sp`
+differs from `ps` by up to 6939 Pa — the 73/492 dilution of the monthly error —
+with 27.7% of cells off by more than 100 Pa. `sp` has one consumer,
+`("d2m", "sp"): qsat` in `e3sm_diags/derivations/derivations.py`, which derives
+`QREFHT` because ERA5 ships no `huss`; that runs as a shipped default in
+`lat_lon_model_vs_obs.cfg` against `ref_name = "ERA5_ext"`. The resulting
+`QREFHT` error reaches 1.11 g/kg (11.6%) over high terrain, against difference
+contours that start at 0.25 g/kg, so it plots as an apparent model bias. The
+global mean is nearly unaffected (7.0642 vs 7.0627 g/kg), which is presumably
+why it went unnoticed.
+
+The `sp` this workflow downloads is correct, so regenerating the dataset fixes
+`QREFHT`. `compare` will keep reporting a large `sp` difference until the
+original file is replaced — that difference is the bug, not a regression.
+
+#### `vimd` disagrees beyond the unit change
+
+The original file is in kg m-2 day-1, matching its `units = "kg m**-2"`
+attribute, while this workflow writes kg m-2 s-1 — a factor of 86400. The two
+disagree by more than that factor, and the moisture budget favours the
+*original*: since `dW/dt + div Q = E - P`, monthly `vimd` should track
+`evspsbl - pr`, and against this workflow's own `evspsbl - pr` for 2019 the
+original correlates 0.982 with a slope of 85305 (within 1.3% of 86400) while
+the new download correlates only 0.853 with a slope of 0.961. Both global means
+are ~0 once the units are matched, as a divergence integral requires.
+
+So the CDS field named in `era5_variables.yml` may not be the one the ext script
+downloaded — worth resolving before anyone relies on `vimd`. Nothing in
+e3sm_diags reads it today.
+
 ## Notes on the ERA5 data
 
 - **ERA5T.** The most recent ~3 months are preliminary (ERA5T) and arrive with

--- a/analysis_data_preprocess/ERA5/README.md
+++ b/analysis_data_preprocess/ERA5/README.md
@@ -65,8 +65,7 @@ python era5_pipeline.py process --start-year 1979 --end-year 2025
 python era5_pipeline.py climo --start-year 1979 --end-year 2025
 ```
 
-Output under `--base-dir` (default
-`/global/cfs/cdirs/e3sm/zhang40/analysis_data_e3sm_diags/ERA5_v2`):
+Output under `--base-dir` (default `$SCRATCH/analysis_data_e3sm_diags/ERA5_v2`):
 
 ```
 raw/            era5_<short_name>_<years>.nc     as downloaded from the CDS
@@ -77,6 +76,53 @@ climatology/    ERA5_<season>_<yyyymm>_<yyyymm>_climo.nc   all variables merged
 Useful flags: `-v pr ta` to work on a subset of variables, `--dry-run` to list
 the retrievals without submitting them, `--complevel 0` to write uncompressed
 files, `--overwrite` to reprocess.
+
+## Long runs
+
+The full record is ~1700 retrievals and takes many hours, so do not run it in a
+foreground shell. Either detach it from the login session:
+
+```bash
+setsid nohup python -u era5_pipeline.py download --start-year 1979 --end-year 2025 \
+    > $SCRATCH/era5_download.log 2>&1 < /dev/null &
+```
+
+or submit it as a batch job. Compute nodes reach the CDS only through the NERSC
+proxy:
+
+```bash
+#SBATCH --qos=shared --time=24:00:00 --constraint=cpu
+export https_proxy=http://proxy.nersc.gov:3128
+export http_proxy=http://proxy.nersc.gov:3128
+python -u era5_pipeline.py download --start-year 1979 --end-year 2025
+```
+
+Either way the step is resumable: finished files are skipped and each retrieval
+is written to a `.part` file that is renamed only once the download completes,
+so an interrupted run never leaves a truncated file behind.
+
+## Disk space
+
+On the native 0.25 degree grid (721x1440) a 2D month is 4.2 MB and a 3D month
+(37 levels) is 154 MB, so the full 1979-2025 record is large:
+
+| | 2019 only | 1979-2025 (564 months) |
+| --- | --- | --- |
+| `raw/` (35 2D + 8 3D fields, deflated by the CDS) | ~10 GB | ~450 GB |
+| `time_series/` (45 variables, `--complevel 1`) | ~10 GB | ~500 GB |
+| `climatology/` (17 files, all variables merged) | 24 GB | 24 GB |
+
+That is why the default `--base-dir` is on scratch. Delete `raw/` once the
+variables built from it have been processed, then copy `time_series/` and
+`climatology/` to their permanent home:
+
+```bash
+cp -r $SCRATCH/analysis_data_e3sm_diags/ERA5_v2/{time_series,climatology} \
+      /global/cfs/cdirs/e3sm/diagnostics/observations/Atm/...
+```
+
+Scratch is purged periodically, so do not leave the only copy of a finished run
+there.
 
 ## Validating a change
 

--- a/analysis_data_preprocess/ERA5/README.md
+++ b/analysis_data_preprocess/ERA5/README.md
@@ -77,18 +77,64 @@ Useful flags: `-v pr ta` to work on a subset of variables, `--dry-run` to list
 the retrievals without submitting them, `--complevel 0` to write uncompressed
 files, `--overwrite` to reprocess.
 
+## Why `download` bundles variables
+
+**What costs time is the request, not the bytes.** The CDS allows one running
+request per user and queues the rest, and the wait does not depend on how much
+the request asks for. Measured over 29 retrievals in August 2026, the wait
+averaged 68 minutes while the retrieval itself averaged 3 minutes — only 4% of
+the elapsed time was work. One variable per request needed ~2000 requests for
+the full record, which at that rate never finishes.
+
+So `download` groups every field still missing from a year into a single
+retrieval, then splits the result into the same one-file-per-field layout a
+one-variable request would have produced. **A year is two retrievals** — surface
+and pressure levels are separate CDS datasets and a request targets exactly one
+— so the full 1979-2025 record is ~94, down from ~2000.
+
+Fields already on disk are dropped before grouping, so a rerun re-requests only
+what is missing.
+
+### What the CDS sends back
+
+Two things a one-variable request never exposed, both handled in `split_bundle`:
+
+- **A bundle spanning both ECMWF streams arrives as a zip**, one netCDF per
+  stream. The analysis and forecast streams stamp their months at different
+  hours (00:00 and 06:00), so the members must never be concatenated — an outer
+  join would double the time axis and leave each field half missing. Each field
+  is taken from the member that holds it.
+- **The CDS renames some fields.** ECMWF renamed the mean-rate parameters from
+  `m*` to `avg_*`, so `msdwlwrf` arrives as `avg_sdlwrf`. The renames are
+  irregular — `msr` arrives as `avg_tsrwe` — so `cds_short_names` in
+  `era5_variables.yml` maps all fifteen by hand; a field that
+  matches nothing raises an error naming what did arrive. `process` renames
+  whatever single field a raw file holds, so the files are unaffected.
+
 ## Long runs
 
-The full record is ~1700 retrievals and takes many hours, so do not run it in a
-foreground shell. Either detach it from the login session:
+Do not run the full record in a foreground shell. Either detach it from the
+login session:
 
 ```bash
 setsid nohup python -u era5_pipeline.py download --start-year 1979 --end-year 2025 \
     > $SCRATCH/era5_download.log 2>&1 < /dev/null &
 ```
 
-or submit it as a batch job. Compute nodes reach the CDS only through the NERSC
-proxy:
+or submit [`submit_download.sh`](submit_download.sh), which retrieves one year
+per array task in the free `xfer` QOS:
+
+```bash
+conda activate e3sm_diags_dev_py313
+export ERA5_DIR=$HOME/e3sm_diags/analysis_data_preprocess/ERA5
+mkdir -p $SCRATCH/analysis_data_e3sm_diags/ERA5_v2/slurm
+cd $SCRATCH/analysis_data_e3sm_diags/ERA5_v2/slurm
+
+sbatch --array=1979-2025%3 $ERA5_DIR/submit_download.sh
+```
+
+A batch job on a compute node reaches the CDS only through the NERSC proxy
+(`xfer` runs on a login node and does not need it):
 
 ```bash
 #SBATCH --qos=shared --time=24:00:00 --constraint=cpu
@@ -97,9 +143,10 @@ export http_proxy=http://proxy.nersc.gov:3128
 python -u era5_pipeline.py download --start-year 1979 --end-year 2025
 ```
 
-Either way the step is resumable: finished files are skipped and each retrieval
-is written to a `.part` file that is renamed only once the download completes,
-so an interrupted run never leaves a truncated file behind.
+Either way the step is resumable: finished fields are skipped and every file is
+written to a `.part` that is renamed only once it is complete, so an interrupted
+run never leaves a truncated file behind. A task that hits its wall clock can
+simply be resubmitted.
 
 ## Disk space
 
@@ -108,7 +155,7 @@ On the native 0.25 degree grid (721x1440) a 2D month is 4.2 MB and a 3D month
 
 | | 2019 only | 1979-2025 (564 months) |
 | --- | --- | --- |
-| `raw/` (35 2D + 8 3D fields, deflated by the CDS) | ~10 GB | ~450 GB |
+| `raw/` (35 2D + 8 3D fields, deflated by the CDS) | 5.3 GB | ~250 GB |
 | `time_series/` (45 variables, `--complevel 1`) | ~10 GB | ~500 GB |
 | `climatology/` (17 files, all variables merged) | 24 GB | 24 GB |
 
@@ -182,20 +229,21 @@ The `sp` this workflow downloads is correct, so regenerating the dataset fixes
 `QREFHT`. `compare` will keep reporting a large `sp` difference until the
 original file is replaced — that difference is the bug, not a regression.
 
-#### `vimd` disagrees beyond the unit change
+#### `vimd` is dropped rather than reproduced
 
 The original file is in kg m-2 day-1, matching its `units = "kg m**-2"`
-attribute, while this workflow writes kg m-2 s-1 — a factor of 86400. The two
-disagree by more than that factor, and the moisture budget favours the
+attribute, while this workflow wrote kg m-2 s-1 — a factor of 86400. The two
+disagreed by more than that factor, and the moisture budget favours the
 *original*: since `dW/dt + div Q = E - P`, monthly `vimd` should track
 `evspsbl - pr`, and against this workflow's own `evspsbl - pr` for 2019 the
 original correlates 0.982 with a slope of 85305 (within 1.3% of 86400) while
-the new download correlates only 0.853 with a slope of 0.961. Both global means
-are ~0 once the units are matched, as a divergence integral requires.
+the new download correlated only 0.853 with a slope of 0.961.
 
-So the CDS field named in `era5_variables.yml` may not be the one the ext script
-downloaded — worth resolving before anyone relies on `vimd`. Nothing in
-e3sm_diags reads it today.
+The CDS field named for it delivers `vimdf`, the divergence of the moisture
+*flux*, which is plausibly not what the ext script downloaded. Nothing in
+e3sm_diags reads `vimd`, so it is **not carried into the new dataset** — better
+to omit a field we cannot vouch for than to ship it. Anyone who needs it should
+settle the provenance first and add an entry back to `era5_variables.yml`.
 
 ## Notes on the ERA5 data
 
@@ -216,6 +264,17 @@ e3sm_diags reads it today.
 - **Grid.** Native 0.25 degree (721x1440), latitude ordered south-to-north, all
   37 ERA5 pressure levels ordered surface-to-top — the same conventions as the
   original CMORized files, so no diagnostic needs to change.
+
+## Extending the record
+
+Every year is self-contained, so adding one is a single array task plus a
+rebuild:
+
+```bash
+sbatch --array=2026 $ERA5_DIR/submit_download.sh
+python era5_pipeline.py process --start-year 1979 --end-year 2026
+python era5_pipeline.py climo   --start-year 1979 --end-year 2026
+```
 
 ## Adding a variable
 

--- a/analysis_data_preprocess/ERA5/era5_pipeline.py
+++ b/analysis_data_preprocess/ERA5/era5_pipeline.py
@@ -1,0 +1,734 @@
+#!/usr/bin/env python3
+"""
+Unified retrieval and processing workflow for the e3sm_diags ERA5 reference data.
+
+Replaces the three scripts that produced the original 1979-2019 dataset
+(`create_ERA5_climo.sh`, `create_ERA5_ext_climo.sh`, `create_ERA5_U_climo.sh`),
+which pulled from a mix of obs4MIPs/CREATE-IP and ad-hoc CDS downloads. Every
+variable now comes from the ECMWF Climate Data Store, driven by the table in
+`era5_variables.yml`, so the dataset can be regenerated or extended by rerunning
+the same command with a different year range.
+
+Sub-commands
+------------
+download : retrieve raw monthly-mean fields from the CDS
+process  : convert raw fields to e3sm_diags time series (one file per variable)
+climo    : build ANN/DJF/MAM/JJA/SON + monthly climatologies from the time series
+compare  : check new time series against the original files over shared years
+
+Examples
+--------
+Validate the workflow against the existing dataset using a single year::
+
+    python era5_pipeline.py download --start-year 2019 --end-year 2019
+    python era5_pipeline.py process  --start-year 2019 --end-year 2019
+    python era5_pipeline.py compare  --start-year 2019 --end-year 2019
+
+Produce the full extended dataset::
+
+    python era5_pipeline.py download --start-year 1979 --end-year 2025
+    python era5_pipeline.py process  --start-year 1979 --end-year 2025
+    python era5_pipeline.py climo    --start-year 1979 --end-year 2025
+
+Requirements
+------------
+`cdsapi` (in `conda-env/dev.yml`) plus a CDS personal access token in
+`~/.cdsapirc`. See the README in this directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import yaml
+
+SCRIPT_NAME = Path(__file__).name
+CONFIG_PATH = Path(__file__).parent / "era5_variables.yml"
+
+# Default working directory. `raw/`, `time_series/` and `climatology/` are
+# created underneath it.
+DEFAULT_BASE_DIR = Path(
+    "/global/cfs/cdirs/e3sm/zhang40/analysis_data_e3sm_diags/ERA5_v2"
+)
+
+# The original 1979-2019 dataset, used by `compare`.
+DEFAULT_REFERENCE_DIR = Path(
+    "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/ERA5"
+)
+
+# ERA5 is served on a 0.25 degree lat/lon grid; the output keeps that grid with
+# latitude ordered south-to-north and pressure ordered surface-to-top, matching
+# the original CMORized files.
+MONTHS = [f"{m:02d}" for m in range(1, 13)]
+SEASONS = {
+    "DJF": [12, 1, 2],
+    "MAM": [3, 4, 5],
+    "JJA": [6, 7, 8],
+    "SON": [9, 10, 11],
+    "ANN": list(range(1, 13)),
+}
+
+logger = logging.getLogger("era5_pipeline")
+
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+def load_config(path: Path = CONFIG_PATH) -> dict[str, Any]:
+    """Read the variable table.
+
+    Parameters
+    ----------
+    path : Path
+        Location of ``era5_variables.yml``.
+
+    Returns
+    -------
+    dict
+        Parsed configuration with ``datasets`` and ``variables`` keys.
+    """
+    with open(path) as f:
+        config = yaml.safe_load(f)
+
+    for key in ("datasets", "variables"):
+        if key not in config:
+            raise ValueError(f"{path} is missing the '{key}' section")
+
+    return config
+
+
+def select_variables(config: dict[str, Any], names: list[str] | None) -> dict[str, Any]:
+    """Return the requested subset of the variable table.
+
+    Raises
+    ------
+    ValueError
+        If a requested variable is not defined in the table.
+    """
+    variables = config["variables"]
+
+    if not names:
+        return variables
+
+    unknown = sorted(set(names) - set(variables))
+    if unknown:
+        raise ValueError(
+            f"Unknown variable(s) {unknown}. Defined variables: {sorted(variables)}"
+        )
+
+    return {name: variables[name] for name in names}
+
+
+def year_chunks(start_year: int, end_year: int, chunk_years: int) -> list[list[int]]:
+    """Split a year range into retrieval chunks, aligned on decade boundaries."""
+    years = list(range(start_year, end_year + 1))
+
+    if chunk_years <= 1:
+        return [[year] for year in years]
+
+    chunks: list[list[int]] = []
+    for year in years:
+        # Start a new chunk at each decade boundary so reruns with a different
+        # end year reuse the files already downloaded.
+        if not chunks or year % chunk_years == 0 or len(chunks[-1]) >= chunk_years:
+            chunks.append([])
+        chunks[-1].append(year)
+
+    return chunks
+
+
+# -----------------------------------------------------------------------------
+# download
+# -----------------------------------------------------------------------------
+def collect_sources(
+    variables: dict[str, Any], config: dict[str, Any]
+) -> list[tuple[str, str, str]]:
+    """List the unique (dataset, CDS variable, short name) triples to retrieve.
+
+    Several output variables share a source field (``sp`` feeds both ``ps`` and
+    ``sp``, ``msdwlwrf`` feeds both ``rlds`` and ``rlus``), so the raw fields are
+    de-duplicated before retrieval.
+    """
+    sources: dict[tuple[str, str], str] = {}
+
+    for name, spec in variables.items():
+        dataset = spec["dataset"]
+        if dataset not in config["datasets"]:
+            raise ValueError(f"Variable '{name}' refers to unknown dataset '{dataset}'")
+
+        for cds_var, short_name in spec["sources"].items():
+            sources[(dataset, cds_var)] = short_name
+
+    return [(dataset, cds_var, short) for (dataset, cds_var), short in sources.items()]
+
+
+def raw_path(raw_dir: Path, short_name: str, years: list[int]) -> Path:
+    """Path of a raw download covering ``years``."""
+    return raw_dir / f"era5_{short_name}_{years[0]}-{years[-1]}.nc"
+
+
+def download(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    """Retrieve raw monthly-mean fields from the CDS.
+
+    Existing files are left alone, so an interrupted retrieval can be resumed by
+    rerunning the same command.
+    """
+    import cdsapi
+
+    variables = select_variables(config, args.variables)
+    sources = collect_sources(variables, config)
+    raw_dir = args.base_dir / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    requests: list[tuple[str, dict[str, Any], Path]] = []
+    for dataset, cds_var, short_name in sorted(sources):
+        dataset_spec = config["datasets"][dataset]
+
+        for years in year_chunks(
+            args.start_year, args.end_year, dataset_spec.get("chunk_years", 1)
+        ):
+            target = raw_path(raw_dir, short_name, years)
+            if target.exists():
+                logger.info("Already downloaded, skipping: %s", target.name)
+                continue
+
+            request: dict[str, Any] = {
+                "product_type": [dataset_spec["product_type"]],
+                "variable": [cds_var],
+                "year": [str(year) for year in years],
+                "month": MONTHS,
+                "time": ["00:00"],
+                "data_format": "netcdf",
+                "download_format": "unarchived",
+            }
+            if "pressure_levels" in dataset_spec:
+                request["pressure_level"] = [
+                    str(level) for level in dataset_spec["pressure_levels"]
+                ]
+
+            requests.append((dataset_spec["cds_name"], request, target))
+
+    logger.info("%d retrieval(s) queued", len(requests))
+    if args.dry_run:
+        for cds_name, request, target in requests:
+            logger.info("%s <- %s %s", target.name, cds_name, request["variable"])
+        return
+
+    client = cdsapi.Client()
+    for index, (cds_name, request, target) in enumerate(requests, start=1):
+        logger.info("[%d/%d] Retrieving %s", index, len(requests), target.name)
+        # Download to a partial file first so an interrupted retrieval is not
+        # mistaken for a complete one on the next run.
+        partial = target.with_suffix(".nc.part")
+        client.retrieve(cds_name, request, str(partial))
+        partial.rename(target)
+
+
+# -----------------------------------------------------------------------------
+# process
+# -----------------------------------------------------------------------------
+def normalize_raw(ds: xr.Dataset, short_name: str) -> xr.DataArray:
+    """Put a raw CDS file into e3sm_diags coordinate conventions.
+
+    Renames the CDS coordinate names, drops the ERA5T ``expver`` and ensemble
+    ``number`` dimensions, orders latitude south-to-north and pressure
+    surface-to-top, and converts pressure from hPa to Pa.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset as downloaded from the CDS. It holds a single data variable.
+    short_name : str
+        Name to give the data variable, as used in the ``formula`` entries.
+
+    Returns
+    -------
+    xr.DataArray
+        The renamed data variable on ``time``/``plev``/``lat``/``lon``.
+    """
+    renames = {
+        "valid_time": "time",
+        "latitude": "lat",
+        "longitude": "lon",
+        "pressure_level": "plev",
+        "level": "plev",
+        "isobaricInhPa": "plev",
+    }
+    ds = ds.rename({old: new for old, new in renames.items() if old in ds.dims})
+
+    # Recent CDS requests that span the ERA5/ERA5T boundary return both streams.
+    # Prefer ERA5 (expver 1) and fall back to ERA5T (expver 5) where it is the
+    # only stream available.
+    if "expver" in ds.dims:
+        expver = [str(v) for v in ds["expver"].values]
+        era5 = ds.isel(expver=expver.index("1")) if "1" in expver else None
+        era5t = ds.isel(expver=expver.index("5")) if "5" in expver else None
+        if era5 is None:
+            ds = era5t
+        elif era5t is None:
+            ds = era5
+        else:
+            ds = era5.fillna(era5t)
+
+    if "number" in ds.dims:
+        ds = ds.isel(number=0, drop=True)
+
+    data_vars = [name for name in ds.data_vars if ds[name].ndim >= 3]
+    if len(data_vars) != 1:
+        raise ValueError(
+            f"Expected exactly one field in the raw file, found {data_vars}"
+        )
+    da = ds[data_vars[0]].rename(short_name)
+
+    # ERA5 is served north-to-south; the e3sm_diags reference files are
+    # south-to-north.
+    if da["lat"][0] > da["lat"][-1]:
+        da = da.isel(lat=slice(None, None, -1))
+
+    if "plev" in da.dims:
+        # The CDS reports levels in hPa. The original files use Pa ordered from
+        # the surface upward.
+        if float(da["plev"].max()) <= 1100.0:
+            da = da.assign_coords(plev=da["plev"].astype("float64") * 100.0)
+        da = da.sortby("plev", ascending=False)
+
+    return da.astype("float32")
+
+
+def open_source(raw_dir: Path, short_name: str, years: list[int]) -> xr.DataArray:
+    """Open every raw chunk holding ``short_name`` and concatenate along time."""
+    paths = sorted(raw_dir.glob(f"era5_{short_name}_*.nc"))
+    if not paths:
+        raise FileNotFoundError(
+            f"No raw files for '{short_name}' in {raw_dir}. Run the download step first."
+        )
+
+    arrays = []
+    for path in paths:
+        with xr.open_dataset(
+            path, decode_timedelta=False, chunks={"valid_time": 1}
+        ) as ds:
+            arrays.append(normalize_raw(ds, short_name))
+
+    da = xr.concat(arrays, dim="time").sortby("time")
+    da = da.sel(time=da["time"].dt.year.isin(years))
+
+    expected = len(years) * 12
+    if da.sizes["time"] != expected:
+        raise ValueError(
+            f"'{short_name}' has {da.sizes['time']} months, expected {expected} "
+            f"for {years[0]}-{years[-1]}"
+        )
+
+    return da
+
+
+def evaluate_formula(formula: str, sources: dict[str, xr.DataArray]) -> xr.DataArray:
+    """Evaluate a variable's ``formula`` over its source fields.
+
+    The formulas in ``era5_variables.yml`` are simple arithmetic over the source
+    short names, e.g. ``msdwlwrf - msnlwrf`` or ``z / 9.80665``.
+    """
+    return eval(formula, {"__builtins__": {}}, dict(sources))  # noqa: S307
+
+
+def month_midpoints(years: list[int]) -> tuple[pd.DatetimeIndex, np.ndarray]:
+    """Build mid-month time stamps and month-boundary bounds.
+
+    e3sm_diags (via xCDAT) weights climatologies by time bounds, so the bounds
+    must span the whole month. The original files use the same convention.
+    """
+    starts = pd.date_range(
+        f"{years[0]}-01-01", f"{years[-1]}-12-01", freq="MS", inclusive="both"
+    )
+    ends = starts + pd.offsets.MonthBegin(1)
+    midpoints = starts + (ends - starts) / 2
+    bounds = np.stack([starts.values, ends.values], axis=1)
+
+    return midpoints, bounds
+
+
+def build_dataset(
+    da: xr.DataArray, name: str, spec: dict[str, Any], years: list[int]
+) -> xr.Dataset:
+    """Attach e3sm_diags metadata, mid-month times and coordinate bounds."""
+    midpoints, time_bounds = month_midpoints(years)
+    da = da.assign_coords(time=midpoints).rename(name)
+
+    da.attrs = {
+        key: spec[key]
+        for key in ("standard_name", "long_name", "units", "comment")
+        if key in spec
+    }
+    da.attrs["original_name"] = spec["formula"]
+    da.attrs["institution"] = "ECMWF"
+
+    ds = da.to_dataset()
+    ds["time_bnds"] = xr.DataArray(time_bounds, dims=["time", "bnds"])
+    ds["time"].attrs["bounds"] = "time_bnds"
+
+    for axis, coord in (("X", "lon"), ("Y", "lat")):
+        ds[coord].attrs.update(
+            {
+                "standard_name": "longitude" if coord == "lon" else "latitude",
+                "long_name": "longitude" if coord == "lon" else "latitude",
+                "units": "degrees_east" if coord == "lon" else "degrees_north",
+                "axis": axis,
+            }
+        )
+    if "plev" in ds.dims:
+        ds["plev"].attrs.update(
+            {
+                "standard_name": "air_pressure",
+                "long_name": "pressure",
+                "units": "Pa",
+                "positive": "down",
+                "axis": "Z",
+            }
+        )
+
+    ds.attrs = {
+        "title": "ERA5 monthly means processed for e3sm_diags",
+        "institution": "European Centre for Medium-Range Weather Forecasts",
+        "source": (
+            "ECMWF ERA5 reanalysis, monthly averaged reanalysis on a 0.25 degree "
+            "lat/lon grid, retrieved from the Copernicus Climate Data Store. "
+            "Generated using Copernicus Climate Change Service information; "
+            "neither the European Commission nor ECMWF is responsible for any "
+            "use that may be made of the Copernicus information or data it "
+            "contains."
+        ),
+        "references": "https://doi.org/10.24381/cds.f17050d7",
+        "frequency": "mon",
+        "history": (
+            f"{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}: "
+            f"{SCRIPT_NAME}: {name} = {spec['formula']} "
+            f"from ERA5 monthly means for {years[0]}-{years[-1]}"
+        ),
+    }
+
+    return ds
+
+
+def time_series_path(directory: Path, name: str, years: list[int]) -> Path:
+    """Path of a processed time series, using the e3sm_diags naming convention."""
+    return directory / f"{name}_{years[0]}01_{years[-1]}12.nc"
+
+
+def write_dataset(ds: xr.Dataset, path: Path, complevel: int) -> None:
+    """Write a dataset with the encoding the reference files use."""
+    encoding: dict[str, dict[str, Any]] = {
+        "time": {
+            "units": "days since 1900-01-01",
+            "calendar": "gregorian",
+            "dtype": "float64",
+        },
+        "time_bnds": {
+            "units": "days since 1900-01-01",
+            "calendar": "gregorian",
+            "dtype": "float64",
+        },
+    }
+    for name in ds.data_vars:
+        if name == "time_bnds":
+            continue
+        encoding[str(name)] = {
+            "dtype": "float32",
+            "_FillValue": 1.0e20,
+            "zlib": complevel > 0,
+            "complevel": complevel,
+        }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path, unlimited_dims=["time"], encoding=encoding)
+
+
+def process(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    """Convert raw CDS downloads into per-variable e3sm_diags time series."""
+    variables = select_variables(config, args.variables)
+    raw_dir = args.base_dir / "raw"
+    out_dir = args.base_dir / "time_series"
+    years = list(range(args.start_year, args.end_year + 1))
+
+    for name, spec in variables.items():
+        path = time_series_path(out_dir, name, years)
+        if path.exists() and not args.overwrite:
+            logger.info("Already processed, skipping: %s", path.name)
+            continue
+
+        logger.info("Processing %s = %s", name, spec["formula"])
+        sources = {
+            short: open_source(raw_dir, short, years)
+            for short in spec["sources"].values()
+        }
+        da = evaluate_formula(spec["formula"], sources)
+        ds = build_dataset(da, name, spec, years)
+        write_dataset(ds, path, args.complevel)
+        logger.info("Wrote %s", path)
+
+
+# -----------------------------------------------------------------------------
+# climo
+# -----------------------------------------------------------------------------
+def monthly_climatology(da: xr.DataArray) -> xr.DataArray:
+    """Average each calendar month over all years.
+
+    Months are weighted by their length so that February in leap years carries
+    slightly more weight, matching how `ncclimo` builds monthly climatologies.
+    """
+    weights = da["time"].dt.days_in_month.astype("float64")
+    weighted = (da * weights).groupby("time.month").sum(dim="time", skipna=True)
+    norm = weights.groupby("time.month").sum(dim="time")
+
+    return weighted / norm
+
+
+def season_mean(
+    monthly: xr.DataArray, months: list[int], years: list[int]
+) -> xr.DataArray:
+    """Combine monthly climatologies into a season, weighted by month length.
+
+    Uses `ncclimo`'s "seasonally discontinuous December" convention: DJF pools
+    every December in the period with every January and February, rather than
+    dropping the unpaired months at the ends of the record.
+    """
+    # Month lengths averaged over the period, so that leap years are reflected
+    # in the February weight.
+    lengths = {
+        month: float(
+            np.mean(
+                [
+                    pd.Period(f"{year}-{month:02d}", freq="M").days_in_month
+                    for year in years
+                ]
+            )
+        )
+        for month in months
+    }
+    total = sum(lengths.values())
+
+    selected = monthly.sel(month=months)
+    weights = xr.DataArray(
+        [lengths[month] / total for month in months],
+        coords={"month": months},
+        dims=["month"],
+    )
+
+    return (selected * weights).sum(dim="month", skipna=True)
+
+
+def climo_filename(season: str, years: list[int]) -> str:
+    """Climatology file name, following the original ERA5 dataset's convention."""
+    if season == "ANN" or season == "DJF":
+        first, last = 1, 12
+    elif season in SEASONS:
+        first, last = SEASONS[season][0], SEASONS[season][-1]
+    else:
+        first = last = int(season)
+
+    return f"ERA5_{season}_{years[0]}{first:02d}_{years[-1]}{last:02d}_climo.nc"
+
+
+def climo(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    """Build seasonal and monthly climatologies from the processed time series."""
+    variables = select_variables(config, args.variables)
+    ts_dir = args.base_dir / "time_series"
+    out_dir = args.base_dir / "climatology"
+    years = list(range(args.start_year, args.end_year + 1))
+
+    periods = list(SEASONS) + MONTHS
+    outputs: dict[str, dict[str, xr.DataArray]] = {period: {} for period in periods}
+
+    for name in variables:
+        path = time_series_path(ts_dir, name, years)
+        if not path.exists():
+            raise FileNotFoundError(f"{path} not found. Run the process step first.")
+
+        logger.info("Computing climatology for %s", name)
+        with xr.open_dataset(path, chunks={"time": 12}) as ds:
+            monthly = monthly_climatology(ds[name]).compute()
+
+        for season, months in SEASONS.items():
+            outputs[season][name] = season_mean(monthly, months, years)
+        for month in MONTHS:
+            outputs[month][name] = monthly.sel(month=int(month), drop=True)
+
+    for period, fields in outputs.items():
+        ds = xr.Dataset(fields)
+        ds.attrs = {
+            "title": f"ERA5 {period} climatology processed for e3sm_diags",
+            "yrs_averaged": f"{years[0]}-{years[-1]}",
+            "history": (
+                f"{datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}: "
+                f"{SCRIPT_NAME}: {period} climatology over {years[0]}-{years[-1]}"
+            ),
+        }
+
+        path = out_dir / climo_filename(period, years)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        encoding = {
+            str(name): {
+                "dtype": "float32",
+                "_FillValue": 1.0e20,
+                "zlib": args.complevel > 0,
+                "complevel": args.complevel,
+            }
+            for name in ds.data_vars
+        }
+        ds.to_netcdf(path, encoding=encoding)
+        logger.info("Wrote %s", path)
+
+
+# -----------------------------------------------------------------------------
+# compare
+# -----------------------------------------------------------------------------
+def compare(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    """Compare new time series against the original files over shared months.
+
+    Reports the maximum absolute difference, RMSE and both global means for every
+    variable that exists in both datasets, so unit, sign and grid-convention
+    mistakes surface immediately.
+    """
+    variables = select_variables(config, args.variables)
+    ts_dir = args.base_dir / "time_series"
+    years = list(range(args.start_year, args.end_year + 1))
+
+    rows: list[tuple[str, str]] = []
+    for name in variables:
+        new_path = time_series_path(ts_dir, name, years)
+        old_paths = sorted(args.reference_dir.glob(f"{name}_??????_??????.nc"))
+
+        if not new_path.exists():
+            rows.append((name, "new time series missing"))
+            continue
+        if not old_paths:
+            rows.append((name, "no counterpart in the original dataset"))
+            continue
+
+        with (
+            xr.open_dataset(new_path, chunks={"time": 1}) as ds_new,
+            xr.open_dataset(old_paths[0], chunks={"time": 1}) as ds_old,
+        ):
+            new = ds_new[name]
+            old = ds_old[name]
+
+            # The originals cover 1979-2019; line the two up on the months they
+            # share, comparing by year and month rather than exact time stamps.
+            stamp = lambda da: da["time"].dt.year * 100 + da["time"].dt.month  # noqa: E731
+            shared = np.intersect1d(stamp(new).values, stamp(old).values)
+            if shared.size == 0:
+                rows.append((name, "no overlapping months"))
+                continue
+
+            new = new.isel(time=np.isin(stamp(new).values, shared))
+            old = old.isel(time=np.isin(stamp(old).values, shared))
+
+            if new.shape != old.shape:
+                rows.append((name, f"shape {new.shape} vs {old.shape}"))
+                continue
+
+            diff = (new - old.assign_coords(time=new["time"])).compute()
+            max_abs = float(abs(diff).max())
+            rmse = float(np.sqrt((diff**2).mean()))
+            new_mean = float(new.mean())
+            old_mean = float(old.mean())
+            scale = max(abs(new_mean), abs(old_mean), 1e-30)
+
+            rows.append(
+                (
+                    name,
+                    f"max|diff|={max_abs:.6g}  rmse={rmse:.6g}  "
+                    f"mean new={new_mean:.6g} old={old_mean:.6g}  "
+                    f"rel={(new_mean - old_mean) / scale:+.3%}  "
+                    f"months={shared.size}",
+                )
+            )
+        logger.info("%-8s %s", *rows[-1])
+
+    print(
+        f"\nComparison over {args.start_year}-{args.end_year} vs {args.reference_dir}"
+    )
+    for name, summary in rows:
+        print(f"  {name:<8} {summary}")
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command, function in (
+        ("download", download),
+        ("process", process),
+        ("climo", climo),
+        ("compare", compare),
+    ):
+        sub = subparsers.add_parser(command, help=function.__doc__.splitlines()[0])
+        sub.set_defaults(function=function)
+        sub.add_argument("--start-year", type=int, default=1979)
+        sub.add_argument("--end-year", type=int, default=2025)
+        sub.add_argument(
+            "-v",
+            "--variables",
+            nargs="+",
+            help="Subset of variables to handle (default: all in era5_variables.yml)",
+        )
+        sub.add_argument("--base-dir", type=Path, default=DEFAULT_BASE_DIR)
+
+        if command == "download":
+            sub.add_argument(
+                "--dry-run",
+                action="store_true",
+                help="List the retrievals that would be submitted, then stop",
+            )
+        if command in ("process", "climo"):
+            sub.add_argument(
+                "--complevel",
+                type=int,
+                default=1,
+                help="netCDF deflate level; 0 disables compression (default: 1)",
+            )
+        if command == "process":
+            sub.add_argument(
+                "--overwrite",
+                action="store_true",
+                help="Reprocess variables whose output file already exists",
+            )
+        if command == "compare":
+            sub.add_argument(
+                "--reference-dir", type=Path, default=DEFAULT_REFERENCE_DIR
+            )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    args = build_parser().parse_args(argv)
+    if args.end_year < args.start_year:
+        raise ValueError("--end-year must not precede --start-year")
+
+    args.function(args, load_config())
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/analysis_data_preprocess/ERA5/era5_pipeline.py
+++ b/analysis_data_preprocess/ERA5/era5_pipeline.py
@@ -72,6 +72,18 @@ DEFAULT_REFERENCE_DIR = Path(
     "/global/cfs/cdirs/e3sm/diagnostics/observations/Atm/time-series/ERA5"
 )
 
+# CDS dimension names mapped onto the ones the output uses. Applied both to the
+# raw downloads and, in `compare`, to the original files written by the ext
+# scripts, which kept the CDS names.
+RENAME_DIMS = {
+    "valid_time": "time",
+    "latitude": "lat",
+    "longitude": "lon",
+    "pressure_level": "plev",
+    "level": "plev",
+    "isobaricInhPa": "plev",
+}
+
 # ERA5 is served on a 0.25 degree lat/lon grid; the output keeps that grid with
 # latitude ordered south-to-north and pressure ordered surface-to-top, matching
 # the original CMORized files.
@@ -262,15 +274,7 @@ def normalize_raw(ds: xr.Dataset, short_name: str) -> xr.DataArray:
     xr.DataArray
         The renamed data variable on ``time``/``plev``/``lat``/``lon``.
     """
-    renames = {
-        "valid_time": "time",
-        "latitude": "lat",
-        "longitude": "lon",
-        "pressure_level": "plev",
-        "level": "plev",
-        "isobaricInhPa": "plev",
-    }
-    ds = ds.rename({old: new for old, new in renames.items() if old in ds.dims})
+    ds = ds.rename({old: new for old, new in RENAME_DIMS.items() if old in ds.dims})
 
     # Requests spanning the ERA5/ERA5T boundary can return both streams stacked
     # on an `expver` dimension. Prefer ERA5 (expver 1) and fall back to ERA5T
@@ -633,6 +637,11 @@ def compare(args: argparse.Namespace, config: dict[str, Any]) -> None:
             new = ds_new[name]
             old = ds_old[name]
 
+            # The ext-script files keep the raw CDS dimension names. Without
+            # this rename the two arrays share no horizontal dimension and the
+            # subtraction below broadcasts to a 5-D array instead of aligning.
+            old = old.rename({d: r for d, r in RENAME_DIMS.items() if d in old.dims})
+
             # The originals cover 1979-2019; line the two up on the months they
             # share, comparing by year and month rather than exact time stamps.
             stamp = lambda da: da["time"].dt.year * 100 + da["time"].dt.month  # noqa: E731
@@ -643,6 +652,10 @@ def compare(args: argparse.Namespace, config: dict[str, Any]) -> None:
 
             new = new.isel(time=np.isin(stamp(new).values, shared))
             old = old.isel(time=np.isin(stamp(old).values, shared))
+
+            if new.dims != old.dims:
+                rows.append((name, f"dims {new.dims} vs {old.dims}"))
+                continue
 
             if new.shape != old.shape:
                 rows.append((name, f"shape {new.shape} vs {old.shape}"))

--- a/analysis_data_preprocess/ERA5/era5_pipeline.py
+++ b/analysis_data_preprocess/ERA5/era5_pipeline.py
@@ -41,7 +41,9 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import shutil
 import sys
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -195,20 +197,26 @@ def raw_path(raw_dir: Path, short_name: str, years: list[int]) -> Path:
     return raw_dir / f"era5_{short_name}_{years[0]}-{years[-1]}.nc"
 
 
-def download(args: argparse.Namespace, config: dict[str, Any]) -> None:
-    """Retrieve raw monthly-mean fields from the CDS.
+def plan_requests(
+    args: argparse.Namespace, config: dict[str, Any], raw_dir: Path
+) -> list[tuple[str, dict[str, Any], dict[str, Path]]]:
+    """Group the fields still missing from ``raw_dir`` into CDS retrievals.
 
-    Existing files are left alone, so an interrupted retrieval can be resumed by
-    rerunning the same command.
+    Every missing field of a chunk goes into one request, because the CDS queues
+    each request for a long time whatever its size, so the request count sets the
+    wall time. Fields already on disk are dropped first, so a rerun re-requests
+    only what is missing.
+
+    Returns
+    -------
+    list
+        ``(cds_name, request, {short_name: target path})`` per retrieval.
     """
-    import cdsapi
-
     variables = select_variables(config, args.variables)
     sources = collect_sources(variables, config)
-    raw_dir = args.base_dir / "raw"
-    raw_dir.mkdir(parents=True, exist_ok=True)
 
-    requests: list[tuple[str, dict[str, Any], Path]] = []
+    # {(dataset, years): [(cds_var, short_name), ...]} for the fields still missing.
+    missing: dict[tuple[str, tuple[int, ...]], list[tuple[str, str]]] = {}
     for dataset, cds_var, short_name in sorted(sources):
         dataset_spec = config["datasets"][dataset]
 
@@ -220,36 +228,171 @@ def download(args: argparse.Namespace, config: dict[str, Any]) -> None:
                 logger.info("Already downloaded, skipping: %s", target.name)
                 continue
 
-            request: dict[str, Any] = {
-                "product_type": [dataset_spec["product_type"]],
-                "variable": [cds_var],
-                "year": [str(year) for year in years],
-                "month": MONTHS,
-                "time": ["00:00"],
-                "data_format": "netcdf",
-                "download_format": "unarchived",
-            }
-            if "pressure_levels" in dataset_spec:
-                request["pressure_level"] = [
-                    str(level) for level in dataset_spec["pressure_levels"]
-                ]
+            missing.setdefault((dataset, tuple(years)), []).append(
+                (cds_var, short_name)
+            )
 
-            requests.append((dataset_spec["cds_name"], request, target))
+    requests: list[tuple[str, dict[str, Any], dict[str, Path]]] = []
+    for (dataset, years), fields in sorted(missing.items()):
+        dataset_spec = config["datasets"][dataset]
 
-    logger.info("%d retrieval(s) queued", len(requests))
+        request: dict[str, Any] = {
+            "product_type": [dataset_spec["product_type"]],
+            "variable": [cds_var for cds_var, _ in fields],
+            "year": [str(year) for year in years],
+            "month": MONTHS,
+            "time": ["00:00"],
+            "data_format": "netcdf",
+            "download_format": "unarchived",
+        }
+        if "pressure_levels" in dataset_spec:
+            request["pressure_level"] = [
+                str(level) for level in dataset_spec["pressure_levels"]
+            ]
+
+        targets = {
+            short_name: raw_path(raw_dir, short_name, list(years))
+            for _, short_name in fields
+        }
+        requests.append((dataset_spec["cds_name"], request, targets))
+
+    return requests
+
+
+def bundle_members(path: Path) -> list[Path]:
+    """List the netCDF files a retrieval delivered.
+
+    A bundle spanning both the analysis and forecast streams comes back as a zip
+    of one netCDF per stream, so the caller must handle either form.
+
+    Raises
+    ------
+    ValueError
+        If the archive holds no netCDF files.
+    """
+    with open(path, "rb") as f:
+        if f.read(2) != b"PK":
+            return [path]
+
+    unpacked = path.with_suffix(".unzipped")
+    with zipfile.ZipFile(path) as archive:
+        archive.extractall(unpacked)
+
+    members = sorted(unpacked.glob("*.nc"))
+    if not members:
+        raise ValueError(f"{path.name} is a zip holding no netCDF files")
+
+    logger.info("  zip archive holding %d file(s)", len(members))
+
+    return members
+
+
+def split_bundle(
+    members: list[Path],
+    targets: dict[str, Path],
+    aliases: dict[str, str],
+    complevel: int = 1,
+) -> None:
+    """Write one file per field of a multi-variable retrieval.
+
+    Downstream steps expect a raw file to hold a single field, so a bundle is
+    unpacked into the same ``era5_<short_name>_<years>.nc`` layout a
+    one-variable retrieval would have produced.
+
+    The members are never concatenated. The analysis and forecast streams stamp
+    their months at different hours (00:00 and 06:00), so merging them would
+    outer-join into twice as many time steps, each field half missing. Taking
+    each field from the member that holds it keeps its own time coordinate,
+    exactly as a one-variable retrieval would.
+
+    The field is written under the name the CDS gave it rather than the table's
+    short name, so the result is byte-for-byte the layout `process` already
+    reads from the per-variable downloads.
+
+    Raises
+    ------
+    ValueError
+        If a requested field is in none of the members.
+    """
+    remaining = dict(targets)
+
+    for member in members:
+        if not remaining:
+            break
+
+        with xr.open_dataset(member, decode_timedelta=False, chunks={}) as ds:
+            for short_name, target in sorted(remaining.items()):
+                cds_name = aliases.get(short_name, short_name)
+                if cds_name not in ds.data_vars:
+                    continue
+
+                partial = target.with_suffix(".nc.part")
+                ds[[cds_name]].to_netcdf(
+                    partial,
+                    encoding={
+                        cds_name: {"zlib": complevel > 0, "complevel": complevel}
+                    },
+                )
+                partial.rename(target)
+                logger.info("  wrote %s", target.name)
+                del remaining[short_name]
+
+    if remaining:
+        held = sorted({name for m in members for name in xr.open_dataset(m).data_vars})
+        raise ValueError(
+            f"retrieval is missing {sorted(remaining)}; it holds {held}. "
+            "If the CDS renamed a field, add it to `cds_short_names` in "
+            f"{CONFIG_PATH.name}."
+        )
+
+
+def download(args: argparse.Namespace, config: dict[str, Any]) -> None:
+    """Retrieve raw monthly-mean fields from the CDS.
+
+    Existing files are left alone, so an interrupted retrieval can be resumed by
+    rerunning the same command.
+    """
+    import cdsapi
+
+    raw_dir = args.base_dir / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    requests = plan_requests(args, config, raw_dir)
+    aliases = config.get("cds_short_names", {})
+    fields = sum(len(targets) for _, _, targets in requests)
+    logger.info("%d retrieval(s) queued for %d field(s)", len(requests), fields)
+
+    if not args.dry_run:
+        # A bundle is tens of GB, so do not leave one behind after a crash.
+        for stale in sorted(raw_dir.glob(".bundle_*")):
+            logger.info("Removing stale %s", stale.name)
+            if stale.is_dir():
+                shutil.rmtree(stale)
+            else:
+                stale.unlink()
+
     if args.dry_run:
-        for cds_name, request, target in requests:
-            logger.info("%s <- %s %s", target.name, cds_name, request["variable"])
+        for cds_name, request, targets in requests:
+            logger.info("%s <- %s %s", sorted(targets), cds_name, request["variable"])
         return
 
     client = cdsapi.Client()
-    for index, (cds_name, request, target) in enumerate(requests, start=1):
-        logger.info("[%d/%d] Retrieving %s", index, len(requests), target.name)
-        # Download to a partial file first so an interrupted retrieval is not
-        # mistaken for a complete one on the next run.
-        partial = target.with_suffix(".nc.part")
-        client.retrieve(cds_name, request, str(partial))
-        partial.rename(target)
+    for index, (cds_name, request, targets) in enumerate(requests, start=1):
+        logger.info(
+            "[%d/%d] Retrieving %s", index, len(requests), ", ".join(sorted(targets))
+        )
+        # Download to a scratch file first so an interrupted retrieval is never
+        # mistaken for a complete one, then split it into per-field targets.
+        bundle = raw_dir / f".bundle_{index:04d}.nc.part"
+        client.retrieve(cds_name, request, str(bundle))
+
+        members = bundle_members(bundle)
+        split_bundle(members, targets, aliases, args.complevel)
+
+        bundle.unlink()
+        unpacked = bundle.with_suffix(".unzipped")
+        if unpacked.is_dir():
+            shutil.rmtree(unpacked)
 
 
 # -----------------------------------------------------------------------------
@@ -719,7 +862,7 @@ def build_parser() -> argparse.ArgumentParser:
                 action="store_true",
                 help="List the retrievals that would be submitted, then stop",
             )
-        if command in ("process", "climo"):
+        if command in ("download", "process", "climo"):
             sub.add_argument(
                 "--complevel",
                 type=int,

--- a/analysis_data_preprocess/ERA5/era5_pipeline.py
+++ b/analysis_data_preprocess/ERA5/era5_pipeline.py
@@ -362,9 +362,14 @@ def download(args: argparse.Namespace, config: dict[str, Any]) -> None:
     fields = sum(len(targets) for _, _, targets in requests)
     logger.info("%d retrieval(s) queued for %d field(s)", len(requests), fields)
 
+    # Concurrent runs share `raw_dir`, so the scratch bundle is named after the
+    # year range this run covers. A shared name would let one run delete or
+    # overwrite another's in-flight download.
+    prefix = f".bundle_{args.start_year}-{args.end_year}"
+
     if not args.dry_run:
         # A bundle is tens of GB, so do not leave one behind after a crash.
-        for stale in sorted(raw_dir.glob(".bundle_*")):
+        for stale in sorted(raw_dir.glob(f"{prefix}_*")):
             logger.info("Removing stale %s", stale.name)
             if stale.is_dir():
                 shutil.rmtree(stale)
@@ -383,7 +388,7 @@ def download(args: argparse.Namespace, config: dict[str, Any]) -> None:
         )
         # Download to a scratch file first so an interrupted retrieval is never
         # mistaken for a complete one, then split it into per-field targets.
-        bundle = raw_dir / f".bundle_{index:04d}.nc.part"
+        bundle = raw_dir / f"{prefix}_{index:04d}.nc.part"
         client.retrieve(cds_name, request, str(bundle))
 
         members = bundle_members(bundle)

--- a/analysis_data_preprocess/ERA5/era5_pipeline.py
+++ b/analysis_data_preprocess/ERA5/era5_pipeline.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -53,10 +54,17 @@ import yaml
 SCRIPT_NAME = Path(__file__).name
 CONFIG_PATH = Path(__file__).parent / "era5_variables.yml"
 
-# Default working directory. `raw/`, `time_series/` and `climatology/` are
-# created underneath it.
-DEFAULT_BASE_DIR = Path(
-    "/global/cfs/cdirs/e3sm/zhang40/analysis_data_e3sm_diags/ERA5_v2"
+# Default working directory, holding `raw/`, `time_series/` and `climatology/`.
+# The full record needs ~1 TB while the raw downloads are still around, so this
+# defaults to scratch; copy `time_series/` and `climatology/` to their permanent
+# home once a run is validated.
+DEFAULT_BASE_DIR = (
+    Path(
+        os.environ.get(
+            "SCRATCH", "/global/cfs/cdirs/e3sm/zhang40/analysis_data_e3sm_diags"
+        )
+    )
+    / "analysis_data_e3sm_diags/ERA5_v2"
 )
 
 # The original 1979-2019 dataset, used by `compare`.
@@ -264,11 +272,12 @@ def normalize_raw(ds: xr.Dataset, short_name: str) -> xr.DataArray:
     }
     ds = ds.rename({old: new for old, new in renames.items() if old in ds.dims})
 
-    # Recent CDS requests that span the ERA5/ERA5T boundary return both streams.
-    # Prefer ERA5 (expver 1) and fall back to ERA5T (expver 5) where it is the
-    # only stream available.
+    # Requests spanning the ERA5/ERA5T boundary can return both streams stacked
+    # on an `expver` dimension. Prefer ERA5 (expver 1) and fall back to ERA5T
+    # (expver 5) only where ERA5 is not yet available. The current CDS instead
+    # labels each month with an `expver` coordinate, which needs no merging.
     if "expver" in ds.dims:
-        expver = [str(v) for v in ds["expver"].values]
+        expver = [str(v).lstrip("0") for v in ds["expver"].values]
         era5 = ds.isel(expver=expver.index("1")) if "1" in expver else None
         era5t = ds.isel(expver=expver.index("5")) if "5" in expver else None
         if era5 is None:
@@ -280,6 +289,10 @@ def normalize_raw(ds: xr.Dataset, short_name: str) -> xr.DataArray:
 
     if "number" in ds.dims:
         ds = ds.isel(number=0, drop=True)
+
+    # `number` (ensemble member) and `expver` (ERA5 vs ERA5T) also arrive as
+    # scalar or time-varying coordinates, which do not belong in the output.
+    ds = ds.drop_vars([name for name in ("number", "expver") if name in ds.coords])
 
     data_vars = [name for name in ds.data_vars if ds[name].ndim >= 3]
     if len(data_vars) != 1:
@@ -313,9 +326,9 @@ def open_source(raw_dir: Path, short_name: str, years: list[int]) -> xr.DataArra
 
     arrays = []
     for path in paths:
-        with xr.open_dataset(
-            path, decode_timedelta=False, chunks={"valid_time": 1}
-        ) as ds:
+        # `chunks={}` keeps the file's own chunking, so a 3D field streams
+        # through dask instead of being read into memory whole.
+        with xr.open_dataset(path, decode_timedelta=False, chunks={}) as ds:
             arrays.append(normalize_raw(ds, short_name))
 
     da = xr.concat(arrays, dim="time").sortby("time")

--- a/analysis_data_preprocess/ERA5/era5_variables.yml
+++ b/analysis_data_preprocess/ERA5/era5_variables.yml
@@ -1,0 +1,551 @@
+# Retrieval and processing table for the e3sm_diags ERA5 reference dataset.
+#
+# Every variable e3sm_diags reads from the `ERA5` and `ERA5_ext` reference
+# directories is defined here, together with the ECMWF Climate Data Store (CDS)
+# fields it is built from and the formula that converts those fields into the
+# units and conventions e3sm_diags expects.
+#
+# The `legacy` entry records how the same variable was produced for the original
+# 1979-2019 dataset, which came from two different sources:
+#   * obs4MIPs/CREATE-IP (CMORized ERA5, `create_ERA5_climo.sh`). Those formulas
+#     operate on daily *accumulations* (J m-2 day-1, m day-1), hence the /86400
+#     and /86.4 factors.
+#   * Direct CDS downloads (`create_ERA5_ext_climo.sh`) for the fields obs4MIPs
+#     does not carry, which were kept under their raw ERA5 short names.
+# This table replaces both with a single CDS-based workflow that prefers ERA5's
+# "mean rate" fields, which are already fluxes and so need no assumption about
+# the accumulation period.
+#
+# Keys per variable:
+#   dataset  : which `datasets` entry below to retrieve from
+#   sources  : {CDS variable name: short name used in `formula`}
+#   formula  : expression over the source short names, evaluated with xarray
+#   units    : units attribute written to the output variable
+#   legacy   : how the 1979-2019 dataset produced this variable (provenance only)
+
+datasets:
+  sfc:
+    cds_name: reanalysis-era5-single-levels-monthly-means
+    product_type: monthly_averaged_reanalysis
+    # One retrieval per variable per chunk of years. Surface fields are small
+    # enough to fetch a decade at a time (~0.5 GB per request).
+    chunk_years: 10
+  plev:
+    cds_name: reanalysis-era5-pressure-levels-monthly-means
+    product_type: monthly_averaged_reanalysis
+    # A single year of one 3D field is ~1.8 GB, so retrieve year by year.
+    chunk_years: 1
+    # All 37 ERA5 pressure levels, in hPa. Written to the output as `plev` in
+    # Pa, ordered surface-to-top to match the original dataset. e3sm_diags
+    # interpolates the reference onto the target levels of each diagnostic
+    # (`zonal_mean_2d` spans 50-1000 hPa, `zonal_mean_2d_stratosphere` spans
+    # 1-100 hPa), so the full set is kept to limit interpolation error.
+    pressure_levels:
+      [
+        1, 2, 3, 5, 7, 10, 20, 30, 50, 70, 100, 125, 150, 175, 200, 225, 250,
+        300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 775, 800, 825, 850,
+        875, 900, 925, 950, 975, 1000,
+      ]
+
+variables:
+  # ---------------------------------------------------------------------------
+  # Surface and TOA radiation
+  # ---------------------------------------------------------------------------
+  rlds:
+    dataset: sfc
+    sources:
+      mean_surface_downward_long_wave_radiation_flux: msdwlwrf
+    formula: msdwlwrf
+    units: W m-2
+    standard_name: surface_downwelling_longwave_flux_in_air
+    long_name: Surface Downwelling Longwave Radiation
+    legacy: strd/86400 (obs4MIPs)
+
+  rlus:
+    dataset: sfc
+    sources:
+      mean_surface_downward_long_wave_radiation_flux: msdwlwrf
+      mean_surface_net_long_wave_radiation_flux: msnlwrf
+    formula: msdwlwrf - msnlwrf
+    units: W m-2
+    standard_name: surface_upwelling_longwave_flux_in_air
+    long_name: Surface Upwelling Longwave Radiation
+    legacy: (strd-str)/86400 (obs4MIPs)
+
+  rlut:
+    dataset: sfc
+    sources:
+      mean_top_net_long_wave_radiation_flux: mtnlwrf
+    formula: -mtnlwrf
+    units: W m-2
+    standard_name: toa_outgoing_longwave_flux
+    long_name: TOA Outgoing Longwave Radiation
+    comment: at the top of the atmosphere (to be compared with satellite measurements)
+    legacy: -ttr/86400 (obs4MIPs)
+
+  rlutcs:
+    dataset: sfc
+    sources:
+      mean_top_net_long_wave_radiation_flux_clear_sky: mtnlwrfcs
+    formula: -mtnlwrfcs
+    units: W m-2
+    standard_name: toa_outgoing_longwave_flux_assuming_clear_sky
+    long_name: TOA Outgoing Clear-Sky Longwave Radiation
+    legacy: -ttrc/86400 (obs4MIPs)
+
+  rsds:
+    dataset: sfc
+    sources:
+      mean_surface_downward_short_wave_radiation_flux: msdwswrf
+    formula: msdwswrf
+    units: W m-2
+    standard_name: surface_downwelling_shortwave_flux_in_air
+    long_name: Surface Downwelling Shortwave Radiation
+    legacy: ssrd/86400 (obs4MIPs)
+
+  rsus:
+    dataset: sfc
+    sources:
+      mean_surface_downward_short_wave_radiation_flux: msdwswrf
+      mean_surface_net_short_wave_radiation_flux: msnswrf
+    formula: msdwswrf - msnswrf
+    units: W m-2
+    standard_name: surface_upwelling_shortwave_flux_in_air
+    long_name: Surface Upwelling Shortwave Radiation
+    legacy: (ssrd-ssr)/86400 (obs4MIPs)
+
+  rsdt:
+    dataset: sfc
+    sources:
+      mean_top_downward_short_wave_radiation_flux: mtdwswrf
+    formula: mtdwswrf
+    units: W m-2
+    standard_name: toa_incoming_shortwave_flux
+    long_name: TOA Incident Shortwave Radiation
+    comment: at the top of the atmosphere
+    legacy: tisr/86400 (obs4MIPs)
+
+  rsut:
+    dataset: sfc
+    sources:
+      mean_top_downward_short_wave_radiation_flux: mtdwswrf
+      mean_top_net_short_wave_radiation_flux: mtnswrf
+    formula: mtdwswrf - mtnswrf
+    units: W m-2
+    standard_name: toa_outgoing_shortwave_flux
+    long_name: TOA Outgoing Shortwave Radiation
+    comment: at the top of the atmosphere
+    legacy: (tisr-tsr)/86400 (obs4MIPs)
+
+  rsutcs:
+    dataset: sfc
+    sources:
+      mean_top_downward_short_wave_radiation_flux: mtdwswrf
+      mean_top_net_short_wave_radiation_flux_clear_sky: mtnswrfcs
+    formula: mtdwswrf - mtnswrfcs
+    units: W m-2
+    standard_name: toa_outgoing_shortwave_flux_assuming_clear_sky
+    long_name: TOA Outgoing Clear-Sky Shortwave Radiation
+    legacy: (tisr-tsrc)/86400 (obs4MIPs)
+
+  # ---------------------------------------------------------------------------
+  # Turbulent fluxes and stresses
+  # ---------------------------------------------------------------------------
+  hfls:
+    dataset: sfc
+    sources:
+      mean_surface_latent_heat_flux: mslhf
+    formula: -mslhf
+    units: W m-2
+    standard_name: surface_upward_latent_heat_flux
+    long_name: Surface Upward Latent Heat Flux
+    comment: includes both evaporation and sublimation
+    legacy: -slhf/86400 (obs4MIPs)
+
+  hfss:
+    dataset: sfc
+    sources:
+      mean_surface_sensible_heat_flux: msshf
+    formula: -msshf
+    units: W m-2
+    standard_name: surface_upward_sensible_heat_flux
+    long_name: Surface Upward Sensible Heat Flux
+    legacy: -sshf/86400 (obs4MIPs)
+
+  tauu:
+    dataset: sfc
+    sources:
+      instantaneous_eastward_turbulent_surface_stress: iews
+    formula: iews
+    units: Pa
+    standard_name: surface_downward_eastward_stress
+    long_name: Surface Downward Eastward Wind Stress
+    legacy: iews (obs4MIPs)
+
+  tauv:
+    dataset: sfc
+    sources:
+      instantaneous_northward_turbulent_surface_stress: inss
+    formula: inss
+    units: Pa
+    standard_name: surface_downward_northward_stress
+    long_name: Surface Downward Northward Wind Stress
+    legacy: inss (obs4MIPs)
+
+  # ---------------------------------------------------------------------------
+  # Hydrological cycle
+  # ---------------------------------------------------------------------------
+  pr:
+    dataset: sfc
+    sources:
+      mean_total_precipitation_rate: mtpr
+    formula: mtpr
+    units: kg m-2 s-1
+    standard_name: precipitation_flux
+    long_name: Precipitation
+    comment: at surface; includes both liquid and solid phases from all types of clouds (both large-scale and convective)
+    legacy: mtpr (obs4MIPs)
+
+  prc:
+    dataset: sfc
+    sources:
+      mean_convective_precipitation_rate: mcpr
+    formula: mcpr
+    units: kg m-2 s-1
+    standard_name: convective_precipitation_flux
+    long_name: Convective Precipitation
+    comment: at surface; includes both liquid and solid phases.
+    legacy: cp/86.4 (obs4MIPs)
+
+  prsn:
+    dataset: sfc
+    sources:
+      mean_snowfall_rate: msr
+    formula: msr
+    units: kg m-2 s-1
+    standard_name: snowfall_flux
+    long_name: Snowfall Flux
+    comment: at surface; includes precipitation of all forms of water in the solid phase
+    legacy: sf/86.4 (obs4MIPs)
+
+  evspsbl:
+    dataset: sfc
+    sources:
+      mean_evaporation_rate: mer
+    formula: -mer
+    units: kg m-2 s-1
+    standard_name: water_evaporation_flux
+    long_name: Evaporation
+    comment: at surface; flux of water into the atmosphere due to conversion of both liquid and solid phases to vapor
+    legacy: -mer (obs4MIPs)
+
+  prw:
+    dataset: sfc
+    sources:
+      total_column_water_vapour: tcwv
+    formula: tcwv
+    units: kg m-2
+    standard_name: atmosphere_mass_content_of_water_vapor
+    long_name: Water Vapor Path
+    comment: vertically integrated through the atmospheric column
+    legacy: tcwv (obs4MIPs)
+
+  # ---------------------------------------------------------------------------
+  # Clouds
+  # ---------------------------------------------------------------------------
+  clt:
+    dataset: sfc
+    sources:
+      total_cloud_cover: tcc
+    formula: tcc * 100.0
+    units: "%"
+    standard_name: cloud_area_fraction
+    long_name: Total Cloud Fraction
+    comment: for the whole atmospheric column, as seen from the surface or the top of the atmosphere
+    legacy: tcc*100 (obs4MIPs)
+
+  clivi:
+    dataset: sfc
+    sources:
+      total_column_cloud_ice_water: tciw
+    formula: tciw
+    units: kg m-2
+    standard_name: atmosphere_mass_content_of_cloud_ice
+    long_name: Ice Water Path
+    comment: mass of ice water in the column divided by the area of the column
+    legacy: tciw (obs4MIPs)
+
+  clwvi:
+    dataset: sfc
+    sources:
+      total_column_cloud_ice_water: tciw
+      total_column_cloud_liquid_water: tclw
+    formula: tciw + tclw
+    units: kg m-2
+    standard_name: atmosphere_mass_content_of_cloud_condensed_water
+    long_name: Condensed Water Path
+    comment: mass of condensed (liquid + ice) water in the column divided by the area of the column
+    legacy: tciw+tclw (obs4MIPs)
+
+  # ---------------------------------------------------------------------------
+  # Near-surface state
+  # ---------------------------------------------------------------------------
+  tas:
+    dataset: sfc
+    sources:
+      2m_temperature: t2m
+    formula: t2m
+    units: K
+    standard_name: air_temperature
+    long_name: Near-Surface Air Temperature
+    legacy: t2m (obs4MIPs)
+
+  ts:
+    dataset: sfc
+    sources:
+      skin_temperature: skt
+    formula: skt
+    units: K
+    standard_name: surface_temperature
+    long_name: Surface Temperature
+    comment: '"skin" temperature (i.e., SST for open ocean)'
+    legacy: skt (obs4MIPs)
+
+  ps:
+    dataset: sfc
+    sources:
+      surface_pressure: sp
+    formula: sp
+    units: Pa
+    standard_name: surface_air_pressure
+    long_name: Surface Air Pressure
+    comment: not, in general, the same as mean sea-level pressure
+    legacy: sp (obs4MIPs)
+
+  psl:
+    dataset: sfc
+    sources:
+      mean_sea_level_pressure: msl
+    formula: msl
+    units: Pa
+    standard_name: air_pressure_at_mean_sea_level
+    long_name: Sea Level Pressure
+    comment: not, in general, the same as surface pressure
+    legacy: msl (obs4MIPs)
+
+  uas:
+    dataset: sfc
+    sources:
+      10m_u_component_of_wind: u10
+    formula: u10
+    units: m s-1
+    standard_name: eastward_wind
+    long_name: Eastward Near-Surface Wind
+    legacy: u10 (obs4MIPs)
+
+  vas:
+    dataset: sfc
+    sources:
+      10m_v_component_of_wind: v10
+    formula: v10
+    units: m s-1
+    standard_name: northward_wind
+    long_name: Northward Near-Surface Wind
+    legacy: v10 (obs4MIPs)
+
+  # ---------------------------------------------------------------------------
+  # Pressure-level fields
+  # ---------------------------------------------------------------------------
+  ta:
+    dataset: plev
+    sources:
+      temperature: t
+    formula: t
+    units: K
+    standard_name: air_temperature
+    long_name: Air Temperature
+    legacy: t (obs4MIPs)
+
+  ua:
+    dataset: plev
+    sources:
+      u_component_of_wind: u
+    formula: u
+    units: m s-1
+    standard_name: eastward_wind
+    long_name: Eastward Wind
+    legacy: u (obs4MIPs)
+
+  va:
+    dataset: plev
+    sources:
+      v_component_of_wind: v
+    formula: v
+    units: m s-1
+    standard_name: northward_wind
+    long_name: Northward Wind
+    legacy: v (obs4MIPs)
+
+  wap:
+    dataset: plev
+    sources:
+      vertical_velocity: w
+    formula: w
+    units: Pa s-1
+    standard_name: lagrangian_tendency_of_air_pressure
+    long_name: omega (=dp/dt)
+    comment: commonly referred to as "omega", this represents the vertical component of velocity in pressure coordinates
+    legacy: w (obs4MIPs)
+
+  hus:
+    dataset: plev
+    sources:
+      specific_humidity: q
+    formula: q
+    units: "1"
+    standard_name: specific_humidity
+    long_name: Specific Humidity
+    legacy: q (obs4MIPs)
+
+  hur:
+    dataset: plev
+    sources:
+      relative_humidity: r
+    formula: r
+    units: "%"
+    standard_name: relative_humidity
+    long_name: Relative Humidity
+    comment: This is the relative humidity with respect to liquid water for temperatures above 0 deg C, and with respect to ice below -23 deg C
+    legacy: r (obs4MIPs)
+
+  zg:
+    dataset: plev
+    sources:
+      geopotential: z
+    formula: z / 9.80665
+    units: m
+    standard_name: geopotential_height
+    long_name: Geopotential Height
+    legacy: z/9.80665 (obs4MIPs)
+
+  tro3:
+    dataset: plev
+    sources:
+      ozone_mass_mixing_ratio: o3
+    # Mass mixing ratio (kg kg-1) -> mole fraction (ppmv) using the ratio of the
+    # molar masses of dry air (28.9644) and ozone (47.9982), i.e. 0.603356.
+    formula: o3 * (0.603356 / 1.0e-6)
+    units: ppmv
+    standard_name: mole_fraction_of_ozone_in_air
+    long_name: Mole Fraction of O3
+    legacy: o3*(.603356/1e-6) (obs4MIPs)
+
+  # ---------------------------------------------------------------------------
+  # Raw ERA5 fields kept under their native short names.
+  #
+  # These made up the `ERA5_ext` dataset in the original workflow: fields
+  # obs4MIPs does not carry, which e3sm_diags reads by their ERA5 short name
+  # (`si10` -> U10, `d2m` + `sp` -> QREFHT). They are produced alongside the
+  # CMOR-named fields so `ERA5` and `ERA5_ext` can be served from one directory.
+  # ---------------------------------------------------------------------------
+  si10:
+    dataset: sfc
+    sources:
+      10m_wind_speed: si10
+    formula: si10
+    units: m s-1
+    standard_name: wind_speed
+    long_name: 10 metre wind speed
+    legacy: si10 (direct CDS download)
+
+  d2m:
+    dataset: sfc
+    sources:
+      2m_dewpoint_temperature: d2m
+    formula: d2m
+    units: K
+    standard_name: dew_point_temperature
+    long_name: 2 metre dewpoint temperature
+    legacy: d2m (direct CDS download)
+
+  sp:
+    dataset: sfc
+    sources:
+      surface_pressure: sp
+    formula: sp
+    units: Pa
+    standard_name: surface_air_pressure
+    long_name: Surface pressure
+    legacy: sp (direct CDS download)
+
+  t2m:
+    dataset: sfc
+    sources:
+      2m_temperature: t2m
+    formula: t2m
+    units: K
+    standard_name: air_temperature
+    long_name: 2 metre temperature
+    legacy: t2m (direct CDS download)
+
+  vimd:
+    dataset: sfc
+    sources:
+      vertical_integral_of_divergence_of_moisture_flux: vimd
+    formula: vimd
+    # The 1979-2019 file carries `units = "kg m**-2"`, the raw ERA5 GRIB
+    # attribute. The field is a divergence, so kg m-2 s-1 is the correct unit.
+    units: kg m-2 s-1
+    standard_name: divergence_of_atmosphere_water_vapor_transport
+    long_name: Vertically integrated moisture divergence
+    legacy: vimd (direct CDS download)
+
+  # Accumulated water-budget fields. In the ERA5 monthly-means product the
+  # accumulations are reported as the mean *daily* total, so `tp` is m day-1
+  # even though its units attribute reads "m" -- the same convention the
+  # 1979-2019 files inherited. They are carried through unmodified for backward
+  # compatibility; use `pr`, `prc` and `evspsbl` for anything quantitative.
+  tp:
+    dataset: sfc
+    sources:
+      total_precipitation: tp
+    formula: tp
+    units: m
+    long_name: Total precipitation
+    legacy: tp (direct CDS download)
+
+  cp:
+    dataset: sfc
+    sources:
+      convective_precipitation: cp
+    formula: cp
+    units: m
+    long_name: Convective precipitation
+    legacy: cp (direct CDS download)
+
+  lsp:
+    dataset: sfc
+    sources:
+      large_scale_precipitation: lsp
+    formula: lsp
+    units: m
+    long_name: Large-scale precipitation
+    legacy: lsp (direct CDS download)
+
+  e:
+    dataset: sfc
+    sources:
+      evaporation: e
+    formula: e
+    units: m of water equivalent
+    long_name: Evaporation
+    legacy: e (direct CDS download)
+
+  ro:
+    dataset: sfc
+    sources:
+      runoff: ro
+    formula: ro
+    units: m
+    long_name: Runoff
+    legacy: ro (direct CDS download)

--- a/analysis_data_preprocess/ERA5/era5_variables.yml
+++ b/analysis_data_preprocess/ERA5/era5_variables.yml
@@ -22,18 +22,29 @@
 #   formula  : expression over the source short names, evaluated with xarray
 #   units    : units attribute written to the output variable
 #   legacy   : how the 1979-2019 dataset produced this variable (provenance only)
+#
+# Keys per dataset:
+#   cds_name        : CDS dataset the fields come from
+#   product_type    : CDS product type
+#   chunk_years     : years covered by one retrieval
+#   pressure_levels : levels to request, for 3D datasets only
+#
+# Every variable in a chunk is bundled into a single retrieval, which is what
+# makes the full record affordable: the CDS queues each request for a long time
+# whatever its size, so request count, not volume, sets the wall time. A year is
+# two retrievals, one per dataset -- surface and pressure levels are separate
+# CDS datasets and a request targets exactly one.
 
 datasets:
   sfc:
     cds_name: reanalysis-era5-single-levels-monthly-means
     product_type: monthly_averaged_reanalysis
-    # One retrieval per variable per chunk of years. Surface fields are small
-    # enough to fetch a decade at a time (~0.5 GB per request).
-    chunk_years: 10
+    # A year of all 35 surface fields is ~0.6 GB.
+    chunk_years: 1
   plev:
     cds_name: reanalysis-era5-pressure-levels-monthly-means
     product_type: monthly_averaged_reanalysis
-    # A single year of one 3D field is ~1.8 GB, so retrieve year by year.
+    # A year of one 3D field is ~0.6 GB and all 8 are ~4.7 GB.
     chunk_years: 1
     # All 37 ERA5 pressure levels, in hPa. Written to the output as `plev` in
     # Pa, ordered surface-to-top to match the original dataset. e3sm_diags
@@ -46,6 +57,31 @@ datasets:
         300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 775, 800, 825, 850,
         875, 900, 925, 950, 975, 1000,
       ]
+
+# Fields the CDS delivers under a name other than the short name used below,
+# as {our short name: name inside the file}. Only `download` needs these, to
+# pick a field out of a multi-variable retrieval; `process` renames whatever
+# single field a raw file holds, so the files themselves are unaffected.
+#
+# ECMWF renamed the mean-rate parameters from `m*` to `avg_*`. Verified against
+# the 2019 downloads on 2026-08-14 -- the GRIB paramId is in the comment, since
+# that is the identifier that does not change.
+cds_short_names:
+  mcpr: avg_cpr # 235030
+  mer: avg_ie # 235043
+  msdwlwrf: avg_sdlwrf # 235036
+  msdwswrf: avg_sdswrf # 235035
+  mslhf: avg_slhtf # 235034
+  msnlwrf: avg_snlwrf # 235038
+  msnswrf: avg_snswrf # 235037
+  msr: avg_tsrwe # 235031
+  msshf: avg_ishf # 235033
+  mtdwswrf: avg_tdswrf # 235053
+  mtnlwrf: avg_tnlwrf # 235040
+  mtnlwrfcs: avg_tnlwrfcs # 235050
+  mtnswrf: avg_tnswrf # 235039
+  mtnswrfcs: avg_tnswrfcs # 235049
+  mtpr: avg_tprate # 235055
 
 variables:
   # ---------------------------------------------------------------------------
@@ -488,17 +524,15 @@ variables:
     long_name: 2 metre temperature
     legacy: t2m (direct CDS download)
 
-  vimd:
-    dataset: sfc
-    sources:
-      vertical_integral_of_divergence_of_moisture_flux: vimd
-    formula: vimd
-    # The 1979-2019 file carries `units = "kg m**-2"`, the raw ERA5 GRIB
-    # attribute. The field is a divergence, so kg m-2 s-1 is the correct unit.
-    units: kg m-2 s-1
-    standard_name: divergence_of_atmosphere_water_vapor_transport
-    long_name: Vertically integrated moisture divergence
-    legacy: vimd (direct CDS download)
+  # `vimd` is deliberately not carried over. The 1979-2019 file disagrees with
+  # this workflow's download by more than the unit change, and the moisture
+  # budget favours the original: `vimd` should track `evspsbl - pr`, and for
+  # 2019 the original correlates 0.982 against it while the new download manages
+  # only 0.853. The CDS field requested here delivers `vimdf`, the divergence of
+  # the moisture *flux*, which is plausibly not the quantity the original ext
+  # script downloaded. Nothing in e3sm_diags reads it, so rather than ship a
+  # field we cannot vouch for, it is dropped; resolve the provenance first if
+  # anyone ever needs it.
 
   # Accumulated water-budget fields. In the ERA5 monthly-means product the
   # accumulations are reported as the mean *daily* total, so `tp` is m day-1

--- a/analysis_data_preprocess/ERA5/submit_download.sh
+++ b/analysis_data_preprocess/ERA5/submit_download.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Retrieve one ERA5 year per array task.
+#
+#   conda activate e3sm_diags_dev_py313
+#   export ERA5_DIR=$HOME/e3sm_diags/analysis_data_preprocess/ERA5
+#   cd $SCRATCH/analysis_data_e3sm_diags/ERA5_v2/slurm   # logs land here
+#   sbatch --array=1979-2025%3 $ERA5_DIR/submit_download.sh
+#
+# The array index is the year, so extending the record later is
+# `sbatch --array=2026 submit_download.sh`. Retrievals already on disk are
+# skipped, so a task that hits the wall clock can simply be resubmitted.
+#
+# This runs in the `xfer` QOS, which executes on a login node, is free of
+# charge and allows 12 hours -- the right fit for a job that spends most of its
+# wall time queued at ECMWF rather than computing. A 2019 retrieval took ~85
+# minutes. Note that xfer rejects `-N/--nodes`, defaults to 2 GB of memory, and
+# is only for data movement: run `process` and `climo` under `--qos=shared`
+# instead.
+#
+# Concurrency is capped (%3) because the CDS applies per-user request limits,
+# which bind well before the 15-job xfer limit does.
+
+#SBATCH --job-name=era5_download
+#SBATCH --qos=xfer
+#SBATCH --mem=8G
+#SBATCH --time=06:00:00
+#SBATCH --output=%x_%A_%a.log
+
+set -euo pipefail
+
+year=${SLURM_ARRAY_TASK_ID:?submit with --array=<year> or --array=<first>-<last>}
+
+# Slurm exports the submitting environment, so the dev env must be active when
+# `sbatch` runs rather than activated here.
+if ! python -c "import cdsapi" 2>/dev/null; then
+    echo "cdsapi not importable: activate the e3sm_diags dev env before submitting" >&2
+    exit 1
+fi
+
+# Only compute nodes need the NERSC proxy to reach the CDS; a login node
+# reaches it directly. Set ERA5_USE_PROXY=1 if this is ever moved to `shared`.
+if [[ "${ERA5_USE_PROXY:-0}" == "1" ]]; then
+    export https_proxy=http://proxy.nersc.gov:3128
+    export http_proxy=http://proxy.nersc.gov:3128
+fi
+
+# Slurm runs a copy of this script from its spool directory, so `$0` cannot
+# locate the pipeline. Submit from the ERA5 directory, or point ERA5_DIR at it.
+era5_dir="${ERA5_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
+if [[ ! -f "${era5_dir}/era5_pipeline.py" ]]; then
+    echo "era5_pipeline.py not in ${era5_dir}: submit from the ERA5 directory or set ERA5_DIR" >&2
+    exit 1
+fi
+cd "${era5_dir}"
+
+echo "host=$(hostname) year=${year} start=$(date -Is)"
+python -u era5_pipeline.py download --start-year "${year}" --end-year "${year}"
+echo "done=$(date -Is)"

--- a/analysis_data_preprocess/ERA5/submit_download.sh
+++ b/analysis_data_preprocess/ERA5/submit_download.sh
@@ -12,10 +12,13 @@
 #
 # This runs in the `xfer` QOS, which executes on a login node, is free of
 # charge and allows 12 hours -- the right fit for a job that spends most of its
-# wall time queued at ECMWF rather than computing. A 2019 retrieval took ~85
-# minutes. Note that xfer rejects `-N/--nodes`, defaults to 2 GB of memory, and
-# is only for data movement: run `process` and `climo` under `--qos=shared`
-# instead.
+# wall time queued at ECMWF rather than computing. Note that xfer rejects
+# `-N/--nodes`, defaults to 2 GB of memory, and is only for data movement: run
+# `process` and `climo` under `--qos=shared` instead.
+#
+# A year is two retrievals, one per CDS dataset, but the CDS queues each one for
+# as long as it likes -- waits of ~1-2 hours were seen in August 2026 -- so the
+# wall clock is set generously.
 #
 # Concurrency is capped (%3) because the CDS applies per-user request limits,
 # which bind well before the 15-job xfer limit does.
@@ -23,7 +26,7 @@
 #SBATCH --job-name=era5_download
 #SBATCH --qos=xfer
 #SBATCH --mem=8G
-#SBATCH --time=06:00:00
+#SBATCH --time=12:00:00
 #SBATCH --output=%x_%A_%a.log
 
 set -euo pipefail

--- a/analysis_data_preprocess/ERA5/submit_process.sh
+++ b/analysis_data_preprocess/ERA5/submit_process.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Build one ERA5 time series per array task.
+#
+#   conda activate e3sm_diags_dev_py313
+#   export ERA5_DIR=$HOME/e3sm_diags/analysis_data_preprocess/ERA5
+#   cd $SCRATCH/analysis_data_e3sm_diags/ERA5_v2/slurm   # logs land here
+#   sbatch --array=0-43%12 $ERA5_DIR/submit_process.sh
+#
+# The array index is a position in the `variables` table of era5_variables.yml,
+# so the task list has to be renumbered if that table gains or loses an entry.
+# List the current mapping with:
+#
+#   python -c "import yaml; print(*enumerate(yaml.safe_load(open('era5_variables.yml'))['variables']), sep='\n')"
+#
+# Splitting by variable rather than running the serial loop matters because the
+# eight pressure-level fields (ta, ua, va, wap, hus, hur, zg, tro3) are ~212 GB
+# of the 237 GB of raw input; back to back they dominate the wall clock, and one
+# failure part way through costs the whole run. Per-variable tasks also make
+# `--overwrite` unnecessary on a retry: `process` skips outputs already on disk.
+#
+# Unlike `submit_download.sh` this is real I/O and compute rather than waiting on
+# ECMWF, so it runs in `shared` (charged, fractional nodes) rather than `xfer`.
+# The raw files are chunked at ~8 MB, so `process` streams them through dask and
+# stays well under the memory below; the request is sized for the 3D fields,
+# which read ~23 GB and write about as much.
+
+#SBATCH --job-name=era5_process
+#SBATCH --qos=shared
+#SBATCH --constraint=cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=08:00:00
+#SBATCH --output=%x_%A_%a.log
+
+set -euo pipefail
+
+index=${SLURM_ARRAY_TASK_ID:?submit with --array=<index> or --array=<first>-<last>}
+
+# Slurm runs a copy of this script from its spool directory, so `$0` cannot
+# locate the pipeline. Submit from the ERA5 directory, or point ERA5_DIR at it.
+era5_dir="${ERA5_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
+if [[ ! -f "${era5_dir}/era5_pipeline.py" ]]; then
+    echo "era5_pipeline.py not in ${era5_dir}: submit from the ERA5 directory or set ERA5_DIR" >&2
+    exit 1
+fi
+cd "${era5_dir}"
+
+start_year=${ERA5_START_YEAR:-1979}
+end_year=${ERA5_END_YEAR:-2025}
+
+variable=$(python - "${index}" <<'PY'
+import sys
+import yaml
+
+names = list(yaml.safe_load(open("era5_variables.yml"))["variables"])
+index = int(sys.argv[1])
+if not 0 <= index < len(names):
+    sys.exit(f"array index {index} is outside 0-{len(names) - 1}")
+print(names[index])
+PY
+)
+
+echo "host=$(hostname) index=${index} variable=${variable} start=$(date -Is)"
+python -u era5_pipeline.py process \
+    --start-year "${start_year}" --end-year "${end_year}" \
+    --variables "${variable}"
+echo "done=$(date -Is)"

--- a/analysis_data_preprocess/README
+++ b/analysis_data_preprocess/README
@@ -41,4 +41,11 @@ B. Generate climo and time-series for each datasets:
    -Run create_PminusE_GPCP-OAFlux_timeseries.py to generate time series of P - E from GPCP and OAFLux
    -Run create_PminusE_GPCP-OAFlux_climo.sh to generate climatology of P - E from GPCP and OAFLux
 
+11. ERA5
+   -Run ERA5/era5_pipeline.py to retrieve monthly means from the ECMWF Climate Data
+    Store, process them into time series, and build climatology. See ERA5/README.md
+    for the workflow and ERA5/era5_variables.yml for the variable table.
+    This supersedes create_ERA5_climo.sh, create_ERA5_ext_climo.sh and
+    create_ERA5_U_climo.sh, which are kept for provenance.
+
 As of Oct 24th 2018, climos of other variables (CRU_IPCC, cloud simulators related[COSP], SSMI) used in E3SM diags are used from data distributed with NCAR's AMWG diagnostics package.We did use analysis_scripts_more_fix.py to add yrs_averaged attritute for data that with this information available.

--- a/conda-env/dev.yml
+++ b/conda-env/dev.yml
@@ -32,6 +32,11 @@ dependencies:
   - xcdat >=0.11.3,<1.0.0
   - xesmf >=0.8.7
   - xskillscore >=0.0.20
+  # Analysis Data Preprocessing
+  # =======================
+  # Used by the `analysis_data_preprocess/` scripts to retrieve ERA5 from the
+  # ECMWF Climate Data Store (CDS).
+  - cdsapi >=0.7.0
   # Testing
   # =======================
   - pytest


### PR DESCRIPTION
## Description

Adds a unified ERA5 retrieval and processing workflow under
`analysis_data_preprocess/ERA5/`, replacing the mix of obs4MIPs downloads and
ad-hoc CDS scripts that produced the current 1979-2019 reference data.

Addresses #1061.

The existing ERA5 reference data came from two unrelated paths: most variables
were taken from obs4MIPs, and the rest from `create_ERA5_ext_climo.sh` /
`create_ERA5_U_climo.sh` against the CDS. Neither records exactly what was
retrieved, so extending the record meant reconstructing the provenance by hand.
This replaces both with a single table-driven pipeline.

```bash
cd analysis_data_preprocess/ERA5
python era5_pipeline.py download --start-year 1979 --end-year 2025
python era5_pipeline.py process  --start-year 1979 --end-year 2025
python era5_pipeline.py climo    --start-year 1979 --end-year 2025
```

Every variable, its CDS name, units and conversion is declared in
`era5_variables.yml`; adding a variable or a year is a table edit rather than a
new script. All three stages are resumable — existing outputs are skipped — so
an interrupted multi-day download can simply be resubmitted.

## Retrieval design

The CDS queues each request for hours regardless of its size (measured mean
wait 68 min against a mean run time of 3.0 min, over 29 jobs), so the pipeline
groups all of a year's missing fields into one retrieval: **78 retrievals for
1979-2025 instead of ~2000**.

That makes the response format the interesting part. A bundled retrieval comes
back as a **zip split by ECMWF stream**, and the two members must not be
merged:

- **analysis** fields are instantaneous states (`t2m`, `sp`, `u`, `q`, …),
  stamped 00:00
- **forecast** fields are accumulations and mean rates (`tp`, `mtpr`,
  `msdwswrf`, …), stamped 06:00

The CDS also renames the mean-rate fields on delivery (`mtpr` → `avg_tprate`),
irregularly enough that the aliases are enumerated in the table rather than
pattern-matched. `submit_download.sh` runs the download as a Slurm array, one
year per task, on the free `xfer` QOS.

## Validation

A full 2019 rerun was compared against the existing 1979-2019 dataset:
**43 of 45 variables agree to float32 roundoff**, including the flux and
precipitation fields (≤0.007% relative difference in the global mean). The two
exceptions are documented in the README, and in both cases the new output is
not the file at fault:

- **`sp`** — the original file is displaced 16 cells east after 2013-11; it is
  bit-identical to the CMORized `ps` before that date. A bug in the original.
- **`vimd`** — deliberately dropped. The CDS field delivers `vimdf`, the
  moisture *flux* divergence; the moisture budget (`dW/dt + div Q = E - P`)
  favours the original file, and nothing in e3sm_diags reads it. Better to omit
  a field we cannot vouch for than to ship it.

Both bundle paths have since been exercised against the real CDS on full years:
the pressure-level bundle (7 fields, 4.13 GB) and the surface bundle (32 fields
delivered as a 489 MB two-member zip) each split into correct one-variable
files, with the streams kept separate and the `avg_*` aliases resolved.

## Status — draft

The 1979-2025 download is still running (Slurm array, ~1-2 days). `process` and
`climo` run afterward, and the resulting `time_series/` and `climatology/`
still need to be copied to the public LCRC/NERSC data directories. **Marking
this draft until the data is produced and published** — the code here is
otherwise ready for review.

Not included, and worth deciding separately: whether to repoint the e3sm_diags
configs at the extended record, and whether to refresh the climatology
reference period.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes

No unit tests are added: this is a standalone preprocessing script under
`analysis_data_preprocess/`, which the test suite does not cover, and its
behaviour is validated against the real CDS and the existing dataset as
described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
