### PR TITLE
Add a complete-run validation skill and fix the compare CLI

### DIFF
--- a/.claude/skills/complete-run/SKILL.md
+++ b/.claude/skills/complete-run/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: complete-run
+description: Run and interpret E3SM Diags Layer 4 complete-run validation on NERSC Perlmutter. Use when validating a high-risk change or a release against the accepted complete-run baseline, when checking for dependency regressions with a freshly solved conda environment, or when re-comparing or promoting complete-run results.
+---
+
+# Layer 4 Complete-Run Validation
+
+Runs a large cross-section of diagnostics against HPC-hosted data and compares
+the resulting netCDF files and PNG plots with the accepted `latest-main`
+baseline.
+
+**The procedure lives in `docs/source/dev_guide/testing.rst`**, sections "Layer
+4: Complete-Run Validation" and "Complete-Run Validation": environment
+construction, the sbatch submission, the Makefile targets, and the tolerances.
+Follow it there rather than reproducing it here. This file covers the judgment
+the procedure does not: which mode to run, what not to do, and how to read the
+result.
+
+This is a manual, human-in-the-loop workflow. It is expensive and it writes to
+shared space on CFS.
+
+## Guardrails
+
+1. **Never run `make promote-complete` or `baseline promote` without explicit
+   confirmation from the user in the current conversation.** Promotion
+   overwrites `latest-main`, the baseline every other developer compares
+   against. A prior "yes" for a different run does not carry over.
+2. **Never use `--allow-non-main`.** It exists for a maintainer overriding the
+   branch check by hand. Surface it, do not reach for it.
+3. **Stop and report after a failed comparison.** Show the user the summary and
+   the diff artifacts. Do not decide whether differences are acceptable, do not
+   loosen tolerances to make a comparison pass, and do not promote.
+4. **Prefer re-comparing over re-running.** The diagnostics take most of an
+   hour; the comparison takes minutes and can be repeated against the same
+   results directory as often as needed.
+
+## Pick a mode, and say which one you picked
+
+The comparison cannot tell you whether a numerical difference came from the
+code or from the dependencies. Decide which one you are holding fixed.
+
+**Mode A — code validation.** Validating a branch. Rebuild the baseline's
+environment from its `prov/environment.yml` so any difference is attributable
+to code. The default for PR validation.
+
+**Mode B — environment regression.** Checking whether current conda-forge
+breaks the plots. Clean `main` checkout, fresh solve from `conda-env/dev.yml`.
+`dev.yml` carries floating constraints that only a fresh solve exercises. The
+pre-release gate, not a per-PR step.
+
+Mode B assumes the code matches the baseline's. `main` moves, so confirm that
+before trusting the attribution:
+
+```bash
+python -m tests.complete_run.baseline show --channel main   # note the manifest sha
+git diff --stat <baseline-sha>..HEAD -- e3sm_diags/
+```
+
+An empty diff means the shipped package is identical and differences really are
+dependencies. A non-empty one means you are running Mode A whether you meant to
+or not; say so.
+
+## Preflight
+
+```bash
+git status --porcelain -uno          # expect clean
+git rev-parse --abbrev-ref HEAD      # Mode B requires main
+python -m tests.complete_run.baseline show --channel main
+```
+
+`baseline show` prints the resolved baseline directory and its manifest. The
+manifest's `environment` block records the python version, platform, and
+curated package versions the baseline was produced with; that is what your run
+will be diffed against. If it reports a missing or broken link, nothing has
+been promoted yet — stop and tell the user the comparison has nothing to run
+against.
+
+`run.py` validates input paths before starting, so a bad path fails in seconds
+rather than an hour into the run.
+
+## Read the report
+
+At `<results-parent>/comparison/<dev>-vs-<baseline>/comparison-report.json`, in
+this order:
+
+1. **`environment`** — first, before anything else. In Mode B this section *is*
+   the result. In Mode A it should be empty; if it is not, the environment did
+   not reproduce the baseline's and numerical differences are not attributable
+   to code. `conda_environment` always differs when the run used a fresh
+   environment, and that difference alone is not a finding.
+2. **`status`** and **`summary.failure_count`** — the verdict.
+3. **The per-category lists** — `missing_dev_files`, `missing_baseline_files`,
+   `missing_variables`, `nan_location_mismatches`, `shape_mismatches`,
+   `tolerance_failures`, `missing_dev_images`, `missing_baseline_images`,
+   `image_mismatches`.
+4. **`paths.diff_artifact_dir`** — the rendered PNG diffs.
+
+**Then stop.** Summarize the failure categories, counts, and the most
+significant diff artifacts, and let the user judge. Do not characterize
+differences as expected or acceptable on your own.
+
+## Handling a failure
+
+A failed comparison leaves the candidate results and artifacts in place. Re-run
+the comparison, not the diagnostics — see `testing.rst` for the targets.
+
+Varying tolerances is a review aid, not a way to pass. Do it only at the user's
+request, and when reporting a comparison that passed at a loosened tolerance,
+say that is what happened.
+
+**If the job hit the walltime**, the results directory has no
+`baseline_manifest.json` — it is written after the diagnostics complete, so its
+absence means the run was cut short. Such a directory can still be compared,
+but its environment provenance degrades to "unavailable" and it can never be
+promoted. Report it and offer to remove it rather than comparing partial
+output; a rerun goes to a new timestamped directory regardless.
+
+## Promotion — only on explicit confirmation
+
+Preconditions: the changes are reviewed, approved, and merged to `main`; the
+run came from a `main` checkout; and **the user has just told you, in this
+conversation, to promote.**
+
+If the run is not on `main` the promotion is refused. That refusal is correct.
+Report it and stop.
+
+## Judgment calls the CLI will not make for you
+
+- **A `--set` subset is not a validation.** Comparing a subset run against a
+  full baseline reports every unrun set as missing files. Useful for iterating
+  on one diagnostic, useless as a gate.
+- **`--results-dir` is used verbatim**, skipping the timestamp-branch-commit
+  suffix that the default path in `params.py` gets. A second run into the same
+  path fails on the immutable-manifest guard. Pass a path not used before.
+- **Do not edit `params.py` to change a run.** Those defaults are the shared
+  contract that makes results comparable. Use the `run.py` CLI flags;
+  `python -m tests.complete_run.run --help` lists them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,23 @@ a corresponding parameter class in `parameter/`.
 - **Framework:** pytest with pytest-cov
 - **Unit tests:** `tests/e3sm_diags/` (run by default)
 - **Integration tests:** `tests/integration/` (run manually)
+- **Complete-run validation:** `tests/complete_run/` (Layer 4, run manually on NERSC)
 - Run unit tests: `pytest` (from repo root)
 - Do not modify or remove existing tests unless directly related to your change
+
+### Complete-Run Validation
+
+Layer 4 is expensive and writes to shared space on CFS. Before driving it, read
+`.claude/skills/complete-run/SKILL.md` for the full procedure, and
+`docs/source/dev_guide/testing.rst` for the canonical reference. Three rules
+apply to any agent running it:
+
+- Never run `make promote-complete` without explicit confirmation in the
+  current conversation. Promotion overwrites the `latest-main` baseline that
+  every other developer compares against.
+- Never pass `--allow-non-main`. Surface the refusal instead of overriding it.
+- Stop and report after a failed comparison. Do not judge whether differences
+  are acceptable, and do not loosen tolerances to make a comparison pass.
 
 ## Pre-commit Hooks
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test-complete-validate: ## run and compare a complete-run candidate with the acc
 
 test-complete-compare: ## compare complete-run NetCDF and PNG outputs to the accepted baseline; usage: make test-complete-compare RUN_DIR=/path/to/results [BASELINE_DIR=/path/to/baseline]
 	@test -n "$(RUN_DIR)" || { echo "Please specify RUN_DIR=/path/to/results" >&2; exit 2; }
-	python -m tests.complete_run.compare --dev-dir "$(RUN_DIR)" $(if $(BASELINE_DIR),--baseline-dir "$(BASELINE_DIR)") --write-diff-pngs
+	python -m tests.complete_run.compare --dev-dir "$(RUN_DIR)" $(if $(BASELINE_DIR),--baseline-dir "$(BASELINE_DIR)") --write-diff-pngs --write-diff-html
 
 promote-complete: ## promote reviewed results; usage: make promote-complete RUN_DIR=/path/to/results
 	@test -n "$(RUN_DIR)" || { echo "Please specify RUN_DIR=/path/to/results" >&2; exit 2; }

--- a/docs/source/dev_guide/testing.rst
+++ b/docs/source/dev_guide/testing.rst
@@ -157,16 +157,93 @@ See `Complete-Run Validation`_ for instructions.
 Complete-Run Validation
 -----------------------
 
+Choosing an Environment
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A comparison cannot attribute a numerical difference to code or to
+dependencies, so decide which of the two is held fixed before running.
+
+Build the environment on a login node, before requesting an allocation. The
+solve is network-bound with no compute, so doing it inside an allocation wastes
+node hours:
+
+.. code-block:: bash
+
+   STAMP=$(date -u +%Y%m%d)-$(git rev-parse --short HEAD)
+   ENV_PREFIX=$SCRATCH/e3sm_diags_complete_run_$STAMP
+
+**Code validation.** Reproduce the baseline's environment, so any difference is
+attributable to the code under review. This is the default for validating a
+branch. Every result directory keeps a full ``conda env export`` at
+``prov/environment.yml``, so the baseline's environment is reconstructible:
+
+.. code-block:: bash
+
+   mamba env create -f <baseline-dir>/prov/environment.yml -p "$ENV_PREFIX"
+
+**Environment regression.** Solve a fresh environment from ``conda-env/dev.yml``
+and run from a clean ``main`` checkout, so the code matches the baseline and any
+difference is attributable to dependencies. ``dev.yml`` carries floating
+constraints that only a fresh solve exercises, which makes this the pre-release
+gate rather than a per-PR step:
+
+.. code-block:: bash
+
+   mamba env create -f conda-env/dev.yml -p "$ENV_PREFIX"
+
+Either way, install the package itself afterward. ``dev.yml`` and the exported
+``environment.yml`` both install dependencies only:
+
+.. code-block:: bash
+
+   conda activate "$ENV_PREFIX"
+   pip install -e .
+
+Placing the prefix in ``$SCRATCH`` is intended. ``$SCRATCH`` is purged on
+NERSC's schedule, and the durable record of the environment is
+``prov/environment.yml`` and the manifest inside the immutable results
+directory on CFS.
+
 Running Complete Validation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run Layer 4 on a NERSC compute node after activating the E3SM Diags Conda
-environment:
+Run Layer 4 on a NERSC compute node. Submitting a batch job avoids holding an
+interactive session open for the length of the run:
+
+.. code-block:: bash
+
+   cat > "$SCRATCH/complete_run_$STAMP.sbatch" <<EOF
+   #!/bin/bash
+   #SBATCH --account=e3sm
+   #SBATCH --qos=regular
+   #SBATCH --constraint=cpu
+   #SBATCH --nodes=1
+   #SBATCH --time=01:00:00
+   #SBATCH --output=$SCRATCH/complete_run_$STAMP.log
+
+   set -euo pipefail
+   source \$(conda info --base)/etc/profile.d/conda.sh
+   conda activate $ENV_PREFIX
+   cd $(pwd)
+   make test-complete-validate
+   EOF
+
+   sbatch "$SCRATCH/complete_run_$STAMP.sbatch"
+
+A batch shell is not a login shell, so ``conda activate`` requires sourcing
+``conda.sh`` first. The ``cd`` into the repository is also required:
+``tests.complete_run.run`` resolves both the ``tests`` package and
+``e3sm_diags`` from the current directory, so running from elsewhere silently
+tests the installed ``e3sm_diags`` instead of the working tree. Request a whole
+node rather than ``--qos shared``; the diagnostics default to 24 workers and
+``enso_diags`` has a history of per-worker memory spikes.
+
+An interactive allocation works equally well for a run being watched:
 
 .. code-block:: bash
 
    salloc --nodes 1 --qos interactive --time 04:00:00 --constraint cpu --account=e3sm
-   conda activate <e3sm_diags_env>
+   conda activate "$ENV_PREFIX"
    make test-complete-validate
 
 By default, results are saved beneath:
@@ -179,6 +256,13 @@ Each run receives an immutable timestamped directory containing the branch and
 commit suffix. The workflow runs the diagnostics, compares the results with the
 accepted ``latest-main`` baseline, and writes a JSON report and PNG diff
 artifacts.
+
+The comparison report's ``environment`` section records the curated package and
+platform differences between the run and its baseline. Read it before the
+per-category results: in an environment-regression run it is the result, and in
+a code-validation run it should be empty, since a non-empty section means the
+environment did not reproduce the baseline's and the numerical differences are
+not attributable to code.
 
 Repeating the Comparison
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -203,6 +287,13 @@ To use a specific baseline, set ``BASELINE_DIR``:
 
 Comparison reports and PNG artifacts are written beneath the ``comparison/``
 directory beside the complete-run result directories.
+
+netCDF values are compared with a relative tolerance of ``1e-5`` and an
+absolute tolerance of ``0.0``; absolute tolerance is deliberately unused
+because it is oversensitive on difference fields. Override either with
+``--rtol`` and ``--atol`` on ``tests.complete_run.compare``. Loosening a
+tolerance is a review aid rather than a way to reach a passing comparison, so
+report any comparison that passed only at a widened tolerance as such.
 
 Promoting an Approved Baseline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/dev_guide/testing.rst
+++ b/docs/source/dev_guide/testing.rst
@@ -197,7 +197,7 @@ Either way, install the package itself afterward. ``dev.yml`` and the exported
 .. code-block:: bash
 
    conda activate "$ENV_PREFIX"
-   pip install -e .
+   pip install .
 
 Placing the prefix in ``$SCRATCH`` is intended. ``$SCRATCH`` is purged on
 NERSC's schedule, and the durable record of the environment is

--- a/docs/source/dev_guide/testing.rst
+++ b/docs/source/dev_guide/testing.rst
@@ -288,6 +288,10 @@ To use a specific baseline, set ``BASELINE_DIR``:
 Comparison reports and PNG artifacts are written beneath the ``comparison/``
 directory beside the complete-run result directories.
 
+``--write-diff-html`` writes an ``index.html`` beside the report listing every
+image mismatch, sorted by mismatch fraction and filterable by set, with each
+plot beside its baseline and diff. It implies ``--write-diff-pngs``.
+
 netCDF values are compared with a relative tolerance of ``1e-5`` and an
 absolute tolerance of ``0.0``; absolute tolerance is deliberately unused
 because it is oversensitive on difference fields. Override either with

--- a/docs/source/dev_guide/testing.rst
+++ b/docs/source/dev_guide/testing.rst
@@ -221,7 +221,7 @@ interactive session open for the length of the run:
    #SBATCH --time=01:00:00
    #SBATCH --output=$SCRATCH/complete_run_$STAMP.log
 
-   set -euo pipefail
+   set -eo pipefail
    source \$(conda info --base)/etc/profile.d/conda.sh
    conda activate $ENV_PREFIX
    cd $(pwd)

--- a/tests/complete_run/compare.py
+++ b/tests/complete_run/compare.py
@@ -61,7 +61,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = _build_parser()
     args = parser.parse_args(argv)
-    compare_files, compare_values, compare_images = _normalize_modes(args.mode)
+    modes = args.mode or ["all"]
+    compare_files, compare_values, compare_images = _normalize_modes(modes)
 
     if not compare_files and not compare_values and not compare_images:
         raise ValueError("At least one compare mode must be selected.")
@@ -104,7 +105,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         dev_dir=args.dev_dir, baseline_dir=args.baseline_dir, summary=summary
     )
 
-    show = set(args.show or [])
+    show = set(args.show or ["all"])
     if "all" in show or "missing-files" in show:
         _render_issue_details("Missing dev files", summary.missing_dev_files)
         _render_issue_details("Missing baseline files", summary.missing_baseline_files)
@@ -133,7 +134,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         atol=args.atol,
         rtol=args.rtol,
         image_mismatch_threshold=args.image_mismatch_threshold,
-        modes=args.mode,
+        modes=modes,
         diff_artifact_dir=diff_artifact_dir,
         environment_comparison=environment_comparison,
         summary=summary,
@@ -183,7 +184,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--mode",
         action="append",
-        default=["all"],
         choices=["all", "files", "data", "images"],
         help=(
             "Comparison mode. Use files for netCDF tree matching, data for shared "
@@ -203,7 +203,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--show",
         action="append",
-        default=["all"],
         choices=[
             "all",
             "missing-files",
@@ -359,18 +358,30 @@ def _environment_provenance_path(run_dir: str | Path) -> Path:
     return Path(run_dir).resolve() / "prov" / "environment.yml"
 
 
+def _strip_environment_identity_lines(lines: list[str]) -> list[str]:
+    """Drop the environment name and prefix, which differ per run by design.
+
+    Each complete run may be executed in its own freshly created environment, so
+    ``name:`` and ``prefix:`` always differ and would otherwise mask the
+    dependency changes the comparison exists to surface.
+    """
+    return [
+        line
+        for line in lines
+        if not line.startswith("name:") and not line.startswith("prefix:")
+    ]
+
+
 def _diff_environment_files(baseline_path: Path, dev_path: Path) -> dict[str, object]:
-    """Return structured environment.yml changes with the top-level name omitted."""
+    """Return structured environment.yml changes with run identity omitted."""
     try:
         baseline_lines = baseline_path.read_text(encoding="utf-8").splitlines()
         dev_lines = dev_path.read_text(encoding="utf-8").splitlines()
     except OSError as error:
         return {"available": False, "detail": str(error), "changes": []}
 
-    baseline_without_name = [
-        line for line in baseline_lines if not line.startswith("name:")
-    ]
-    dev_without_name = [line for line in dev_lines if not line.startswith("name:")]
+    baseline_without_name = _strip_environment_identity_lines(baseline_lines)
+    dev_without_name = _strip_environment_identity_lines(dev_lines)
     matcher = difflib.SequenceMatcher(
         a=baseline_without_name, b=dev_without_name, autojunk=False
     )
@@ -407,10 +418,8 @@ def _format_environment_file_diff(
 
     baseline_lines = baseline_path.read_text(encoding="utf-8").splitlines()
     dev_lines = dev_path.read_text(encoding="utf-8").splitlines()
-    baseline_without_name = [
-        line for line in baseline_lines if not line.startswith("name:")
-    ]
-    dev_without_name = [line for line in dev_lines if not line.startswith("name:")]
+    baseline_without_name = _strip_environment_identity_lines(baseline_lines)
+    dev_without_name = _strip_environment_identity_lines(dev_lines)
     diff = difflib.unified_diff(
         baseline_without_name,
         dev_without_name,

--- a/tests/complete_run/compare.py
+++ b/tests/complete_run/compare.py
@@ -30,6 +30,7 @@ from typing import Sequence
 
 from e3sm_diags.logger import _setup_child_logger, _setup_root_logger
 from tests.complete_run.baseline import _load_manifest, _ManifestError
+from tests.complete_run.diff_html import write_diff_html
 from tests.complete_run.helpers import (
     ComparisonIssue,
     ComparisonSummary,
@@ -76,7 +77,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
 
     diff_artifact_dir = None
-    if args.write_diff_pngs:
+    if args.write_diff_pngs or args.write_diff_html:
+        # The HTML index links to the diff artifacts, so it implies them.
         diff_artifact_dir = args.diff_artifact_dir or str(
             report_path.parent / "diff-pngs"
         )
@@ -127,7 +129,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         _render_issue_details("Image mismatches", summary.image_mismatches)
 
     exit_code = 0 if summary.failure_count == 0 else 1
-    _write_comparison_report(
+    report = _write_comparison_report(
         report_path=report_path,
         dev_dir=args.dev_dir,
         baseline_dir=args.baseline_dir,
@@ -141,6 +143,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         exit_code=exit_code,
     )
     logger.info("Wrote comparison report: %s", report_path)
+
+    if args.write_diff_html:
+        html_path = write_diff_html(report, report_path)
+        if html_path is None:
+            logger.info("No image mismatches to review; skipped the HTML index.")
+        else:
+            logger.info("Wrote image diff index: %s", html_path)
 
     return exit_code
 
@@ -219,6 +228,15 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Write PNG diff artifacts for mismatched shared files (default: False).",
+    )
+    parser.add_argument(
+        "--write-diff-html",
+        action="store_true",
+        default=False,
+        help=(
+            "Write an HTML index of image differences beside the JSON report, "
+            "sorted by mismatch fraction (default: False)."
+        ),
     )
     parser.add_argument(
         "--diff-artifact-dir",
@@ -458,8 +476,8 @@ def _write_comparison_report(
     environment_comparison: dict[str, object],
     summary: ComparisonSummary,
     exit_code: int,
-) -> None:
-    """Write a JSON record of a complete-run comparison."""
+) -> dict:
+    """Write a JSON record of a complete-run comparison and return it."""
     report = {
         "schema_version": 1,
         "created_at_utc": datetime.now(timezone.utc).isoformat(),
@@ -502,6 +520,8 @@ def _write_comparison_report(
     }
     report_path.parent.mkdir(parents=True, exist_ok=True)
     report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    return report
 
 
 def _issues_to_report(issues: Sequence[ComparisonIssue]) -> list[dict[str, str | None]]:

--- a/tests/complete_run/diff_html.py
+++ b/tests/complete_run/diff_html.py
@@ -1,0 +1,237 @@
+"""Render a browsable HTML index of complete-run image differences.
+
+The page is self-contained and written beside the JSON report. It does not use
+``output_viewer``, which renders a fixed table with no severity ordering,
+filtering, or incremental loading.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+from pathlib import Path
+
+_FRACTION = re.compile(r"fraction: ([0-9.eE+-]+)")
+
+_STYLE = """
+:root{--bg:#f7f7f8;--panel:#fff;--ink:#1b1b1f;--muted:#5f6169;--line:#e2e3e8;
+--accent:#8b2f2f;--ok:#1f7a4d;--chip:#eef0f4}
+@media (prefers-color-scheme:dark){:root{--bg:#15161a;--panel:#1d1f24;--ink:#e9e9ee;
+--muted:#a0a3ad;--line:#2c2f36;--accent:#e08a8a;--ok:#6fd39b;--chip:#262931}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+header{padding:24px 28px 18px;border-bottom:1px solid var(--line);background:var(--panel)}
+h1{margin:0 0 4px;font-size:20px;letter-spacing:-.01em}
+.sub{color:var(--muted);font-size:13px}
+.stats{display:flex;gap:28px;flex-wrap:wrap;margin:16px 0 4px}
+.stat b{display:block;font-size:22px;font-variant-numeric:tabular-nums}
+.stat span{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+.stat.ok b{color:var(--ok)}.stat.warn b{color:var(--accent)}
+details.envbox{margin-top:14px;font-size:13px}
+details.envbox ul{margin:8px 0 0 18px;padding:0}
+.controls{position:sticky;top:0;z-index:5;background:var(--panel);
+border-bottom:1px solid var(--line);padding:12px 28px;display:flex;gap:10px;
+flex-wrap:wrap;align-items:center}
+input[type=search]{padding:7px 10px;border:1px solid var(--line);border-radius:7px;
+background:var(--bg);color:var(--ink);min-width:230px;font-size:13px}
+.chip{border:1px solid var(--line);background:var(--chip);color:var(--ink);
+border-radius:999px;padding:5px 11px;font-size:12px;cursor:pointer}
+.chip[aria-pressed=true]{background:var(--ink);color:var(--panel);border-color:var(--ink)}
+main{padding:20px 28px 60px}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:10px;
+margin-bottom:14px;overflow:hidden}
+.head{padding:10px 14px;display:flex;gap:14px;align-items:center;
+border-bottom:1px solid var(--line)}
+.frac{font-variant-numeric:tabular-nums;font-weight:650;color:var(--accent);min-width:74px}
+.name{flex:1;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12.5px;
+word-break:break-all}
+.tag{background:var(--chip);border-radius:5px;padding:2px 7px;font-size:11px;
+color:var(--muted);white-space:nowrap}
+.trip{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;padding:12px 14px}
+@media (max-width:900px){.trip{grid-template-columns:1fr}}
+figure{margin:0}
+figcaption{font-size:11px;color:var(--muted);text-transform:uppercase;
+letter-spacing:.05em;margin-bottom:5px}
+.trip a{display:block}
+.trip img{width:100%;height:300px;object-fit:contain;border:1px solid var(--line);
+border-radius:6px;background:#fff;display:block}
+body.fit .trip img{height:auto}
+.empty{color:var(--muted);padding:30px 0}
+section.extra{margin-top:34px}
+section.extra h2{font-size:15px;margin:0 0 6px}
+section.extra p{color:var(--muted);margin:0 0 10px}
+section.extra ul{columns:2;font-family:ui-monospace,monospace;font-size:12px;color:var(--muted)}
+@media (max-width:900px){section.extra ul{columns:1}}
+#sentinel{height:1px}
+"""
+
+_SCRIPT = """
+const list=document.getElementById('list'),empty=document.getElementById('empty'),
+shown=document.getElementById('shown'),sentinel=document.getElementById('sentinel');
+const PAGE=25;let activeSet='*',query='',items=[],drawn=0;
+function card(r){return `<div class="card"><div class="head">
+<span class="frac">${(r.frac*100).toFixed(2)}%</span>
+<span class="name">${r.path}</span><span class="tag">${r.set}</span></div>
+<div class="trip">
+<figure><figcaption>Baseline</figcaption><a href="${r.expected}" target="_blank" rel="noopener">
+<img loading="lazy" src="${r.expected}" alt="baseline"></a></figure>
+<figure><figcaption>This run</figcaption><a href="${r.actual}" target="_blank" rel="noopener">
+<img loading="lazy" src="${r.actual}" alt="this run"></a></figure>
+<figure><figcaption>Diff</figcaption><a href="${r.diff}" target="_blank" rel="noopener">
+<img loading="lazy" src="${r.diff}" alt="diff"></a></figure></div></div>`;}
+function more(){if(drawn>=items.length)return;
+const next=items.slice(drawn,drawn+PAGE);
+list.insertAdjacentHTML('beforeend',next.map(card).join(''));drawn+=next.length;
+shown.textContent=`${drawn} of ${items.length} shown`;}
+function render(){items=ROWS.filter(r=>(activeSet==='*'||r.set===activeSet)&&
+(query===''||r.path.toLowerCase().includes(query)));
+list.innerHTML='';drawn=0;empty.hidden=items.length>0;more();}
+new IntersectionObserver(e=>{if(e[0].isIntersecting)more();},
+{rootMargin:'900px'}).observe(sentinel);
+document.getElementById('q').addEventListener('input',e=>{
+query=e.target.value.trim().toLowerCase();render();});
+document.querySelectorAll('.chip[data-set]').forEach(b=>b.addEventListener('click',()=>{
+document.querySelectorAll('.chip[data-set]').forEach(o=>o.setAttribute('aria-pressed','false'));
+b.setAttribute('aria-pressed','true');activeSet=b.dataset.set;render();window.scrollTo(0,0);}));
+document.getElementById('size').addEventListener('click',e=>{
+const on=document.body.classList.toggle('fit');
+e.target.setAttribute('aria-pressed',String(on));
+e.target.textContent=on?'shorter':'taller';});
+render();
+"""
+
+
+def _mismatch_fraction(detail: str) -> float:
+    """Return the mismatched-pixel fraction recorded in an issue detail."""
+    match = _FRACTION.search(detail or "")
+
+    return float(match.group(1)) if match else 0.0
+
+
+def _build_rows(report: dict, root: Path) -> list[dict[str, object]]:
+    """Return image-mismatch rows sorted with the largest difference first."""
+    entries = sorted(
+        (e for e in report["summary"]["image_mismatches"] if e.get("artifact_path")),
+        key=lambda e: _mismatch_fraction(e.get("detail", "")),
+        reverse=True,
+    )
+    rows: list[dict[str, object]] = []
+    for entry in entries:
+        diff = os.path.relpath(entry["artifact_path"], root)
+        rows.append(
+            {
+                "path": entry["relative_path"],
+                "set": entry["relative_path"].split("/")[0],
+                "frac": _mismatch_fraction(entry.get("detail", "")),
+                "diff": diff,
+                "actual": diff.replace("_diff.png", "_actual.png"),
+                "expected": diff.replace("_diff.png", "_expected.png"),
+            }
+        )
+
+    return rows
+
+
+def write_diff_html(report: dict, report_path: str | Path) -> Path | None:
+    """Write an HTML index of image differences beside the JSON report.
+
+    Parameters
+    ----------
+    report : dict
+        The comparison report, as written to ``comparison-report.json``.
+    report_path : str | Path
+        Path of that JSON report; the page is written to its directory.
+
+    Returns
+    -------
+    Path | None
+        Path of the written page, or ``None`` when there are no image
+        mismatches with diff artifacts to link.
+    """
+    root = Path(report_path).parent
+    rows = _build_rows(report, root)
+    if not rows:
+        return None
+
+    summary = report["summary"]
+    sets = sorted({str(row["set"]) for row in rows})
+    counts = {name: sum(1 for row in rows if row["set"] == name) for name in sets}
+    environment = report.get("environment") or {}
+    differences = environment.get("differences") or []
+    missing_files = summary.get("missing_baseline_files", [])
+    missing_images = summary.get("missing_baseline_images", [])
+    extra_sets = sorted({path.split("/")[0] for path in missing_files + missing_images})
+
+    chips = "".join(
+        f'<button class="chip" data-set="{html.escape(name)}" aria-pressed="false">'
+        f"{html.escape(name)} ({counts[name]})</button>"
+        for name in sets
+    )
+    env_items = (
+        "".join(f"<li><code>{html.escape(str(d))}</code></li>" for d in differences)
+        or "<li>none</li>"
+    )
+    extra_items = "".join(
+        f"<li>{html.escape(path)}</li>" for path in sorted(missing_images)
+    )
+
+    page = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Complete-run image diffs</title>
+<style>{_STYLE}</style>
+</head>
+<body>
+<header>
+  <h1>Complete-run image diffs</h1>
+  <div class="sub"><code>{html.escape(Path(report["paths"]["dev_dir"]).name)}</code>
+    vs baseline <code>{html.escape(Path(report["paths"]["baseline_dir"]).name)}</code></div>
+  <div class="stats">
+    <div class="stat ok"><b>{len(summary["matching_files"])} / {summary["compared_file_count"]}</b>
+      <span>netCDF files match</span></div>
+    <div class="stat warn"><b>{len(rows)}</b><span>image mismatches</span></div>
+    <div class="stat"><b>{len(summary["matching_images"])}</b><span>images matched</span></div>
+    <div class="stat"><b>{summary["failure_count"]}</b><span>total findings</span></div>
+  </div>
+  <details class="envbox">
+    <summary>Environment differences vs baseline</summary>
+    <ul>{env_items}</ul>
+  </details>
+</header>
+<div class="controls">
+  <input type="search" id="q" placeholder="Filter by filename&hellip;" aria-label="Filter by filename">
+  <button class="chip" data-set="*" aria-pressed="true">all ({len(rows)})</button>
+  {chips}
+  <button class="chip" id="size" aria-pressed="false">taller</button>
+  <span class="tag" id="shown"></span>
+</div>
+<main>
+  <div id="list"></div>
+  <div id="sentinel"></div>
+  <div class="empty" id="empty" hidden>Nothing matches that filter.</div>
+  <section class="extra">
+    <h2>Present in this run, absent from the baseline</h2>
+    <p>{len(missing_files)} files and {len(missing_images)} images, under
+      <code>{html.escape(", ".join(extra_sets)) or "&mdash;"}</code>. These have no diff
+      images, since the baseline has nothing to compare against.</p>
+    <ul>{extra_items}</ul>
+  </section>
+</main>
+<script>
+const ROWS = {json.dumps(rows)};
+{_SCRIPT}
+</script>
+</body>
+</html>
+"""
+
+    output_path = root / "index.html"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(page, encoding="utf-8")
+
+    return output_path

--- a/tests/complete_run/validate.py
+++ b/tests/complete_run/validate.py
@@ -120,6 +120,7 @@ def _build_compare_argv(args: argparse.Namespace) -> list[str]:
         "--image-mismatch-threshold",
         str(args.image_mismatch_threshold),
         "--write-diff-pngs",
+        "--write-diff-html",
     ]
     for mode in args.mode or ["all"]:
         compare_argv.extend(["--mode", mode])

--- a/tests/e3sm_diags/test_complete_run_compare.py
+++ b/tests/e3sm_diags/test_complete_run_compare.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
 import xarray as xr
 from PIL import Image
 
-from tests.complete_run import baseline, compare
+from tests.complete_run import baseline, compare, diff_html
 from tests.complete_run.helpers import ComparisonSummary
 from tests.complete_run.params import DEFAULT_RESULTS_DIR
 
@@ -238,3 +239,87 @@ def test_images_mode_fails_and_reports_png_mismatches(tmp_path: Path):
         / "lat_lon"
         / "plot_diff.png"
     ).exists()
+
+
+class TestDiffHtml:
+    def _report(self, tmp_path: Path, mismatches: list[dict]) -> dict:
+        return {
+            "paths": {
+                "dev_dir": str(tmp_path / "dev"),
+                "baseline_dir": str(tmp_path / "baseline"),
+            },
+            "environment": {"differences": ["matplotlib (3.10.9 -> 3.11.1)"]},
+            "summary": {
+                "matching_files": ["a.nc"],
+                "matching_images": [],
+                "compared_file_count": 1,
+                "failure_count": len(mismatches),
+                "image_mismatches": mismatches,
+                "missing_baseline_files": [],
+                "missing_baseline_images": [],
+            },
+        }
+
+    def test_returns_none_without_image_mismatches(self, tmp_path: Path):
+        report_path = tmp_path / "comparison-report.json"
+
+        assert (
+            diff_html.write_diff_html(self._report(tmp_path, []), report_path) is None
+        )
+        assert not (tmp_path / "index.html").exists()
+
+    def test_sorts_by_mismatch_fraction_and_links_the_triptych(self, tmp_path: Path):
+        diffs = tmp_path / "diff-pngs"
+        diffs.mkdir()
+        mismatches = [
+            {
+                "relative_path": "polar/small.png",
+                "detail": "Mismatched pixel fraction: 0.001 (threshold: 0.0002).",
+                "artifact_path": str(diffs / "small_diff.png"),
+            },
+            {
+                "relative_path": "lat_lon/big.png",
+                "detail": "Mismatched pixel fraction: 0.05 (threshold: 0.0002).",
+                "artifact_path": str(diffs / "big_diff.png"),
+            },
+        ]
+        report_path = tmp_path / "comparison-report.json"
+
+        out = diff_html.write_diff_html(self._report(tmp_path, mismatches), report_path)
+
+        assert out == tmp_path / "index.html"
+        page = out.read_text(encoding="utf-8")
+        match = re.search(r"const ROWS = (\[.*?\]);", page, re.S)
+        assert match is not None
+        rows = json.loads(match.group(1))
+        assert [row["path"] for row in rows] == ["lat_lon/big.png", "polar/small.png"]
+        assert rows[0]["set"] == "lat_lon"
+        # Paths are relative to the report, and the baseline/current panels are
+        # derived from the diff artifact's name.
+        assert rows[0]["diff"] == "diff-pngs/big_diff.png"
+        assert rows[0]["expected"] == "diff-pngs/big_expected.png"
+        assert rows[0]["actual"] == "diff-pngs/big_actual.png"
+
+    def test_html_flag_implies_diff_artifacts(self, tmp_path: Path):
+        """The index links to diff PNGs, so requesting it must produce them."""
+        dev_dir = tmp_path / "dev"
+        baseline_dir = tmp_path / "baseline"
+        (dev_dir / "lat_lon").mkdir(parents=True)
+        (baseline_dir / "lat_lon").mkdir(parents=True)
+        Image.new("RGB", (10, 10), "white").save(dev_dir / "lat_lon" / "plot.png")
+        Image.new("RGB", (10, 10), "black").save(baseline_dir / "lat_lon" / "plot.png")
+
+        result = compare.main(
+            [
+                "--dev-dir",
+                str(dev_dir),
+                "--baseline-dir",
+                str(baseline_dir),
+                "--write-diff-html",
+            ]
+        )
+
+        assert result == 1
+        index = tmp_path / "comparison" / "dev-vs-baseline" / "index.html"
+        assert index.exists()
+        assert "lat_lon/plot.png" in index.read_text(encoding="utf-8")

--- a/tests/e3sm_diags/test_complete_run_compare.py
+++ b/tests/e3sm_diags/test_complete_run_compare.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+import xarray as xr
 from PIL import Image
 
 from tests.complete_run import baseline, compare
@@ -172,6 +173,34 @@ def test_main_returns_comparison_status(
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["exit_code"] == expected_exit_code
     assert report["summary"]["failure_count"] == summary.failure_count
+
+
+def test_images_mode_skips_netcdf_checks(tmp_path: Path):
+    """``--mode images`` must narrow the comparison, not add to the default."""
+    dev_dir = tmp_path / "dev"
+    baseline_dir = tmp_path / "baseline"
+    (dev_dir / "lat_lon").mkdir(parents=True)
+    (baseline_dir / "lat_lon").mkdir(parents=True)
+    Image.new("RGB", (10, 10), "white").save(dev_dir / "lat_lon" / "plot.png")
+    Image.new("RGB", (10, 10), "white").save(baseline_dir / "lat_lon" / "plot.png")
+    xr.Dataset({"ts": ("x", [1.0])}).to_netcdf(baseline_dir / "lat_lon" / "ts.nc")
+
+    result = compare.main(
+        [
+            "--dev-dir",
+            str(dev_dir),
+            "--baseline-dir",
+            str(baseline_dir),
+            "--mode",
+            "images",
+        ]
+    )
+
+    assert result == 0
+    report_path = tmp_path / "comparison" / "dev-vs-baseline" / "comparison-report.json"
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["comparison_settings"]["modes"] == ["images"]
+    assert report["summary"]["missing_dev_files"] == []
 
 
 def test_images_mode_fails_and_reports_png_mismatches(tmp_path: Path):

--- a/tests/e3sm_diags/test_complete_run_validate.py
+++ b/tests/e3sm_diags/test_complete_run_validate.py
@@ -66,6 +66,7 @@ def test_validate_runs_candidate_then_compares_with_forwarded_options(
             "--image-mismatch-threshold",
             "0.75",
             "--write-diff-pngs",
+            "--write-diff-html",
             "--mode",
             "images",
             "--show",


### PR DESCRIPTION
## Description

Adds `.claude/skills/complete-run/SKILL.md`, an agent skill for the Layer 4
complete-run validation added in #903. It carries the guardrails (never promote
without confirmation, never `--allow-non-main`, stop and report on a failed
comparison) and the code-vs-dependency mode decision, and points at
`testing.rst` for the commands rather than duplicating them.

The skill lives in the repo rather than in a personal `~/.claude/skills/`
because its content describes `tests/complete_run/*.py` and must be reviewed
alongside changes to it.

### Using it

Ask for the validation in plain language:

> run a complete-run validation on main

The agent chooses a mode, runs the preflight, builds the environment on the
login node, submits the job, and reads the report back to you. Then it stops.
Deciding whether a difference is acceptable is a judgment about climate output,
so the guardrails hand that back rather than take it, and moving `latest-main`
needs you to ask for it in that conversation:

> promote the complete-run result &lt;results-dir-name&gt; to latest-main

Claude Code finds the skill in the checkout with no setup, and it can also be
called by name as `/complete-run`. Other agents pick up the guardrails from
`AGENTS.md`, which carries them inline and points here for the rest.

None of it is required. Every command is in `testing.rst` and works by hand;
what the skill adds is the part that is not in the code — which mode a run
needs, how to read the report, and what not to do.

### HTML index of image differences

A comparison can report several hundred image mismatches, which the JSON report
records but cannot present for review. `--write-diff-html` writes an
`index.html` beside that report, sorted by mismatch fraction and filterable by
set, showing each plot beside its baseline and its diff. It implies
`--write-diff-pngs`, which it links to, and both `make test-complete-validate`
and `make test-complete-compare` pass it.

Because results live under `/global/cfs/cdirs/e3sm/www`, the page is served at
the matching `portal.nersc.gov/cfs/e3sm` URL and can be shared for review
without copying anything.

### Fixes

Found while using the workflow on a real run:

- `environment.yml` diffs stripped `name:` but not the `prefix:` line
  `conda env export` emits, so every comparison run in a fresh environment
  reported a spurious difference.
- `--mode` and `--show` used `action="append"` with `default=["all"]`. Argparse
  appends to a default rather than replacing it, so `--mode images` became
  `["all", "images"]` and still ran every check. Resolved at the use site now,
  matching `validate.py`.
- The documented environment setup used `pip install -e .`, which skips the
  `[tool.setuptools.data-files]` entries and leaves `share/e3sm_diags/`
  unpopulated, so the run fails on a missing `.cfg`.
- The documented `sbatch` script used `set -euo pipefail`, and the cartopy
  activation hook reads `CARTOPY_DATA_DIR` before setting it, so `set -u`
  aborted the job during `conda activate`.

The last two were each verified by a complete run on `main`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

If applicable:

- [x] New and existing unit tests pass with my changes (locally and CI/CD build)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have noted that this is a breaking change for a major release
